### PR TITLE
TXN-1274: Fix handling signed transactions in WalletConnect client

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/txnlab/use-wallet/issues"
   },
   "homepage": "https://txnlab.github.io/use-wallet",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "React hooks for using Algorand compatible wallets in dApps.",
   "scripts": {
     "dev": "yarn storybook",

--- a/src/clients/walletconnect/client.ts
+++ b/src/clients/walletconnect/client.ts
@@ -234,17 +234,16 @@ class WalletConnectClient extends BaseWallet {
     this.keepWCAliveStop();
 
     // Join the newly signed transactions with the original group of transactions.
-    const signedTxns = result.reduce((signedTxns: Uint8Array[], txn, i) => {
-      if (txn) {
-        signedTxns.push(new Uint8Array(Buffer.from(txn, "base64")));
+    const signedTxns = transactions.reduce<Uint8Array[]>((acc, txn, i) => {
+      if (signedIndexes.includes(i)) {
+        const signedByUser = result[i]
+        signedByUser && acc.push(new Uint8Array(Buffer.from(signedByUser, 'base64')))
+      } else if (returnGroup) {
+        acc.push(txn)
       }
 
-      if (returnGroup) {
-        signedTxns.push(transactions[i]);
-      }
-
-      return signedTxns;
-    }, []);
+      return acc
+    }, [])
 
     return signedTxns;
   }


### PR DESCRIPTION
In the WalletConnect client's `signTransactions` method, signed transactions are merged back into the original transaction group and returned.

Previously we iterated over the payload returned by WalletConnect to create this array, now we iterate over the original group instead.

Each transaction's array index is checked against `signedIndexes`, containing the index of every transaction sent for signature. If there's a match, we swap it out for the signed transaction from the payload. If not, the original transaction is pushed to the result array.

(This follows the same pattern used in both the Pera and Defly clients.)

When complete, the new array is returned.

Closes https://github.com/TxnLab/use-wallet/issues/44