### PR TITLE
v1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/txnlab/use-wallet/issues"
   },
   "homepage": "https://txnlab.github.io/use-wallet",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "React hooks for using Algorand compatible wallets in dApps.",
   "scripts": {
     "dev": "yarn storybook",

--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -38,7 +38,9 @@ abstract class BaseClient {
   abstract reconnect(onDisconnect: () => void): Promise<Wallet | null>;
   abstract signTransactions(
     connectedAccounts: string[],
-    transactions: Array<Uint8Array>
+    transactions: Array<Uint8Array>,
+    indexesToSign?: number[],
+    returnGroup?: boolean
   ): Promise<Uint8Array[]>;
   abstract signEncodedTransactions(
     transactions: TransactionsArray

--- a/src/clients/myalgo/client.ts
+++ b/src/clients/myalgo/client.ts
@@ -101,22 +101,32 @@ class MyAlgoWalletClient extends BaseWallet {
 
   async signTransactions(
     connectedAccounts: string[],
-    transactions: Uint8Array[]
+    transactions: Uint8Array[],
+    indexesToSign?: number[],
+    returnGroup = true
   ) {
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn);
     }) as Array<DecodedTransaction | DecodedSignedTransaction>;
 
-    // Get the unsigned transactions.
-    const txnsToSign = decodedTxns.reduce<Uint8Array[]>((acc, txn, i) => {
-      // If the transaction isn't already signed and is to be sent from a connected account,
-      // add it to the arrays of transactions to be signed.
+    const signedIndexes: number[] = [];
 
-      if (
-        !("txn" in txn) &&
+    // Get the transactions to be signed
+    const txnsToSign = decodedTxns.reduce<Uint8Array[]>((acc, txn, i) => {
+      const isSigned = "txn" in txn;
+
+      // If the indexes to be signed is specified, add it to the transactions to be signed,
+      if (indexesToSign && indexesToSign.length && indexesToSign?.includes(i)) {
+        signedIndexes.push(i);
+        acc.push(transactions[i]);
+        // Otherwise, if the transaction is unsigned and is to be sent from a connected account,
+        // add it to the transactions to be signed
+      } else if (
+        !isSigned &&
         connectedAccounts.includes(this.algosdk.encodeAddress(txn["snd"]))
       ) {
+        signedIndexes.push(i);
         acc.push(transactions[i]);
       }
 
@@ -126,13 +136,12 @@ class MyAlgoWalletClient extends BaseWallet {
     // Sign them with the client.
     const result = await this.#client.signTransaction(txnsToSign);
 
-    // Join the newly signed transactions with the original group of transactions.
-    const signedTxns = decodedTxns.reduce<Uint8Array[]>((acc, txn, i) => {
-      if (!("txn" in txn)) {
+    const signedTxns = transactions.reduce<Uint8Array[]>((acc, txn, i) => {
+      if (signedIndexes.includes(i)) {
         const signedByUser = result.shift()?.blob;
         signedByUser && acc.push(signedByUser);
-      } else {
-        acc.push(transactions[i]);
+      } else if (returnGroup) {
+        acc.push(txn);
       }
 
       return acc;

--- a/src/clients/pera/client.ts
+++ b/src/clients/pera/client.ts
@@ -99,7 +99,7 @@ class PeraWalletClient extends BaseWallet {
 
   async reconnect(onDisconnect: () => void) {
     const accounts = await this.#client.reconnectSession().catch(console.info);
-    console.log("accounts?", accounts);
+
     this.#client.connector?.on("disconnect", onDisconnect);
 
     if (!accounts) {
@@ -123,26 +123,47 @@ class PeraWalletClient extends BaseWallet {
 
   async signTransactions(
     connectedAccounts: string[],
-    transactions: Uint8Array[]
+    transactions: Uint8Array[],
+    indexesToSign?: number[],
+    returnGroup = true
   ) {
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn);
     }) as Array<DecodedTransaction | DecodedSignedTransaction>;
 
+    const signedIndexes: number[] = [];
+
     // Marshal the transactions,
     // and add the signers property if they shouldn't be signed.
     const txnsToSign = decodedTxns.reduce<PeraTransaction[]>((acc, txn, i) => {
-      if (
-        !("txn" in txn) &&
-        connectedAccounts.includes(this.algosdk.encodeAddress(txn["snd"]))
-      ) {
+      const isSigned = "txn" in txn;
+
+      // If the indexes to be signed is specified, designate that it should be signed
+      if (indexesToSign && indexesToSign.length && indexesToSign.includes(i)) {
+        signedIndexes.push(i);
         acc.push({
           txn: this.algosdk.decodeUnsignedTransaction(transactions[i]),
         });
-      } else {
+        // If the transaction is unsigned and is to be sent from a connected account,
+        // designate that it should be signed
+      } else if (
+        !isSigned &&
+        connectedAccounts.includes(this.algosdk.encodeAddress(txn["snd"]))
+      ) {
+        signedIndexes.push(i);
+        acc.push({
+          txn: this.algosdk.decodeUnsignedTransaction(transactions[i]),
+        });
+        // Otherwise, designate that it should not be signed
+      } else if (isSigned) {
         acc.push({
           txn: this.algosdk.decodeSignedTransaction(transactions[i]).txn,
+          signers: [],
+        });
+      } else if (!isSigned) {
+        acc.push({
+          txn: this.algosdk.decodeUnsignedTransaction(transactions[i]),
           signers: [],
         });
       }
@@ -154,11 +175,11 @@ class PeraWalletClient extends BaseWallet {
     const result = await this.#client.signTransaction([txnsToSign]);
 
     // Join the newly signed transactions with the original group of transactions.
-    const signedTxns = decodedTxns.reduce<Uint8Array[]>((acc, txn, i) => {
-      if (!("txn" in txn)) {
+    const signedTxns = transactions.reduce<Uint8Array[]>((acc, txn, i) => {
+      if (signedIndexes.includes(i)) {
         const signedByUser = result.shift();
         signedByUser && acc.push(signedByUser);
-      } else {
+      } else if (returnGroup) {
         acc.push(transactions[i]);
       }
 

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -146,7 +146,11 @@ export default function useWallet() {
     }
   };
 
-  const signTransactions = async (transactions: Array<Uint8Array>) => {
+  const signTransactions = async (
+    transactions: Array<Uint8Array>,
+    indexesToSign?: number[],
+    returnGroup = true
+  ) => {
     const walletClient = await getClient(activeAccount?.providerId);
 
     if (!walletClient || !activeAccount?.address) {
@@ -155,7 +159,9 @@ export default function useWallet() {
 
     const signedTransactions = await walletClient.signTransactions(
       connectedActiveAccounts.map((acct) => acct.address),
-      transactions
+      transactions,
+      indexesToSign,
+      returnGroup
     );
 
     return signedTransactions;
@@ -183,8 +189,10 @@ export default function useWallet() {
     const txnBlobs: Array<Uint8Array> = txnGroup.map(
       algosdk.encodeUnsignedTransaction
     );
-    const txns = await Promise.resolve(signTransactions(txnBlobs));
-    return txns.filter((_, index) => indexesToSign.includes(index));
+
+    return await Promise.resolve(
+      signTransactions(txnBlobs, indexesToSign, false)
+    );
   };
 
   const getAccountInfo = async () => {


### PR DESCRIPTION
* Fix the `signer` method so that it accepts both signed and unsigned transactions.
* Add the `indexesToSign` option to `signTransactions` to optionally specify which indexes of the group should be signed
* Add the `returnGroup` parameter to `signTransactions` to specify if all transactions that were passed should be returned, or just the ones signed by the provider.