### PR TITLE
TXN-1406: Fix default providers if none specified

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -12,6 +12,13 @@ export enum PROVIDER_ID {
   MNEMONIC = 'mnemonic'
 }
 
+export const DEFAULT_PROVIDERS = [
+  PROVIDER_ID.PERA,
+  PROVIDER_ID.DEFLY,
+  PROVIDER_ID.DAFFI,
+  PROVIDER_ID.EXODUS
+]
+
 export const DEFAULT_NETWORK: Network = 'mainnet'
 
 export const DEFAULT_NODE_BASEURL = 'https://mainnet-api.algonode.cloud'

--- a/src/utils/initializeProviders.test.ts
+++ b/src/utils/initializeProviders.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_NODE_BASEURL,
   DEFAULT_NODE_PORT,
   DEFAULT_NODE_TOKEN,
+  DEFAULT_PROVIDERS,
   PROVIDER_ID
 } from '../constants'
 import { createMockClient } from '../testUtils/mockClients'
@@ -67,21 +68,16 @@ describe('initializeProviders', () => {
   })
 
   it('should initialize default providers with default node configuration', async () => {
-    const defaultProviders = [
-      PROVIDER_ID.PERA,
-      PROVIDER_ID.DEFLY,
-      PROVIDER_ID.EXODUS,
-      PROVIDER_ID.ALGOSIGNER,
-      PROVIDER_ID.MYALGO
-    ]
-
     // Initialize default providers
     const result = await initializeProviders()
 
     // Check if the returned object has the correct keys
-    expect(Object.keys(result)).toEqual(expect.arrayContaining(defaultProviders))
+    expect(Object.keys(result)).toEqual(expect.arrayContaining(DEFAULT_PROVIDERS))
     expect(Object.keys(result)).not.toContain(PROVIDER_ID.KMD)
     expect(Object.keys(result)).not.toContain(PROVIDER_ID.MNEMONIC)
+    expect(Object.keys(result)).not.toContain(PROVIDER_ID.WALLETCONNECT)
+    expect(Object.keys(result)).not.toContain(PROVIDER_ID.ALGOSIGNER)
+    expect(Object.keys(result)).not.toContain(PROVIDER_ID.MYALGO)
 
     // Check if the clients were initialized with the default node configuration
     for (const providerId of Object.keys(result)) {

--- a/src/utils/initializeProviders.ts
+++ b/src/utils/initializeProviders.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_NODE_TOKEN,
   DEFAULT_NODE_PORT,
   DEFAULT_NETWORK,
-  PROVIDER_ID
+  DEFAULT_PROVIDERS
 } from '../constants'
 
 export const initializeProviders = async <T extends keyof ProviderConfigMapping>(
@@ -52,10 +52,7 @@ export const initializeProviders = async <T extends keyof ProviderConfigMapping>
   // Initialize default providers if `providers` is undefined or empty
   if (!providers || providers.length === 0) {
     const initPromises = Object.keys(allClients)
-      .filter(
-        (id) =>
-          id !== PROVIDER_ID.KMD && id !== PROVIDER_ID.MNEMONIC && id !== PROVIDER_ID.WALLETCONNECT
-      )
+      .filter((id) => DEFAULT_PROVIDERS.includes(id as T))
       .map((id) => initClient(id as T))
 
     await Promise.all(initPromises)


### PR DESCRIPTION
### Description

The default provider list still contained MyAlgo and AlgoSigner. Since the list of non-default providers is now longer than the list of defaults, the way they're filtered is also refactored.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
