### PR TITLE
TXN-1404: Fix "No matching export" error for WalletConnect peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "@typescript-eslint/parser": "^5.55.0",
     "@walletconnect/modal": "^2.4.7",
     "@walletconnect/sign-client": "^2.8.1",
-    "@walletconnect/types": "^2.8.1",
-    "@walletconnect/utils": "^2.8.1",
     "algosdk": "^2.1.0",
     "babel-jest": "^29.1.2",
     "babel-loader": "^8.2.3",

--- a/src/clients/walletconnect2/client.ts
+++ b/src/clients/walletconnect2/client.ts
@@ -1,4 +1,3 @@
-import { getSdkError } from '@walletconnect/utils'
 import type SignClient from '@walletconnect/sign-client'
 import type { WalletConnectModal } from '@walletconnect/modal'
 import BaseClient from '../base'
@@ -186,7 +185,11 @@ class WalletConnectClient extends BaseClient {
       }
       await this.#client.disconnect({
         topic: session.topic,
-        reason: getSdkError('USER_DISCONNECTED')
+        // replicates getSdkError('USER_DISCONNECTED') from @walletconnect/utils
+        reason: {
+          message: 'User disconnected.',
+          code: 6000
+        }
       })
     } catch (error) {
       console.error('Error disconnecting', error)

--- a/src/clients/walletconnect2/types.ts
+++ b/src/clients/walletconnect2/types.ts
@@ -1,10 +1,9 @@
 import type algosdk from 'algosdk'
 import type SignClient from '@walletconnect/sign-client'
 import type { CommonInitParams, Metadata, Network } from '../../types'
-import type { SignClientTypes } from '@walletconnect/types'
 import type { WalletConnectModal, WalletConnectModalConfig } from '@walletconnect/modal'
 
-export type WalletConnectOptions = SignClientTypes.Options
+export type WalletConnectOptions = SignClient['opts']
 
 export type WalletConnectModalOptions = Omit<
   WalletConnectModalConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3712,7 +3712,7 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/types@2.8.1", "@walletconnect/types@^2.8.1":
+"@walletconnect/types@2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.8.1.tgz#640eb6ad23866886fbe09a9b29832bf3f8647a09"
   integrity sha512-MLISp85b+27vVkm3Wkud+eYCwySXCdOrmn0yQCSN6DnRrrunrD05ksz4CXGP7h2oXUvvXPDt/6lXBf1B4AfqrA==
@@ -3729,7 +3729,7 @@
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-1.8.0.tgz#3f5e85b2d6b149337f727ab8a71b8471d8d9a195"
   integrity sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==
 
-"@walletconnect/utils@2.8.1", "@walletconnect/utils@^2.8.1":
+"@walletconnect/utils@2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.8.1.tgz#1356f4bba7f8b6664fc5b61ce3497596c8d9d603"
   integrity sha512-d6p9OX3v70m6ijp+j4qvqiQZQU1vbEHN48G8HqXasyro3Z+N8vtcB5/gV4pTYsbWgLSDtPHj49mzbWQ0LdIdTw==


### PR DESCRIPTION
### Description

To avoid requiring @walletconnect/utils and @walletconnect/types to be installed as peer
dependencies to support WalletConnect 2.0, the modules that were being used are removed and
replicated.

The types package in particular wasn't a necessary dependency.
