### PR TITLE
TXN-1408: Use @walletconnect/modal-sign-html

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ import algosdk from 'algosdk'
 import { PROVIDER_ID, WalletProvider, useInitializeProviders } from '@txnlab/use-wallet'
 import { DeflyWalletConnect } from '@blockshake/defly-connect'
 import { PeraWalletConnect } from '@perawallet/connect'
-import { Web3ModalSign } from '@web3modal/sign-html'
+import { Web3ModalSign } from '@walletconnect/modal-sign-html'
 
 export default function App() {
   const providers = useInitializeProviders({
@@ -552,7 +552,7 @@ However, Algorand apps with `use-wallet` will be able to support the new protoco
 
 1. **Obtain a project ID** - You will need to obtain a project ID from [WalletConnect Cloud](https://cloud.walletconnect.com/). This is a simple process, and there is no waiting period. Every app will need its own unique project ID.
 
-2. **Install peer dependency** - Install `@web3modal/sign-html`.
+2. **Install peer dependency** - Install `@walletconnect/modal-sign-html`.
 
 3. **Update provider configuration** - You will need to use a provider object to initialize WalletConnect, and pass your `clientOptions` as shown below
 
@@ -657,10 +657,10 @@ const providers = useInitializeProviders({
 
 ### WalletConnect provider
 
-The WalletConnect provider now supports WalletConnect 2.0. To continue supporting this provider, or to add support to your application, you must install the `@web3modal/sign-html` package.
+The WalletConnect provider now supports WalletConnect 2.0. To continue supporting this provider, or to add support to your application, you must install the `@walletconnect/modal-sign-html` package.
 
 ```bash
-npm install @web3modal/sign-html
+npm install @walletconnect/modal-sign-html
 ```
 
 The peer dependencies for WalletConnect 1.x should be uninstalled.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/react": "^18.0.15",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.55.0",
-    "@web3modal/sign-html": "^2.4.7",
+    "@walletconnect/modal-sign-html": "^2.5.2",
     "algosdk": "^2.1.0",
     "babel-jest": "^29.1.2",
     "babel-loader": "^8.2.3",
@@ -96,7 +96,7 @@
     "@daffiwallet/connect": "^1.0.3",
     "@perawallet/connect": "^1.2.1",
     "@randlabs/myalgo-connect": "^1.4.2",
-    "@web3modal/sign-html": "^2.4.7",
+    "@walletconnect/modal-sign-html": "^2.5.2",
     "algosdk": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -114,7 +114,7 @@
     "@randlabs/myalgo-connect": {
       "optional": true
     },
-    "@web3modal/sign-html": {
+    "@walletconnect/modal-sign-html": {
       "optional": true
     }
   },

--- a/src/clients/walletconnect2/client.ts
+++ b/src/clients/walletconnect2/client.ts
@@ -1,8 +1,8 @@
 import type {
-  Web3ModalSign,
-  Web3ModalSignOptions,
-  Web3ModalSignSession
-} from '@web3modal/sign-html'
+  WalletConnectModalSign,
+  WalletConnectModalSignOptions,
+  WalletConnectModalSignSession
+} from '@walletconnect/modal-sign-html'
 import BaseClient from '../base'
 import { DecodedSignedTransaction, DecodedTransaction, Network, Wallet } from '../../types'
 import { PROVIDER_ID } from '../../constants'
@@ -13,8 +13,8 @@ import Algod, { getAlgodClient } from '../../algod'
 import { formatJsonRpcRequest } from './utils'
 
 class WalletConnectClient extends BaseClient {
-  #client: Web3ModalSign
-  clientOptions?: Web3ModalSignOptions
+  #client: WalletConnectModalSign
+  clientOptions?: WalletConnectModalSignOptions
   network: Network
   chain: string
 
@@ -63,10 +63,10 @@ class WalletConnectClient extends BaseClient {
       const chain = ALGORAND_CHAINS[network]
 
       const clientModule = clientStatic
-        ? { Web3ModalSign: clientStatic }
-        : await import('@web3modal/sign-html')
+        ? { WalletConnectModalSign: clientStatic }
+        : await import('@walletconnect/modal-sign-html')
 
-      const Client = clientModule.Web3ModalSign
+      const Client = clientModule.WalletConnectModalSign
 
       // Initialize client
       const client = new Client({
@@ -107,7 +107,7 @@ class WalletConnectClient extends BaseClient {
     }
 
     try {
-      const session: Web3ModalSignSession = await this.#client.connect({
+      const session: WalletConnectModalSignSession = await this.#client.connect({
         requiredNamespaces
       })
 
@@ -124,7 +124,7 @@ class WalletConnectClient extends BaseClient {
   }
 
   public async reconnect() {
-    const session: Web3ModalSignSession | undefined = await this.#client.getSession()
+    const session: WalletConnectModalSignSession | undefined = await this.#client.getSession()
     if (typeof session === 'undefined') {
       return null
     }
@@ -248,7 +248,7 @@ class WalletConnectClient extends BaseClient {
   }
 
   async #getSession() {
-    const session: Web3ModalSignSession | undefined = await this.#client.getSession()
+    const session: WalletConnectModalSignSession | undefined = await this.#client.getSession()
     if (typeof session === 'undefined') {
       throw new Error('Session is not connected')
     }

--- a/src/clients/walletconnect2/types.ts
+++ b/src/clients/walletconnect2/types.ts
@@ -1,11 +1,14 @@
-import type { Web3ModalSign, Web3ModalSignOptions } from '@web3modal/sign-html'
+import type {
+  WalletConnectModalSign,
+  WalletConnectModalSignOptions
+} from '@walletconnect/modal-sign-html'
 import type algosdk from 'algosdk'
 import { CommonInitParams, Metadata, Network } from '../../types'
 
 export type WalletConnectClientConstructor = {
   metadata: Metadata
-  client: Web3ModalSign
-  clientOptions: Web3ModalSignOptions
+  client: WalletConnectModalSign
+  clientOptions: WalletConnectModalSignOptions
   algosdk: typeof algosdk
   algodClient: algosdk.Algodv2
   network: Network
@@ -13,8 +16,8 @@ export type WalletConnectClientConstructor = {
 }
 
 export type InitParams = CommonInitParams & {
-  clientOptions?: Web3ModalSignOptions
-  clientStatic?: typeof Web3ModalSign
+  clientOptions?: WalletConnectModalSignOptions
+  clientStatic?: typeof WalletConnectModalSign
 }
 
 export type WalletConnectTransaction = {

--- a/src/testUtils/mockClients.ts
+++ b/src/testUtils/mockClients.ts
@@ -3,7 +3,7 @@ import { DeflyWalletConnect } from '@blockshake/defly-connect'
 import { DaffiWalletConnect } from '@daffiwallet/connect'
 import { PeraWalletConnect } from '@perawallet/connect'
 import MyAlgoConnect from '@randlabs/myalgo-connect'
-import { Web3ModalSign } from '@web3modal/sign-html'
+import { WalletConnectModalSign } from '@walletconnect/modal-sign-html'
 import algosdk from 'algosdk'
 import AlgoSignerClient from '../clients/algosigner/client'
 import DaffiWalletClient from '../clients/daffi/client'
@@ -401,7 +401,7 @@ export const createWalletConnectMockInstance = (
       icon: 'walletconnect-icon-b64',
       isWalletConnect: true
     },
-    client: new Web3ModalSign(options),
+    client: new WalletConnectModalSign(options),
     clientOptions: {
       ...options
     },

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -3,7 +3,10 @@ import type { PeraWalletConnect } from '@perawallet/connect'
 import type { DeflyWalletConnect } from '@blockshake/defly-connect'
 import type { DaffiWalletConnect } from '@daffiwallet/connect'
 import type MyAlgoConnect from '@randlabs/myalgo-connect'
-import type { Web3ModalSign, Web3ModalSignOptions } from '@web3modal/sign-html'
+import type {
+  WalletConnectModalSign,
+  WalletConnectModalSignOptions
+} from '@walletconnect/modal-sign-html'
 import type algosdk from 'algosdk'
 import type { AlgodClientOptions, Network } from './node'
 import type { PeraWalletConnectOptions } from '../clients/pera/types'
@@ -27,8 +30,8 @@ export type ProviderConfigMapping = {
     clientStatic?: typeof DeflyWalletConnect
   }
   [PROVIDER_ID.WALLETCONNECT]: {
-    clientOptions?: Web3ModalSignOptions
-    clientStatic?: typeof Web3ModalSign
+    clientOptions?: WalletConnectModalSignOptions
+    clientStatic?: typeof WalletConnectModalSign
   }
   [PROVIDER_ID.MYALGO]: {
     clientOptions?: MyAlgoConnectOptions

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,13 +3631,39 @@
     pino "7.11.0"
     tslib "1.14.1"
 
-"@walletconnect/modal@2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@walletconnect/modal/-/modal-2.4.7.tgz#fd84d6f1ac767865d63153e32150f790739a189a"
-  integrity sha512-kFpvDTT44CgNGcwQVC0jHrYed4xorghKX1DOGo8ZfBSJ5TJx3p6d6SzLxkH1cZupWbljWkYS6SqvZcUBs8vWpg==
+"@walletconnect/modal-core@2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal-core/-/modal-core-2.5.2.tgz#b847191d36274e947aa805b5ca9fe2cae273cc63"
+  integrity sha512-meYjouZxAik0peyhxDUTRY77uu/r4tLe1QoJp/Ra3brHD0i93uwX5U8RlBNDLGQhLGIraZl6xNANcxHGRHFSuQ==
   dependencies:
-    "@web3modal/core" "2.4.7"
-    "@web3modal/ui" "2.4.7"
+    buffer "6.0.3"
+    valtio "1.10.5"
+
+"@walletconnect/modal-sign-html@^2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal-sign-html/-/modal-sign-html-2.5.2.tgz#244f5baa8574be8949c90ebe6ddd667c3840ef18"
+  integrity sha512-ULery8TISHBkSoaBjEl5f3JypQLM0YUqbLmI1rjjwmSRTFxfwRK9Vlv4ElEaTeC3c00klsqYOj2sqG3lksaV4A==
+  dependencies:
+    "@walletconnect/modal" "2.5.2"
+    "@walletconnect/sign-client" "2.8.1"
+
+"@walletconnect/modal-ui@2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal-ui/-/modal-ui-2.5.2.tgz#cb6184bd4c0e207fcfc566b13046938fe03e1cfd"
+  integrity sha512-ZbHsFP+LWvyJ3wwJf3nJKkwqMOHpJ5ECnAZgopMX+hp/bS+4JEeCzUy1StmzyriT6RImLFRQkI6Zas/NetaUnw==
+  dependencies:
+    "@walletconnect/modal-core" "2.5.2"
+    lit "2.7.5"
+    motion "10.16.2"
+    qrcode "1.5.3"
+
+"@walletconnect/modal@2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal/-/modal-2.5.2.tgz#402e5904e2a39fddc63a6a99bd9c621a0c315d6f"
+  integrity sha512-vMLAQFjbMeXZ3+ojb+0OmMRpXCg92vCWJS2t3pF6XyxZrp/qxB9W87HwP7q6ecJtePM1Snil5QlpXipprqzr9g==
+  dependencies:
+    "@walletconnect/modal-core" "2.5.2"
+    "@walletconnect/modal-ui" "2.5.2"
 
 "@walletconnect/randombytes@^1.0.3":
   version "1.0.3"
@@ -3788,32 +3814,6 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.1"
     tslib "1.14.1"
-
-"@web3modal/core@2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/core/-/core-2.4.7.tgz#e128be449bc5f6f23f6fb32f12021c096b5e7a07"
-  integrity sha512-FZMmI4JnEZovRDdN+PZBMe2ot8ly+UftVkZ6lmtfgiRZ2Gy3k/4IYE8/KwOSmN63Lf2Oj2077buLR17i0xoKZA==
-  dependencies:
-    buffer "6.0.3"
-    valtio "1.10.5"
-
-"@web3modal/sign-html@^2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/sign-html/-/sign-html-2.4.7.tgz#8280ad68b8c61f1389b712344a758e5f7cf15fe6"
-  integrity sha512-HsnhpJJfdyB9X5nrPV6gCXGSDju9oT4lZ53Vmaw5G4ZuGHC/X2zzoo1OhJSTFYP5IJ60gsj70SZpSWbSw3WAwg==
-  dependencies:
-    "@walletconnect/modal" "2.4.7"
-    "@walletconnect/sign-client" "2.8.1"
-
-"@web3modal/ui@2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/ui/-/ui-2.4.7.tgz#94d70e60386eb6fae422c56386019e761f80a50a"
-  integrity sha512-5tU9u5CVYueZ9y+1x1A1Q0bFUfk3gOIKy3MT6Vx+aI0RDxVu7OYQDw6wbNPlgz/wd9JPYXG6uSv8WTBpdyit8Q==
-  dependencies:
-    "@web3modal/core" "2.4.7"
-    lit "2.7.5"
-    motion "10.16.2"
-    qrcode "1.5.3"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"


### PR DESCRIPTION
### Description

This replaces the deprecated @web3modal/sign-html package

### Checklist

- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
