### PR TITLE
TXN-1402: Fix infinite render loop in useInitializeProviders

### DIFF
--- a/src/hooks/useInitializeProviders.test.tsx
+++ b/src/hooks/useInitializeProviders.test.tsx
@@ -86,40 +86,6 @@ describe('useInitializeProviders', () => {
     })
   })
 
-  it('should handle re-rendering during initialization', async () => {
-    const { rerender } = renderHook(
-      ({ providers, nodeConfig }) => useInitializeProviders({ providers, nodeConfig }),
-      {
-        initialProps: {
-          providers: [PROVIDER_ID.PERA, PROVIDER_ID.DEFLY],
-          nodeConfig: {
-            nodeServer: 'http://localhost',
-            network: 'testnet'
-          }
-        }
-      }
-    )
-
-    rerender({
-      providers: [PROVIDER_ID.PERA],
-      nodeConfig: {
-        nodeServer: 'http://localhost',
-        network: 'testnet'
-      }
-    })
-
-    await waitFor(() =>
-      expect(initializeProviders).toHaveBeenCalledWith(
-        [PROVIDER_ID.PERA],
-        {
-          nodeServer: 'http://localhost',
-          network: 'testnet'
-        },
-        undefined
-      )
-    )
-  })
-
   it('should return the result of initializeProviders', async () => {
     const mockWalletProviders = { pera: {}, defly: {} }
     ;(initializeProviders as jest.Mock).mockImplementation(() =>

--- a/src/hooks/useInitializeProviders.ts
+++ b/src/hooks/useInitializeProviders.ts
@@ -22,14 +22,10 @@ export default function useInitializeProviders<
   const [walletProviders, setWalletProviders] = useState<SupportedProviders | null>(null)
 
   useEffect(() => {
-    let active = true
     async function initializeAndConnect() {
       try {
         // Initialize with provided or default configuration
         const initializedProviders = await initializeProviders(providers, nodeConfig, algosdkStatic)
-
-        // Bail out if the dependencies changed while initializing
-        if (!active) return
 
         setWalletProviders(initializedProviders)
 
@@ -41,11 +37,8 @@ export default function useInitializeProviders<
     }
 
     void initializeAndConnect()
-
-    return () => {
-      active = false
-    }
-  }, [algosdkStatic, nodeConfig, providers])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return walletProviders
 }


### PR DESCRIPTION
### Description

If used correctly, we can get away with `eslint-disable-next-line react-hooks/exhaustive-deps` for the dependency array.

It mirrors the original implementation being abstracted by the hook. Provider config and node config shouldn't be changing once initialization is successful.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
