### PR TITLE
fix: decoding unsigned AlgoSigner txn as signed

### DIFF
--- a/src/clients/algosigner.ts
+++ b/src/clients/algosigner.ts
@@ -182,7 +182,7 @@ class AlgoSignerClient extends BaseWallet {
 
         if (
           "txn" in txn ||
-          connectedAccounts.includes(this.algosdk.encodeAddress(txn["snd"]))
+          !connectedAccounts.includes(this.algosdk.encodeAddress(txn["snd"]))
         ) {
           txnObj.txn = this.#client.encoding.msgpackToBase64(
             this.algosdk.decodeSignedTransaction(transactions[i]).txn.toByte()


### PR DESCRIPTION
Hi there, thanks a lot for open-sourcing this work, it's been incredibly useful to me and I'm sure many others. I came across this inconsistency and I believe based on the other clients, the connectedAccounts condition should be negated? Otherwise feel free to ignore if I misunderstood something.