### PR TITLE
TXN-1407: Replace @walletconnect/sign-client with @web3modal/sign-html

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,8 +511,7 @@ import algosdk from 'algosdk'
 import { PROVIDER_ID, WalletProvider, useInitializeProviders } from '@txnlab/use-wallet'
 import { DeflyWalletConnect } from '@blockshake/defly-connect'
 import { PeraWalletConnect } from '@perawallet/connect'
-import SignClient from '@walletconnect/sign-client'
-import { WalletConnectModal } from '@walletconnect/modal'
+import { Web3ModalSign } from '@web3modal/sign-html'
 
 export default function App() {
   const providers = useInitializeProviders({
@@ -521,8 +520,7 @@ export default function App() {
       { id: PROVIDER_ID.DEFLY, clientStatic: DeflyWalletConnect },
       {
         id: PROVIDER_ID.WALLETCONNECT,
-        clientStatic: SignClient,
-        modalStatic: WalletConnectModal,
+        clientStatic: Web3ModalSign,
         clientOptions: {
           projectId: '<YOUR_PROJECT_ID>',
           metadata: {
@@ -554,7 +552,7 @@ However, Algorand apps with `use-wallet` will be able to support the new protoco
 
 1. **Obtain a project ID** - You will need to obtain a project ID from [WalletConnect Cloud](https://cloud.walletconnect.com/). This is a simple process, and there is no waiting period. Every app will need its own unique project ID.
 
-2. **Install peer dependencies** - Install `@walletconnect/sign-client` and `@walletconnect/modal`.
+2. **Install peer dependency** - Install `@web3modal/sign-html`.
 
 3. **Update provider configuration** - You will need to use a provider object to initialize WalletConnect, and pass your `clientOptions` as shown below
 
@@ -659,10 +657,10 @@ const providers = useInitializeProviders({
 
 ### WalletConnect provider
 
-The WalletConnect provider now supports WalletConnect 2.0. To continue supporting this provider, or to add support to your application, you must install the `@walletconnect/sign-client` and `@walletconnect/modal` packages.
+The WalletConnect provider now supports WalletConnect 2.0. To continue supporting this provider, or to add support to your application, you must install the `@web3modal/sign-html` package.
 
 ```bash
-npm install @walletconnect/sign-client @walletconnect/modal
+npm install @web3modal/sign-html
 ```
 
 The peer dependencies for WalletConnect 1.x should be uninstalled.

--- a/__mocks__/walletconnect-client.js
+++ b/__mocks__/walletconnect-client.js
@@ -1,3 +1,0 @@
-const WalletConnect = jest.fn()
-
-export default WalletConnect

--- a/__mocks__/walletconnect-modal.js
+++ b/__mocks__/walletconnect-modal.js
@@ -1,1 +1,0 @@
-export const WalletConnectModal = jest.fn()

--- a/__mocks__/walletconnect-sign-client.js
+++ b/__mocks__/walletconnect-sign-client.js
@@ -1,1 +1,0 @@
-export const SignClient = jest.fn()

--- a/__mocks__/walletconnect-utils.js
+++ b/__mocks__/walletconnect-utils.js
@@ -1,1 +1,0 @@
-export const getSdkError = jest.fn()

--- a/__mocks__/web3modal-sign-html.js
+++ b/__mocks__/web3modal-sign-html.js
@@ -1,0 +1,1 @@
+export const Web3ModalSign = jest.fn()

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -89,10 +89,7 @@ export default {
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
-    '@walletconnect/utils': '<rootDir>/__mocks__/walletconnect-utils.js',
-    '@walletconnect/sign-client': '<rootDir>/__mocks__/walletconnect-sign-client.js',
-    '@walletconnect/modal': '<rootDir>/__mocks__/walletconnect-modal.js',
-    '@walletconnect/client': '<rootDir>/__mocks__/walletconnect-client.js'
+    '@web3modal/sign-html': '<rootDir>/__mocks__/web3modal-sign-html.js'
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "@types/react": "^18.0.15",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.55.0",
-    "@walletconnect/modal": "^2.4.7",
-    "@walletconnect/sign-client": "^2.8.1",
+    "@web3modal/sign-html": "^2.4.7",
     "algosdk": "^2.1.0",
     "babel-jest": "^29.1.2",
     "babel-loader": "^8.2.3",
@@ -97,8 +96,7 @@
     "@daffiwallet/connect": "^1.0.3",
     "@perawallet/connect": "^1.2.1",
     "@randlabs/myalgo-connect": "^1.4.2",
-    "@walletconnect/modal": "^2.4.7",
-    "@walletconnect/sign-client": "^2.8.1",
+    "@web3modal/sign-html": "^2.4.7",
     "algosdk": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -116,10 +114,7 @@
     "@randlabs/myalgo-connect": {
       "optional": true
     },
-    "@walletconnect/sign-client": {
-      "optional": true
-    },
-    "@walletconnect/modal": {
+    "@web3modal/sign-html": {
       "optional": true
     }
   },

--- a/src/clients/walletconnect2/client.ts
+++ b/src/clients/walletconnect2/client.ts
@@ -14,7 +14,7 @@ import { formatJsonRpcRequest } from './utils'
 
 class WalletConnectClient extends BaseClient {
   #client: Web3ModalSign
-  clientOptions: Web3ModalSignOptions
+  clientOptions?: Web3ModalSignOptions
   network: Network
   chain: string
 
@@ -54,6 +54,10 @@ class WalletConnectClient extends BaseClient {
         throw new Error(
           `WalletConnect only supports Algorand mainnet, testnet, and betanet. "${network}" is not supported.`
         )
+      }
+
+      if (!clientOptions) {
+        throw new Error('WalletConnect clientOptions must be provided')
       }
 
       const chain = ALGORAND_CHAINS[network]

--- a/src/clients/walletconnect2/client.ts
+++ b/src/clients/walletconnect2/client.ts
@@ -1,23 +1,20 @@
-import type SignClient from '@walletconnect/sign-client'
-import type { WalletConnectModal } from '@walletconnect/modal'
+import type {
+  Web3ModalSign,
+  Web3ModalSignOptions,
+  Web3ModalSignSession
+} from '@web3modal/sign-html'
 import BaseClient from '../base'
-import Algod, { getAlgodClient } from '../../algod'
-import { formatJsonRpcRequest } from './utils'
-import { isPublicNetwork } from '../../utils/types'
+import { DecodedSignedTransaction, DecodedTransaction, Network, Wallet } from '../../types'
 import { PROVIDER_ID } from '../../constants'
 import { ALGORAND_CHAINS, DEFAULT_NETWORK, ICON } from './constants'
-import type { Network, Wallet, DecodedTransaction, DecodedSignedTransaction } from '../../types'
-import type {
-  InitParams,
-  WalletConnectClientConstructor,
-  WalletConnectOptions,
-  WalletConnectTransaction
-} from './types'
+import { InitParams, WalletConnectClientConstructor, WalletConnectTransaction } from './types'
+import { isPublicNetwork } from '../../utils/types'
+import Algod, { getAlgodClient } from '../../algod'
+import { formatJsonRpcRequest } from './utils'
 
 class WalletConnectClient extends BaseClient {
-  #client: SignClient
-  clientOptions?: WalletConnectOptions
-  #modal: WalletConnectModal
+  #client: Web3ModalSign
+  clientOptions: Web3ModalSignOptions
   network: Network
   chain: string
 
@@ -25,7 +22,6 @@ class WalletConnectClient extends BaseClient {
     metadata,
     client,
     clientOptions,
-    modal,
     algosdk,
     algodClient,
     network,
@@ -34,7 +30,6 @@ class WalletConnectClient extends BaseClient {
     super(metadata, algosdk, algodClient)
     this.#client = client
     this.clientOptions = clientOptions
-    this.#modal = modal
     this.network = network
     this.chain = chain
     this.metadata = WalletConnectClient.metadata
@@ -51,8 +46,6 @@ class WalletConnectClient extends BaseClient {
     clientOptions,
     algodOptions,
     clientStatic,
-    modalStatic,
-    modalOptions,
     algosdkStatic,
     network = DEFAULT_NETWORK
   }: InitParams): Promise<BaseClient | null> {
@@ -65,23 +58,19 @@ class WalletConnectClient extends BaseClient {
 
       const chain = ALGORAND_CHAINS[network]
 
-      // Initialize sign client
-      const Client = clientStatic || (await import('@walletconnect/sign-client')).default
+      const clientModule = clientStatic
+        ? { Web3ModalSign: clientStatic }
+        : await import('@web3modal/sign-html')
 
-      const client = await Client.init(clientOptions)
+      const Client = clientModule.Web3ModalSign
 
-      // Initialize web3modal
-      const modalModule = modalStatic
-        ? { WalletConnectModal: modalStatic }
-        : await import('@walletconnect/modal')
-
-      const Web3Modal = modalModule.WalletConnectModal
-
-      const modal = new Web3Modal({
-        explorerExcludedWalletIds: 'ALL',
-        ...modalOptions,
-        projectId: clientOptions?.projectId || '',
-        walletConnectVersion: 2
+      // Initialize client
+      const client = new Client({
+        ...clientOptions,
+        modalOptions: {
+          explorerExcludedWalletIds: 'ALL',
+          ...clientOptions.modalOptions
+        }
       })
 
       // Initialize algod client
@@ -89,27 +78,22 @@ class WalletConnectClient extends BaseClient {
       const algodClient = getAlgodClient(algosdk, algodOptions)
 
       // Initialize wallet client
-      const walletClient = new WalletConnectClient({
+      return new WalletConnectClient({
         metadata: WalletConnectClient.metadata,
         client,
         clientOptions,
-        modal,
         algosdk,
         algodClient,
         network,
         chain
       })
-
-      walletClient.#subscribeToEvents()
-
-      return walletClient
     } catch (error) {
-      console.error('Error initializing', error)
+      console.error('Error initializing WalletConnect client', error)
       return null
     }
   }
 
-  async connect(): Promise<Wallet> {
+  public async connect(): Promise<Wallet> {
     const requiredNamespaces = {
       algorand: {
         chains: [this.chain],
@@ -118,46 +102,25 @@ class WalletConnectClient extends BaseClient {
       }
     }
 
-    const { uri, approval } = await this.#client.connect({ requiredNamespaces })
-
-    if (uri) {
-      await this.#modal.openModal({ uri, standaloneChains: [this.chain] })
-    }
-
-    return new Promise<Wallet>((resolve, reject) => {
-      const unsubscribeModal = this.#modal.subscribeModal((state) => {
-        if (!state.open) {
-          unsubscribeModal()
-          reject(new Error('Modal closed'))
-        }
+    try {
+      const session: Web3ModalSignSession = await this.#client.connect({
+        requiredNamespaces
       })
 
-      approval()
-        .then((session) => {
-          const { accounts } = session.namespaces.algorand
+      const { accounts } = session.namespaces.algorand
 
-          resolve({
-            ...WalletConnectClient.metadata,
-            accounts: accounts.map((accountStr, index) => ({
-              name: `WalletConnect ${index + 1}`,
-              address: accountStr.split(':').pop() as string,
-              providerId: WalletConnectClient.metadata.id
-            }))
-          })
-        })
-        .catch((error) => {
-          reject(error)
-        })
-        .finally(() => {
-          unsubscribeModal()
-          this.#modal.closeModal()
-        })
-    })
+      return {
+        ...WalletConnectClient.metadata,
+        accounts: this.#mapAccounts(accounts)
+      }
+    } catch (error) {
+      console.error('Error connecting to WalletConnect', error)
+      throw error
+    }
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async reconnect() {
-    const session = this.#getSession()
+  public async reconnect() {
+    const session: Web3ModalSignSession | undefined = await this.#client.getSession()
     if (typeof session === 'undefined') {
       return null
     }
@@ -166,23 +129,14 @@ class WalletConnectClient extends BaseClient {
 
     return {
       ...WalletConnectClient.metadata,
-      accounts: accounts.map((accountStr, index) => ({
-        name: `WalletConnect ${index + 1}`,
-        address: accountStr.split(':').pop() as string,
-        providerId: WalletConnectClient.metadata.id
-      }))
+      accounts: this.#mapAccounts(accounts)
     }
   }
 
-  async disconnect() {
+  public async disconnect() {
     try {
-      if (typeof this.#client === 'undefined') {
-        throw new Error('WalletConnect is not initialized')
-      }
-      const session = this.#getSession()
-      if (typeof session === 'undefined') {
-        throw new Error('Session is not connected')
-      }
+      const session = await this.#getSession()
+
       await this.#client.disconnect({
         topic: session.topic,
         // replicates getSdkError('USER_DISCONNECTED') from @walletconnect/utils
@@ -196,35 +150,76 @@ class WalletConnectClient extends BaseClient {
     }
   }
 
-  async signTransactions(
+  public async signTransactions(
     connectedAccounts: string[],
     txnGroups: Uint8Array[] | Uint8Array[][],
-    indexesToSign?: number[],
+    indexesToSign: number[] = [],
     returnGroup = true
   ) {
-    // If txnGroups is a nested array, flatten it
+    // Flatten transactions array if nested
     const transactions: Uint8Array[] = Array.isArray(txnGroups[0])
       ? (txnGroups as Uint8Array[][]).flatMap((txn) => txn)
       : (txnGroups as Uint8Array[])
 
-    // Decode the transactions to access their properties.
+    const { txnsToSign, signedIndexes } = this.#composeTransactions(
+      transactions,
+      connectedAccounts,
+      indexesToSign
+    )
+
+    const request = formatJsonRpcRequest('algo_signTxn', [txnsToSign])
+
+    const session = await this.#getSession()
+
+    const response = await this.#client.request<Array<string | null>>({
+      chainId: this.chain,
+      topic: session.topic,
+      request
+    })
+
+    // Check if the result is the same length as the transactions
+    const lengthsMatch = response.length === transactions.length
+
+    // Join the signed transactions with the original group of transactions
+    const signedTxns = transactions.reduce<Uint8Array[]>((acc, txn, i) => {
+      if (signedIndexes.includes(i)) {
+        const signedTxn = lengthsMatch ? response[i] : response.shift()
+        signedTxn && acc.push(new Uint8Array(Buffer.from(signedTxn, 'base64')))
+      } else if (returnGroup) {
+        acc.push(txn)
+      }
+
+      return acc
+    }, [])
+
+    return signedTxns
+  }
+
+  #composeTransactions(
+    transactions: Uint8Array[],
+    connectedAccounts: string[],
+    indexesToSign: number[]
+  ) {
+    // Decode the transactions
     const decodedTxns = transactions.map((txn) => {
       return this.algosdk.decodeObj(txn)
     }) as Array<DecodedTransaction | DecodedSignedTransaction>
 
+    // Track signed transactions
     const signedIndexes: number[] = []
 
-    // Marshal the transactions,
-    // and add the signers property if they shouldn't be signed.
+    // Marshal the transactions into WalletConnect format
     const txnsToSign = decodedTxns.reduce<WalletConnectTransaction[]>((acc, txn, i) => {
       const isSigned = 'txn' in txn
 
-      if (indexesToSign && indexesToSign.length && indexesToSign.includes(i)) {
-        signedIndexes.push(i)
-        acc.push({
-          txn: Buffer.from(transactions[i]).toString('base64')
-        })
-      } else if (!isSigned && connectedAccounts.includes(this.algosdk.encodeAddress(txn['snd']))) {
+      const senderAccount = !isSigned
+        ? this.algosdk.encodeAddress(txn['snd'])
+        : this.algosdk.encodeAddress(txn.txn['snd'])
+
+      const shouldSign =
+        indexesToSign.includes(i) || (!isSigned && connectedAccounts.includes(senderAccount))
+
+      if (shouldSign) {
         signedIndexes.push(i)
         acc.push({
           txn: Buffer.from(transactions[i]).toString('base64')
@@ -245,63 +240,23 @@ class WalletConnectClient extends BaseClient {
       return acc
     }, [])
 
-    const session = this.#getSession()
+    return { txnsToSign, signedIndexes }
+  }
+
+  async #getSession() {
+    const session: Web3ModalSignSession | undefined = await this.#client.getSession()
     if (typeof session === 'undefined') {
       throw new Error('Session is not connected')
     }
-
-    const request = formatJsonRpcRequest('algo_signTxn', [txnsToSign])
-
-    // Play an audio file to keep Wallet Connect's web socket open on iOS
-    // when the user goes into background mode.
-    // await this.keepWCAliveStart()
-
-    const response = await this.#client.request<Array<string | null>>({
-      chainId: this.chain,
-      topic: session.topic,
-      request
-    })
-
-    // this.keepWCAliveStop()
-
-    // Check if the result is the same length as the transactions
-    const lengthsMatch = response.length === transactions.length
-
-    // Join the newly signed transactions with the original group of transactions.
-    const signedTxns = transactions.reduce<Uint8Array[]>((acc, txn, i) => {
-      if (signedIndexes.includes(i)) {
-        const signedByUser = lengthsMatch ? response[i] : response.shift()
-        signedByUser && acc.push(new Uint8Array(Buffer.from(signedByUser, 'base64')))
-      } else if (returnGroup) {
-        acc.push(txn)
-      }
-
-      return acc
-    }, [])
-
-    return signedTxns
+    return session
   }
 
-  #subscribeToEvents() {
-    if (typeof this.#client === 'undefined') {
-      throw new Error('WalletConnect is not initialized')
-    }
-
-    this.#client.on('session_event', (args) => {
-      console.log('EVENT', 'session_event', args)
-    })
-
-    this.#client.on('session_update', ({ topic, params }) => {
-      console.log('EVENT', 'session_update', { topic, params })
-    })
-
-    this.#client.on('session_delete', () => {
-      console.log('EVENT', 'session_delete')
-    })
-  }
-
-  #getSession() {
-    return this.#client.session.getAll().at(-1)
+  #mapAccounts(accounts: string[]) {
+    return accounts.map((accountStr, index) => ({
+      name: `WalletConnect ${index + 1}`,
+      address: accountStr.split(':').pop() as string,
+      providerId: WalletConnectClient.metadata.id
+    }))
   }
 }
 

--- a/src/clients/walletconnect2/types.ts
+++ b/src/clients/walletconnect2/types.ts
@@ -1,31 +1,20 @@
+import type { Web3ModalSign, Web3ModalSignOptions } from '@web3modal/sign-html'
 import type algosdk from 'algosdk'
-import type SignClient from '@walletconnect/sign-client'
-import type { CommonInitParams, Metadata, Network } from '../../types'
-import type { WalletConnectModal, WalletConnectModalConfig } from '@walletconnect/modal'
-
-export type WalletConnectOptions = SignClient['opts']
-
-export type WalletConnectModalOptions = Omit<
-  WalletConnectModalConfig,
-  'projectId' | 'walletConnectVersion'
->
-
-export type InitParams = CommonInitParams & {
-  clientOptions?: WalletConnectOptions
-  clientStatic?: typeof SignClient
-  modalStatic?: typeof WalletConnectModal
-  modalOptions?: WalletConnectModalOptions
-}
+import { CommonInitParams, Metadata, Network } from 'src/types'
 
 export type WalletConnectClientConstructor = {
   metadata: Metadata
-  client: SignClient
-  clientOptions?: WalletConnectOptions
-  modal: WalletConnectModal
+  client: Web3ModalSign
+  clientOptions: Web3ModalSignOptions
   algosdk: typeof algosdk
   algodClient: algosdk.Algodv2
   network: Network
   chain: string
+}
+
+export type InitParams = CommonInitParams & {
+  clientOptions: Web3ModalSignOptions
+  clientStatic: typeof Web3ModalSign
 }
 
 export type WalletConnectTransaction = {

--- a/src/clients/walletconnect2/types.ts
+++ b/src/clients/walletconnect2/types.ts
@@ -13,8 +13,8 @@ export type WalletConnectClientConstructor = {
 }
 
 export type InitParams = CommonInitParams & {
-  clientOptions: Web3ModalSignOptions
-  clientStatic: typeof Web3ModalSign
+  clientOptions?: Web3ModalSignOptions
+  clientStatic?: typeof Web3ModalSign
 }
 
 export type WalletConnectTransaction = {

--- a/src/clients/walletconnect2/types.ts
+++ b/src/clients/walletconnect2/types.ts
@@ -1,6 +1,6 @@
 import type { Web3ModalSign, Web3ModalSignOptions } from '@web3modal/sign-html'
 import type algosdk from 'algosdk'
-import { CommonInitParams, Metadata, Network } from 'src/types'
+import { CommonInitParams, Metadata, Network } from '../../types'
 
 export type WalletConnectClientConstructor = {
   metadata: Metadata

--- a/src/hooks/useInitializeProviders.test.tsx
+++ b/src/hooks/useInitializeProviders.test.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { renderHook, waitFor } from '@testing-library/react'
 import useInitializeProviders from './useInitializeProviders'
-import { PROVIDER_ID } from './useWallet'
+import { PROVIDER_ID } from '../constants'
 import { initializeProviders, reconnectProviders } from '../utils'
 
 jest.mock('../utils')

--- a/src/hooks/useWallet.test.tsx
+++ b/src/hooks/useWallet.test.tsx
@@ -4,7 +4,7 @@
 
 import { act, renderHook } from '@testing-library/react'
 import React from 'react'
-import useWallet, { PROVIDER_ID } from './useWallet'
+import useWallet from './useWallet'
 import DeflyWalletClient from '../clients/defly'
 import PeraWalletClient from '../clients/pera'
 import { default as ClientProvider } from '../store/state/clientStore'
@@ -14,6 +14,7 @@ import { mockAccounts } from '../testUtils/mockAccounts'
 import { createDeflyMockInstance, createPeraMockInstance } from '../testUtils/mockClients'
 import { clearAccounts } from '../utils/clearAccounts'
 import type { WalletClient } from '../types'
+import { PROVIDER_ID } from '../constants'
 
 const peraAccounts = mockAccounts(PROVIDER_ID.PERA, 2)
 const deflyAccounts = mockAccounts(PROVIDER_ID.DEFLY, 1)

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -9,8 +9,6 @@ import allClients from '../clients'
 import { clearAccounts } from '../utils/clearAccounts'
 import shallow from 'zustand/shallow'
 
-export { PROVIDER_ID }
-
 export default function useWallet() {
   const [providers, setProviders] = useState<Provider[] | null>(null)
   const clients = useContext(ClientContext)

--- a/src/testUtils/mockClients.ts
+++ b/src/testUtils/mockClients.ts
@@ -3,8 +3,7 @@ import { DeflyWalletConnect } from '@blockshake/defly-connect'
 import { DaffiWalletConnect } from '@daffiwallet/connect'
 import { PeraWalletConnect } from '@perawallet/connect'
 import MyAlgoConnect from '@randlabs/myalgo-connect'
-import { WalletConnectModal } from '@walletconnect/modal'
-import { SignClient } from '@walletconnect/sign-client'
+import { Web3ModalSign } from '@web3modal/sign-html'
 import algosdk from 'algosdk'
 import AlgoSignerClient from '../clients/algosigner/client'
 import DaffiWalletClient from '../clients/daffi/client'
@@ -384,6 +383,17 @@ export const createWalletConnectMockInstance = (
   clientOptions?: ClientOptions,
   accounts: Array<Account> = []
 ): WalletConnectClient => {
+  const options = {
+    projectId: 'project-id',
+    metadata: {
+      name: 'Example Dapp',
+      description: 'Example Dapp',
+      url: '#',
+      icons: ['https://walletconnect.com/walletconnect-logo.png']
+    },
+    ...(clientOptions && clientOptions)
+  }
+
   const mockWalletConnectClient = new WalletConnectClient({
     metadata: {
       id: PROVIDER_ID.WALLETCONNECT,
@@ -391,8 +401,10 @@ export const createWalletConnectMockInstance = (
       icon: 'walletconnect-icon-b64',
       isWalletConnect: true
     },
-    client: new SignClient(),
-    modal: new WalletConnectModal({ projectId: 'project-id', walletConnectVersion: 2 }),
+    client: new Web3ModalSign(options),
+    clientOptions: {
+      ...options
+    },
     algosdk,
     algodClient: {
       accountInformation: () => ({
@@ -400,8 +412,7 @@ export const createWalletConnectMockInstance = (
       })
     } as any,
     network: 'test-network',
-    chain: 'algorand:testnet',
-    ...(clientOptions && clientOptions)
+    chain: 'algorand:testnet'
   })
 
   // Mock the connect method

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -2,18 +2,16 @@ import { PROVIDER_ID } from '../constants'
 import type { PeraWalletConnect } from '@perawallet/connect'
 import type { DeflyWalletConnect } from '@blockshake/defly-connect'
 import type { DaffiWalletConnect } from '@daffiwallet/connect'
-import type SignClient from '@walletconnect/sign-client'
 import type MyAlgoConnect from '@randlabs/myalgo-connect'
-import type { WalletConnectModal } from '@walletconnect/modal'
-import { AlgodClientOptions, Network } from './node'
+import type { Web3ModalSign, Web3ModalSignOptions } from '@web3modal/sign-html'
 import type algosdk from 'algosdk'
+import type { AlgodClientOptions, Network } from './node'
 import type { PeraWalletConnectOptions } from '../clients/pera/types'
-import { DeflyWalletConnectOptions } from '../clients/defly/types'
-import { ExodusOptions } from '../clients/exodus/types'
-import { KmdOptions } from '../clients/kmd/types'
-import { MyAlgoConnectOptions } from '../clients/myalgo/types'
-import { WalletConnectModalOptions, WalletConnectOptions } from '../clients/walletconnect2/types'
-import { DaffiWalletConnectOptions } from '../clients/daffi/types'
+import type { DeflyWalletConnectOptions } from '../clients/defly/types'
+import type { ExodusOptions } from '../clients/exodus/types'
+import type { KmdOptions } from '../clients/kmd/types'
+import type { MyAlgoConnectOptions } from '../clients/myalgo/types'
+import type { DaffiWalletConnectOptions } from '../clients/daffi/types'
 
 export type ProviderConfigMapping = {
   [PROVIDER_ID.PERA]: {
@@ -29,10 +27,8 @@ export type ProviderConfigMapping = {
     clientStatic?: typeof DeflyWalletConnect
   }
   [PROVIDER_ID.WALLETCONNECT]: {
-    clientOptions?: WalletConnectOptions
-    clientStatic?: typeof SignClient
-    modalStatic?: typeof WalletConnectModal
-    modalOptions?: WalletConnectModalOptions
+    clientOptions?: Web3ModalSignOptions
+    clientStatic?: typeof Web3ModalSign
   }
   [PROVIDER_ID.MYALGO]: {
     clientOptions?: MyAlgoConnectOptions

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,7 +3631,7 @@
     pino "7.11.0"
     tslib "1.14.1"
 
-"@walletconnect/modal@^2.4.7":
+"@walletconnect/modal@2.4.7":
   version "2.4.7"
   resolved "https://registry.yarnpkg.com/@walletconnect/modal/-/modal-2.4.7.tgz#fd84d6f1ac767865d63153e32150f790739a189a"
   integrity sha512-kFpvDTT44CgNGcwQVC0jHrYed4xorghKX1DOGo8ZfBSJ5TJx3p6d6SzLxkH1cZupWbljWkYS6SqvZcUBs8vWpg==
@@ -3681,7 +3681,7 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/sign-client@^2.8.1":
+"@walletconnect/sign-client@2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.8.1.tgz#8c6de724eff6a306c692dd66e66944089be5e30a"
   integrity sha512-6DbpjP9BED2YZOZdpVgYo0HwPBV7k99imnsdMFrTn16EFAxhuYP0/qPwum9d072oNMGWJSA6d4rzc8FHNtHsCA==
@@ -3796,6 +3796,14 @@
   dependencies:
     buffer "6.0.3"
     valtio "1.10.5"
+
+"@web3modal/sign-html@^2.4.7":
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/@web3modal/sign-html/-/sign-html-2.4.7.tgz#8280ad68b8c61f1389b712344a758e5f7cf15fe6"
+  integrity sha512-HsnhpJJfdyB9X5nrPV6gCXGSDju9oT4lZ53Vmaw5G4ZuGHC/X2zzoo1OhJSTFYP5IJ60gsj70SZpSWbSw3WAwg==
+  dependencies:
+    "@walletconnect/modal" "2.4.7"
+    "@walletconnect/sign-client" "2.8.1"
 
 "@web3modal/ui@2.4.7":
   version "2.4.7"


### PR DESCRIPTION
### Description

The @web3modal/sign-html client handles all of the @walletconnect/modal logic as well as lots of the complexity being handled manually in the previous WalletConnect provider client. And it's one peer dependency to install vs two.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
