### PR TITLE
TXN-1285: Fix dependency resolution errors using NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/txnlab/use-wallet/issues"
   },
   "homepage": "https://txnlab.github.io/use-wallet",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "React hooks for using Algorand compatible wallets in dApps.",
   "scripts": {
     "dev": "yarn storybook",
@@ -30,7 +30,7 @@
     "@babel/preset-env": "^7.16.4",
     "@babel/preset-react": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",
-    "@blockshake/defly-connect": "^1.0.0",
+    "@blockshake/defly-connect": "^1.1.2",
     "@json-rpc-tools/utils": "^1.7.6",
     "@mdx-js/react": "^2.1.2",
     "@perawallet/connect": "^1.2.1",
@@ -75,7 +75,6 @@
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-polyfill-node": "^0.11.0",
     "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-rename-node-modules": "^1.3.1",
     "rollup-plugin-typescript2": "^0.34.1",
     "sass": "^1.43.5",
     "sass-loader": "^13.1.0",
@@ -84,9 +83,9 @@
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
-    "@blockshake/defly-connect": "^1.0.0",
+    "@blockshake/defly-connect": "^1.1.2",
     "@json-rpc-tools/utils": "^1.7.6",
-    "@perawallet/connect": "^1.1.0",
+    "@perawallet/connect": "^1.2.1",
     "@randlabs/myalgo-connect": "^1.4.2",
     "@walletconnect/client": "^1.8.0",
     "algorand-walletconnect-qrcode-modal": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,18 +1129,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blockshake/defly-connect@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@blockshake/defly-connect/-/defly-connect-1.0.0.tgz#44f0b4954efdff421ba4ddf49a47958d9591159d"
-  integrity sha512-tXFb5Qtfn3keh4lfk/o/6eG6HG8mwQSfKb1HRyMTPsXcJM7chX+6zAaw6zVtxviathupN0MSZK5MmxB1WU2PkA==
+"@blockshake/defly-connect@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@blockshake/defly-connect/-/defly-connect-1.1.2.tgz#7935883f77527cdb022fc4a87bb29bee686f11f7"
+  integrity sha512-64plibtIAlVmRsLsc7xvQEeYWmABgbd5+RpebS+f0/Uqo5anFYHFtvoaAmSdnfwcD27M+DsIjHRS2mpAxs6e+w==
   dependencies:
-    "@json-rpc-tools/utils" "^1.7.6"
     "@walletconnect/client" "^1.8.0"
     "@walletconnect/types" "^1.8.0"
-    bowser "^2.11.0"
+    bowser "2.11.0"
     buffer "^6.0.3"
     lottie-web "^5.9.6"
-    qr-code-styling "^1.6.0-rc.1"
+    qr-code-styling "1.6.0-rc.1"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -4244,7 +4243,7 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bowser@2.11.0, bowser@^2.11.0:
+bowser@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
   integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
@@ -8630,13 +8629,6 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
-magic-string@^0.25.7:
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
-  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
-  dependencies:
-    sourcemap-codec "^1.4.8"
-
 magic-string@^0.26.4, magic-string@^0.26.7:
   version "0.26.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.7.tgz#caf7daf61b34e9982f8228c4527474dac8981d6f"
@@ -10348,7 +10340,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qr-code-styling@1.6.0-rc.1, qr-code-styling@^1.6.0-rc.1:
+qr-code-styling@1.6.0-rc.1:
   version "1.6.0-rc.1"
   resolved "https://registry.yarnpkg.com/qr-code-styling/-/qr-code-styling-1.6.0-rc.1.tgz#6c89e185fa50cc9135101085c12ae95b06f1b290"
   integrity sha512-ModRIiW6oUnsP18QzrRYZSc/CFKFKIdj7pUs57AEVH20ajlglRpN3HukjHk0UbNMTlKGuaYl7Gt6/O5Gg2NU2Q==
@@ -10916,14 +10908,6 @@ rollup-plugin-postcss@^4.0.2:
     rollup-pluginutils "^2.8.2"
     safe-identifier "^0.4.2"
     style-inject "^0.3.0"
-
-rollup-plugin-rename-node-modules@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz#d80091fc817ce726e7cdfc388ec2f4da286e280f"
-  integrity sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==
-  dependencies:
-    estree-walker "^2.0.1"
-    magic-string "^0.25.7"
 
 rollup-plugin-typescript2@^0.34.1:
   version "0.34.1"


### PR DESCRIPTION
Upgrades `@blockshake/defly-connect` and `@perawallet/connect` to latest versions, and removes `rollup-plugin-rename-node-modules`. This should resolve the errors on `npm install` reported in https://github.com/TxnLab/use-wallet/issues/54