### PR TITLE
TXN-1283: Fix return type of groupTransactionsBySender

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -113,7 +113,7 @@ abstract class BaseClient {
         }
         acc[sender].push(obj)
         return acc
-      }, {} as { [sender: string]: TxnInfo[] })
+      }, {} as Record<string, Array<TxnInfo>>)
     }
 
     const decodedGroup = transactions.reduce((acc: TxnInfo[], [type, txn], index) => {


### PR DESCRIPTION
The return type of `groupTransactionsBySender` in the base client was inadvertently changed in https://github.com/TxnLab/use-wallet/pull/52

This reverts it back to its original return type of `Record<string, Array<TxnInfo>>` 