### PR TITLE
TXN-1292: Update initializeProviders to be async

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,33 @@ npm install algosdk @blockshake/defly-connect @perawallet/connect @randlabs/myal
 
 ### Set up the Wallet Provider
 
-In `app.js`, initialize the Wallet Provider so that the `useWallet` hook can be used in the child components, and use the `reconnectProviders` function to restore sessions for users returning to the app.
+In `app.js`, initialize the `WalletProvider` so that the `useWallet` hook can be used anywhere in your app, and use the `reconnectProviders` function to restore sessions for returning users.
 
 ```jsx
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { reconnectProviders, initializeProviders, WalletProvider } from '@txnlab/use-wallet'
 
-const walletProviders = initializeProviders()
-
 export default function App() {
-  // Reconnect the session when the user returns to the dApp
-  React.useEffect(() => {
-    reconnectProviders(walletProviders)
+  const [walletProviders, setWalletProviders] = useState(null)
+
+  useEffect(() => {
+    async function initializeAndConnect() {
+      // Initialize with default configuration
+      const providers = await initializeProviders()
+      setWalletProviders(providers)
+
+      // Reconnect the session when the user returns to the app
+      reconnectProviders(providers)
+    }
+
+    initializeAndConnect()
   }, [])
 
-  return <WalletProvider value={walletProviders}>...</WalletProvider>
+  return (
+    <WalletProvider value={walletProviders}>
+      <div className="App">{/* ... */}</div>
+    </WalletProvider>
+  )
 }
 ```
 
@@ -71,7 +83,7 @@ By default, all of the supported providers except for `KMD` are returned by `use
 ```jsx
 import { initializeProviders, PROVIDER_ID } from '@txnlab/use-wallet'
 
-const walletProviders = initializeProviders([PROVIDER_ID.KMD_WALLET, PROVIDER_ID.WALLET_CONNECT])
+const providers = await initializeProviders([PROVIDER_ID.KMD, PROVIDER_ID.WALLETCONNECT])
 ```
 
 For more configuration options, see [Provider Configuration](#provider-configuration).
@@ -254,10 +266,10 @@ useEffect(() => {
 
 ## Provider Configuration
 
-The `initializeProviders` functon accepts a configuration object that can be used to configure the nodes that the providers use to send transactions, as shown below.
+The `initializeProviders` function accepts a configuration object that can be used to configure the nodes that the providers use to send transactions, as shown below.
 
 ```jsx
-const walletProviders = initializeProviders([], {
+const providers = await initializeProviders([], {
   network: 'devmodenet',
   nodeServer: 'http://algod',
   nodeToken: 'xxxxxxxxx',

--- a/src/components/Example/Example.tsx
+++ b/src/components/Example/Example.tsx
@@ -1,14 +1,25 @@
-import React, { useEffect } from 'react'
-import { reconnectProviders, initializeProviders, WalletProvider } from '../../index'
+import React, { useState, useEffect } from 'react'
+import {
+  reconnectProviders,
+  initializeProviders,
+  WalletProvider,
+  SupportedProviders
+} from '../../index'
 import Account from './Account'
 import Connect from './Connect'
 import Transact from './Transact'
 
-const walletProviders = initializeProviders()
-
 export default function ConnectWallet() {
+  const [walletProviders, setWalletProviders] = useState<SupportedProviders | null>(null)
+
   useEffect(() => {
-    reconnectProviders(walletProviders)
+    async function initializeAndConnect() {
+      const providers = await initializeProviders()
+      setWalletProviders(providers)
+      reconnectProviders(providers)
+    }
+
+    initializeAndConnect()
   }, [])
 
   return (

--- a/src/utils/initializeProviders.test.ts
+++ b/src/utils/initializeProviders.test.ts
@@ -29,7 +29,7 @@ describe('initializeProviders', () => {
     jest.restoreAllMocks()
   })
 
-  it('should return an empty object if window is undefined', () => {
+  it('should return an empty object if window is undefined', async () => {
     const originalWindow = global.window
 
     Object.defineProperty(global, 'window', {
@@ -39,7 +39,7 @@ describe('initializeProviders', () => {
       configurable: true
     })
 
-    const result = initializeProviders()
+    const result = await initializeProviders()
     expect(result).toEqual({})
 
     Object.defineProperty(global, 'window', {
@@ -48,7 +48,7 @@ describe('initializeProviders', () => {
     })
   })
 
-  it('should initialize default wallets with default node configuration', () => {
+  it('should initialize default wallets with default node configuration', async () => {
     const defaultProviders = [
       PROVIDER_ID.PERA,
       PROVIDER_ID.DEFLY,
@@ -64,7 +64,7 @@ describe('initializeProviders', () => {
       algosdkStatic: undefined
     }
 
-    const result = initializeProviders()
+    const result = await initializeProviders()
     const initializedIds = Object.keys(result)
 
     defaultProviders.forEach((id) => {
@@ -78,10 +78,10 @@ describe('initializeProviders', () => {
     expect(initializedIds).not.toContain(PROVIDER_ID.MNEMONIC)
   })
 
-  it('should initialize specified wallets only', () => {
+  it('should initialize specified wallets only', async () => {
     const providers = [PROVIDER_ID.PERA, PROVIDER_ID.DEFLY]
 
-    const result = initializeProviders(providers)
+    const result = await initializeProviders(providers)
     const initializedIds = Object.keys(result)
 
     expect(initializedIds).toMatchSnapshot()
@@ -97,7 +97,7 @@ describe('initializeProviders', () => {
     })
   })
 
-  it('should initialize using custom node configuration', () => {
+  it('should initialize using custom node configuration', async () => {
     const nodeConfig = {
       network: 'testnet',
       nodeServer: 'http://localhost',
@@ -107,7 +107,7 @@ describe('initializeProviders', () => {
 
     const providers = [PROVIDER_ID.WALLETCONNECT, PROVIDER_ID.ALGOSIGNER]
 
-    const result = initializeProviders(providers, nodeConfig)
+    const result = await initializeProviders(providers, nodeConfig)
     const initializedIds = Object.keys(result)
 
     providers.forEach((id) => {
@@ -120,10 +120,10 @@ describe('initializeProviders', () => {
     })
   })
 
-  it('should initialize using provided algosdk instance', () => {
+  it('should initialize using provided algosdk instance', async () => {
     const providers = [PROVIDER_ID.PERA, PROVIDER_ID.DEFLY]
 
-    const result = initializeProviders(providers, undefined, algosdk)
+    const result = await initializeProviders(providers, undefined, algosdk)
     const initializedIds = Object.keys(result)
 
     providers.forEach((id) => {


### PR DESCRIPTION
### Description

The `initializeProviders` utility function needs to be async, so we can await each client's async `init` method. Otherwise a race condition occurs and if the app mounts before initialization completes, `reconnectProviders` is called too early.

⚠️ **BREAKING CHANGE:** The exported `initializeProviders` function is now async and must be awaited and called from inside a `useEffect` hook. The README has been updated accordingly.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
