### PR TITLE
TXN-1398: Handle nested transaction arrays in signTransactions

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -36,7 +36,7 @@ abstract class BaseClient {
   abstract reconnect(onDisconnect: () => void): Promise<Wallet | null>
   abstract signTransactions(
     connectedAccounts: string[],
-    transactions: Array<Uint8Array>,
+    txnGroups: Uint8Array[] | Uint8Array[][],
     indexesToSign?: number[],
     returnGroup?: boolean
   ): Promise<Uint8Array[]>

--- a/src/clients/daffi/client.ts
+++ b/src/clients/daffi/client.ts
@@ -107,10 +107,15 @@ class DaffiWalletClient extends BaseWallet {
 
   async signTransactions(
     connectedAccounts: string[],
-    transactions: Uint8Array[],
+    txnGroups: Uint8Array[] | Uint8Array[][],
     indexesToSign?: number[],
     returnGroup = true
   ) {
+    // If txnGroups is a nested array, flatten it
+    const transactions: Uint8Array[] = Array.isArray(txnGroups[0])
+      ? (txnGroups as Uint8Array[][]).flatMap((txn) => txn)
+      : (txnGroups as Uint8Array[])
+
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn)

--- a/src/clients/defly/client.ts
+++ b/src/clients/defly/client.ts
@@ -106,10 +106,15 @@ class DeflyWalletClient extends BaseWallet {
 
   async signTransactions(
     connectedAccounts: string[],
-    transactions: Uint8Array[],
+    txnGroups: Uint8Array[] | Uint8Array[][],
     indexesToSign?: number[],
     returnGroup = true
   ) {
+    // If txnGroups is a nested array, flatten it
+    const transactions: Uint8Array[] = Array.isArray(txnGroups[0])
+      ? (txnGroups as Uint8Array[][]).flatMap((txn) => txn)
+      : (txnGroups as Uint8Array[])
+
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn)

--- a/src/clients/exodus/client.ts
+++ b/src/clients/exodus/client.ts
@@ -115,10 +115,15 @@ class ExodusClient extends BaseWallet {
 
   async signTransactions(
     connectedAccounts: string[],
-    transactions: Array<Uint8Array>,
+    txnGroups: Uint8Array[] | Uint8Array[][],
     indexesToSign?: number[],
     returnGroup = true
   ) {
+    // If txnGroups is a nested array, flatten it
+    const transactions: Uint8Array[] = Array.isArray(txnGroups[0])
+      ? (txnGroups as Uint8Array[][]).flatMap((txn) => txn)
+      : (txnGroups as Uint8Array[])
+
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn)

--- a/src/clients/kmd/client.ts
+++ b/src/clients/kmd/client.ts
@@ -160,10 +160,15 @@ class KMDWalletClient extends BaseWallet {
 
   async signTransactions(
     connectedAccounts: string[],
-    transactions: Uint8Array[],
+    txnGroups: Uint8Array[] | Uint8Array[][],
     indexesToSign?: number[],
     returnGroup = true
   ) {
+    // If txnGroups is a nested array, flatten it
+    const transactions: Uint8Array[] = Array.isArray(txnGroups[0])
+      ? (txnGroups as Uint8Array[][]).flatMap((txn) => txn)
+      : (txnGroups as Uint8Array[])
+
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn)

--- a/src/clients/mnemonic/client.ts
+++ b/src/clients/mnemonic/client.ts
@@ -87,13 +87,18 @@ class MnemonicWalletClient extends BaseWallet {
 
   signTransactions(
     connectedAccounts: string[],
-    transactions: Uint8Array[],
+    txnGroups: Uint8Array[] | Uint8Array[][],
     indexesToSign?: number[],
     returnGroup = true
   ): Promise<Uint8Array[]> {
     if (!this.#client) {
       throw new Error('Client not connected')
     }
+
+    // If txnGroups is a nested array, flatten it
+    const transactions: Uint8Array[] = Array.isArray(txnGroups[0])
+      ? (txnGroups as Uint8Array[][]).flatMap((txn) => txn)
+      : (txnGroups as Uint8Array[])
 
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {

--- a/src/clients/pera/client.ts
+++ b/src/clients/pera/client.ts
@@ -107,10 +107,15 @@ class PeraWalletClient extends BaseWallet {
 
   async signTransactions(
     connectedAccounts: string[],
-    transactions: Uint8Array[],
+    txnGroups: Uint8Array[] | Uint8Array[][],
     indexesToSign?: number[],
     returnGroup = true
   ) {
+    // If txnGroups is a nested array, flatten it
+    const transactions: Uint8Array[] = Array.isArray(txnGroups[0])
+      ? (txnGroups as Uint8Array[][]).flatMap((txn) => txn)
+      : (txnGroups as Uint8Array[])
+
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn)

--- a/src/clients/walletconnect/client.ts
+++ b/src/clients/walletconnect/client.ts
@@ -150,10 +150,15 @@ class WalletConnectClient extends BaseWallet {
 
   async signTransactions(
     connectedAccounts: string[],
-    transactions: Uint8Array[],
+    txnGroups: Uint8Array[] | Uint8Array[][],
     indexesToSign?: number[],
     returnGroup = true
   ) {
+    // If txnGroups is a nested array, flatten it
+    const transactions: Uint8Array[] = Array.isArray(txnGroups[0])
+      ? (txnGroups as Uint8Array[][]).flatMap((txn) => txn)
+      : (txnGroups as Uint8Array[])
+
     // Decode the transactions to access their properties.
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn)


### PR DESCRIPTION
### Description

The `signTransactions` function returned by `useWallet` currently accepts only an array of encoded transactions, but it should also be able to handle a nested array (array of arrays).

Each client's `signTransactions` method now checks for a nested array and flattens it before decoding and marshaling the transactions for signature.