### PR TITLE
TXN-1408: Switch to @walletconnect/modal-sign-html

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ useEffect(() => {
 - Documentation - https://docs.walletconnect.com/
 - WalletConnect Cloud - https://cloud.walletconnect.com/
 - Web3Modal - https://web3modal.com/
-- Install dependency - `npm install @web3modal/sign-html`
+- Install dependency - `npm install @walletconnect/modal-sign-html`
 
 ### Exodus Wallet
 
@@ -533,7 +533,7 @@ import { PROVIDER_ID, WalletProvider, useInitializeProviders } from '@txnlab/use
 import { DeflyWalletConnect } from '@blockshake/defly-connect'
 import { PeraWalletConnect } from '@perawallet/connect'
 import { DaffiWalletConnect } from '@daffiwallet/connect'
-import { Web3ModalSign } from '@web3modal/sign-html'
+import { WalletConnectModalSign } from '@walletconnect/modal-sign-html'
 
 export default function App() {
   const providers = useInitializeProviders({
@@ -543,7 +543,7 @@ export default function App() {
       { id: PROVIDER_ID.DAFFI, clientStatic: DaffiWalletConnect },
       {
         id: PROVIDER_ID.WALLETCONNECT,
-        clientStatic: Web3ModalSign,
+        clientStatic: WalletConnectModalSign,
         clientOptions: {
           projectId: '<YOUR_PROJECT_ID>',
           metadata: {
@@ -584,7 +584,7 @@ However, Algorand apps with `use-wallet` will be able to support the new protoco
 
 1. **Obtain a project ID** - You will need to obtain a project ID from [WalletConnect Cloud](https://cloud.walletconnect.com/). This is a simple process, and there is no waiting period. Every app will need its own unique project ID.
 
-2. **Install client library** - Install `@web3modal/sign-html` and set `clientStatic` to the imported `Web3ModalSign` module.
+2. **Install client library** - Install `@walletconnect/modal-sign-html` and set `clientStatic` to the imported `WalletConnectModalSign` module.
 
 3. **Required options** - Set the required `clientOptions` as shown below
 
@@ -593,7 +593,7 @@ const providers = useInitializeProviders({
   providers: [
     {
       id: PROVIDER_ID.WALLETCONNECT,
-      clientStatic: Web3ModalSign,
+      clientStatic: WalletConnectModalSign,
       clientOptions: {
         projectId: '<YOUR_PROJECT_ID>',
         metadata: {
@@ -696,10 +696,10 @@ const providers = useInitializeProviders({
 
 ### WalletConnect peer dependencies
 
-The WalletConnect provider now supports WalletConnect 2.0. To continue supporting this provider, or to add support to your application, you must install the `@web3modal/sign-html` package.
+The WalletConnect provider now supports WalletConnect 2.0. To continue supporting this provider, or to add support to your application, you must install the `@walletconnect/modal-sign-html` package.
 
 ```bash
-npm install @web3modal/sign-html
+npm install @walletconnect/modal-sign-html
 ```
 
 The peer dependencies for WalletConnect 1.x should be uninstalled.

--- a/__mocks__/walletconnect-modal-sign-html.js
+++ b/__mocks__/walletconnect-modal-sign-html.js
@@ -1,0 +1,1 @@
+export const WalletConnectModalSign = jest.fn()

--- a/__mocks__/web3modal-sign-html.js
+++ b/__mocks__/web3modal-sign-html.js
@@ -1,1 +1,0 @@
-export const Web3ModalSign = jest.fn()

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -89,7 +89,7 @@ export default {
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
-    '@web3modal/sign-html': '<rootDir>/__mocks__/web3modal-sign-html.js'
+    '@walletconnect/modal-sign-html': '<rootDir>/__mocks__/walletconnect-modal-sign-html.js'
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/react": "^18.0.15",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.55.0",
-    "@web3modal/sign-html": "^2.4.7",
+    "@walletconnect/modal-sign-html": "^2.5.4",
     "algosdk": "^2.1.0",
     "babel-jest": "^29.1.2",
     "babel-loader": "^9.0.0",
@@ -93,7 +93,6 @@
     "@daffiwallet/connect": "^1.0.3",
     "@perawallet/connect": "^1.2.1",
     "@randlabs/myalgo-connect": "^1.4.2",
-    "@web3modal/sign-html": "^2.4.7",
     "algosdk": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -111,7 +110,7 @@
     "@randlabs/myalgo-connect": {
       "optional": true
     },
-    "@web3modal/sign-html": {
+    "@walletconnect/modal-sign-html": {
       "optional": true
     }
   },

--- a/src/clients/walletconnect2/client.ts
+++ b/src/clients/walletconnect2/client.ts
@@ -10,18 +10,18 @@ import { isPublicNetwork } from '../../utils/types'
 import { ALGORAND_CHAINS, ICON } from './constants'
 import { formatJsonRpcRequest } from './utils'
 import type {
-  Web3ModalSign,
-  Web3ModalSignOptions,
-  Web3ModalSignSession
-} from '@web3modal/sign-html'
+  WalletConnectModalSign,
+  WalletConnectModalSignOptions,
+  WalletConnectModalSignSession
+} from '@walletconnect/modal-sign-html'
 import type { DecodedSignedTransaction, DecodedTransaction, Network } from '../../types/node'
 import type { InitParams } from '../../types/providers'
 import type { Wallet } from '../../types/wallet'
 import type { WalletConnectClientConstructor, WalletConnectTransaction } from './types'
 
 class WalletConnectClient extends BaseClient {
-  #client: Web3ModalSign
-  clientOptions?: Web3ModalSignOptions
+  #client: WalletConnectModalSign
+  clientOptions?: WalletConnectModalSignOptions
   network: Network
   chain: string
 
@@ -120,7 +120,7 @@ class WalletConnectClient extends BaseClient {
     }
 
     try {
-      const session: Web3ModalSignSession = await this.#client.connect({
+      const session: WalletConnectModalSignSession = await this.#client.connect({
         requiredNamespaces
       })
 
@@ -137,7 +137,7 @@ class WalletConnectClient extends BaseClient {
   }
 
   public async reconnect() {
-    const session: Web3ModalSignSession | undefined = await this.#client.getSession()
+    const session: WalletConnectModalSignSession | undefined = await this.#client.getSession()
     if (typeof session === 'undefined') {
       return null
     }
@@ -261,7 +261,7 @@ class WalletConnectClient extends BaseClient {
   }
 
   async #getSession() {
-    const session: Web3ModalSignSession | undefined = await this.#client.getSession()
+    const session: WalletConnectModalSignSession | undefined = await this.#client.getSession()
     if (typeof session === 'undefined') {
       throw new Error('Session is not connected')
     }

--- a/src/clients/walletconnect2/types.ts
+++ b/src/clients/walletconnect2/types.ts
@@ -1,12 +1,15 @@
-import type { Web3ModalSign, Web3ModalSignOptions } from '@web3modal/sign-html'
+import type {
+  WalletConnectModalSign,
+  WalletConnectModalSignOptions
+} from '@walletconnect/modal-sign-html'
 import type algosdk from 'algosdk'
 import type { Network } from '../../types/node'
 import type { Metadata } from '../../types/wallet'
 
 export type WalletConnectClientConstructor = {
   metadata: Metadata
-  client: Web3ModalSign
-  clientOptions: Web3ModalSignOptions
+  client: WalletConnectModalSign
+  clientOptions: WalletConnectModalSignOptions
   algosdk: typeof algosdk
   algodClient: algosdk.Algodv2
   network: Network

--- a/src/testUtils/mockClients.ts
+++ b/src/testUtils/mockClients.ts
@@ -3,7 +3,7 @@ import { DeflyWalletConnect } from '@blockshake/defly-connect'
 import { DaffiWalletConnect } from '@daffiwallet/connect'
 import { PeraWalletConnect } from '@perawallet/connect'
 import MyAlgoConnect from '@randlabs/myalgo-connect'
-import { Web3ModalSign } from '@web3modal/sign-html'
+import { WalletConnectModalSign } from '@walletconnect/modal-sign-html'
 import algosdk from 'algosdk'
 import AlgoSignerClient from '../clients/algosigner/client'
 import DaffiWalletClient from '../clients/daffi/client'
@@ -401,7 +401,7 @@ export const createWalletConnectMockInstance = (
       icon: 'walletconnect-icon-b64',
       isWalletConnect: true
     },
-    client: new Web3ModalSign(options),
+    client: new WalletConnectModalSign(options),
     clientOptions: {
       ...options
     },

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -3,7 +3,10 @@ import type { PeraWalletConnect } from '@perawallet/connect'
 import type { DeflyWalletConnect } from '@blockshake/defly-connect'
 import type { DaffiWalletConnect } from '@daffiwallet/connect'
 import type MyAlgoConnect from '@randlabs/myalgo-connect'
-import type { Web3ModalSign, Web3ModalSignOptions } from '@web3modal/sign-html'
+import type {
+  WalletConnectModalSign,
+  WalletConnectModalSignOptions
+} from '@walletconnect/modal-sign-html'
 import type algosdk from 'algosdk'
 import type { AlgodClientOptions, Network } from './node'
 import type { PeraWalletConnectOptions } from '../clients/pera/types'
@@ -29,8 +32,8 @@ export type ProviderConfigMapping = {
     clientStatic?: typeof DeflyWalletConnect
   }
   [PROVIDER_ID.WALLETCONNECT]: {
-    clientOptions?: Web3ModalSignOptions
-    clientStatic?: typeof Web3ModalSign
+    clientOptions?: WalletConnectModalSignOptions
+    clientStatic?: typeof WalletConnectModalSign
   }
   [PROVIDER_ID.MYALGO]: {
     clientOptions?: MyAlgoConnectOptions
@@ -89,8 +92,8 @@ type ProviderDef =
   | (ProviderConfig<PROVIDER_ID.DEFLY> & { clientStatic: typeof DeflyWalletConnect })
   | (ProviderConfig<PROVIDER_ID.DAFFI> & { clientStatic: typeof DaffiWalletConnect })
   | (ProviderConfig<PROVIDER_ID.WALLETCONNECT> & {
-      clientStatic: typeof Web3ModalSign
-      clientOptions: Web3ModalSignOptions
+      clientStatic: typeof WalletConnectModalSign
+      clientOptions: WalletConnectModalSignOptions
     })
   | (ProviderConfig<PROVIDER_ID.MYALGO> & { clientStatic: typeof MyAlgoConnect })
   | ProviderConfig<PROVIDER_ID.EXODUS>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,10 +3765,10 @@
     "@walletconnect/types" "^1.8.0"
     "@walletconnect/utils" "^1.8.0"
 
-"@walletconnect/core@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.8.1.tgz#f74404af372a11e05c214cbc14b5af0e9c0cf916"
-  integrity sha512-mN9Zkdl/NeThntK8cydDoQOW6jUEpOeFgYR1RCKPLH51VQwlbdSgvvQIeanSQXEY4U7AM3x8cs1sxqMomIfRQg==
+"@walletconnect/core@2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.8.3.tgz#cd1942e49b09fc8fc97867da1853c3cda71013c9"
+  integrity sha512-uQG3XoGJscnxOWTO/W39QOXQszNpSbV8b/BFJoful9D1IUGeTracGc8FdKtNQFfvyhrx3gooZ+HwOK6QBirXzQ==
   dependencies:
     "@walletconnect/heartbeat" "1.2.1"
     "@walletconnect/jsonrpc-provider" "1.0.13"
@@ -3781,8 +3781,8 @@
     "@walletconnect/relay-auth" "^1.0.4"
     "@walletconnect/safe-json" "^1.0.2"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.8.1"
-    "@walletconnect/utils" "2.8.1"
+    "@walletconnect/types" "2.8.3"
+    "@walletconnect/utils" "2.8.3"
     events "^3.3.0"
     lodash.isequal "4.5.0"
     uint8arrays "^3.1.0"
@@ -3903,13 +3903,39 @@
     pino "7.11.0"
     tslib "1.14.1"
 
-"@walletconnect/modal@2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@walletconnect/modal/-/modal-2.4.7.tgz#fd84d6f1ac767865d63153e32150f790739a189a"
-  integrity sha512-kFpvDTT44CgNGcwQVC0jHrYed4xorghKX1DOGo8ZfBSJ5TJx3p6d6SzLxkH1cZupWbljWkYS6SqvZcUBs8vWpg==
+"@walletconnect/modal-core@2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal-core/-/modal-core-2.5.4.tgz#7d739a90a9cf103067eea46507ea649e8dada436"
+  integrity sha512-ISe4LqmEDFU7b6rLgonqaEtMXzG6ko13HA7S8Ty3d7GgfAEe29LM1dq3zo8ehEOghhofhj1PiiNfvaogZKzT1g==
   dependencies:
-    "@web3modal/core" "2.4.7"
-    "@web3modal/ui" "2.4.7"
+    buffer "6.0.3"
+    valtio "1.10.6"
+
+"@walletconnect/modal-sign-html@^2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal-sign-html/-/modal-sign-html-2.5.4.tgz#b5cb8c07d066994c8b7e2a10014ea5720d58e827"
+  integrity sha512-RjnJwzWSOKYXnv7a4Lu2hRw2pWW3fIDWpQ3hk0JcrthpSa9QUVs7loxGOrnj7VDZecKlBX6GX2ugF9YwF7ffKQ==
+  dependencies:
+    "@walletconnect/modal" "2.5.4"
+    "@walletconnect/sign-client" "2.8.3"
+
+"@walletconnect/modal-ui@2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal-ui/-/modal-ui-2.5.4.tgz#0433fb0226dd47e17fede620c5a5ff332baed155"
+  integrity sha512-5qLLjwbE3YC4AsCVhf8J87otklkApcQ5DCMykOcS0APPv8lKQ46JxpQhfWwRYaUkuIiHonI9h1YxFARDkoaI9g==
+  dependencies:
+    "@walletconnect/modal-core" "2.5.4"
+    lit "2.7.5"
+    motion "10.16.2"
+    qrcode "1.5.3"
+
+"@walletconnect/modal@2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal/-/modal-2.5.4.tgz#66659051f9c0f35c151d3a8d940f8c64d42fab74"
+  integrity sha512-JAKMcCd4JQvSEr7pNitg3OBke4DN1JyaQ7bdi3x4T7oLgOr9Y88qdkeOXko/0aJonDHJsM88hZ10POQWmKfEMA==
+  dependencies:
+    "@walletconnect/modal-core" "2.5.4"
+    "@walletconnect/modal-ui" "2.5.4"
 
 "@walletconnect/randombytes@^1.0.3":
   version "1.0.3"
@@ -3953,19 +3979,19 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/sign-client@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.8.1.tgz#8c6de724eff6a306c692dd66e66944089be5e30a"
-  integrity sha512-6DbpjP9BED2YZOZdpVgYo0HwPBV7k99imnsdMFrTn16EFAxhuYP0/qPwum9d072oNMGWJSA6d4rzc8FHNtHsCA==
+"@walletconnect/sign-client@2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.8.3.tgz#2476716cfaed921a80a93e4342124105e5a1f720"
+  integrity sha512-fOlyZfzV4xJO0CDCMrQ3hw4bIuboncqVpJ0BgTF5yQtKklv+5pEqlFnhU8GN2rE6GThU1zyPQNibT/jRG7lCAw==
   dependencies:
-    "@walletconnect/core" "2.8.1"
+    "@walletconnect/core" "2.8.3"
     "@walletconnect/events" "^1.0.1"
     "@walletconnect/heartbeat" "1.2.1"
     "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/logger" "^2.0.1"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.8.1"
-    "@walletconnect/utils" "2.8.1"
+    "@walletconnect/types" "2.8.3"
+    "@walletconnect/utils" "2.8.3"
     events "^3.3.0"
 
 "@walletconnect/socket-transport@^1.8.0":
@@ -3984,10 +4010,10 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/types@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.8.1.tgz#640eb6ad23866886fbe09a9b29832bf3f8647a09"
-  integrity sha512-MLISp85b+27vVkm3Wkud+eYCwySXCdOrmn0yQCSN6DnRrrunrD05ksz4CXGP7h2oXUvvXPDt/6lXBf1B4AfqrA==
+"@walletconnect/types@2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.8.3.tgz#2a389458ebda56b4119231579e1b37b0fe24f981"
+  integrity sha512-crZ5IfWEp+ctygfDNifzB68sVWKwfLMiF7GZuoOzKJuFYbXtcNjtpmFdAd3cPT+a8L30XMgv0shEdIHTj2JglQ==
   dependencies:
     "@walletconnect/events" "^1.0.1"
     "@walletconnect/heartbeat" "1.2.1"
@@ -4001,10 +4027,10 @@
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-1.8.0.tgz#3f5e85b2d6b149337f727ab8a71b8471d8d9a195"
   integrity sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==
 
-"@walletconnect/utils@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.8.1.tgz#1356f4bba7f8b6664fc5b61ce3497596c8d9d603"
-  integrity sha512-d6p9OX3v70m6ijp+j4qvqiQZQU1vbEHN48G8HqXasyro3Z+N8vtcB5/gV4pTYsbWgLSDtPHj49mzbWQ0LdIdTw==
+"@walletconnect/utils@2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.8.3.tgz#32d3111f1638e45663cf8b65c6d3af28cf5591d5"
+  integrity sha512-PwNEj/kGO7J7ZyrAaVqYkASLBG77qDE/+6JPX11GAucSy2wac92WefLjfVsPLNPwiNmYiV1eGbxzR3KCdlnrLA==
   dependencies:
     "@stablelib/chacha20poly1305" "1.0.1"
     "@stablelib/hkdf" "1.0.1"
@@ -4014,7 +4040,7 @@
     "@walletconnect/relay-api" "^1.0.9"
     "@walletconnect/safe-json" "^1.0.2"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.8.1"
+    "@walletconnect/types" "2.8.3"
     "@walletconnect/window-getters" "^1.0.1"
     "@walletconnect/window-metadata" "^1.0.1"
     detect-browser "5.3.0"
@@ -4060,32 +4086,6 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.1"
     tslib "1.14.1"
-
-"@web3modal/core@2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/core/-/core-2.4.7.tgz#e128be449bc5f6f23f6fb32f12021c096b5e7a07"
-  integrity sha512-FZMmI4JnEZovRDdN+PZBMe2ot8ly+UftVkZ6lmtfgiRZ2Gy3k/4IYE8/KwOSmN63Lf2Oj2077buLR17i0xoKZA==
-  dependencies:
-    buffer "6.0.3"
-    valtio "1.10.5"
-
-"@web3modal/sign-html@^2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/sign-html/-/sign-html-2.4.7.tgz#8280ad68b8c61f1389b712344a758e5f7cf15fe6"
-  integrity sha512-HsnhpJJfdyB9X5nrPV6gCXGSDju9oT4lZ53Vmaw5G4ZuGHC/X2zzoo1OhJSTFYP5IJ60gsj70SZpSWbSw3WAwg==
-  dependencies:
-    "@walletconnect/modal" "2.4.7"
-    "@walletconnect/sign-client" "2.8.1"
-
-"@web3modal/ui@2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/ui/-/ui-2.4.7.tgz#94d70e60386eb6fae422c56386019e761f80a50a"
-  integrity sha512-5tU9u5CVYueZ9y+1x1A1Q0bFUfk3gOIKy3MT6Vx+aI0RDxVu7OYQDw6wbNPlgz/wd9JPYXG6uSv8WTBpdyit8Q==
-  dependencies:
-    "@web3modal/core" "2.4.7"
-    lit "2.7.5"
-    motion "10.16.2"
-    qrcode "1.5.3"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -14291,10 +14291,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-valtio@1.10.5:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.10.5.tgz#7852125e3b774b522827d96bd9c76d285c518678"
-  integrity sha512-jTp0k63VXf4r5hPoaC6a6LCG4POkVSh629WLi1+d5PlajLsbynTMd7qAgEiOSPxzoX5iNvbN7iZ/k/g29wrNiQ==
+valtio@1.10.6:
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.10.6.tgz#80ed00198b949939863a0fa56ae687abb417fc4f"
+  integrity sha512-SxN1bHUmdhW6V8qsQTpCgJEwp7uHbntuH0S9cdLQtiohuevwBksbpXjwj5uDMA7bLwg1WKyq9sEpZrx3TIMrkA==
   dependencies:
     proxy-compare "2.5.1"
     use-sync-external-store "1.2.0"


### PR DESCRIPTION
### Description

The deprecated @web3modal/sign-html peer dependency is replaced by @walletconnect/modal-sign-html.

This is a like-for-like change, except for the renamed exports. The client's methods/API are the same. The @walletconnect/modal-sign-html package uses a more recent version of @walletconnect/core than the deprecated @web3modal/sign-html.

**BREAKING CHANGE:** @web3modal/sign-html will no longer work

### Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
