### PR TITLE
fix: preserve order of providers as passed into `useInitializeProviders`

### DIFF
--- a/src/utils/initializeProviders.test.ts
+++ b/src/utils/initializeProviders.test.ts
@@ -97,7 +97,7 @@ describe('initializeProviders', () => {
     const result = await initializeProviders(providers)
 
     // Check if the returned object has the correct keys
-    expect(Object.keys(result)).toEqual(expect.arrayContaining(providers))
+    expect(Object.keys(result)).toEqual(providers)
 
     // Check if the returned clients are instances of BaseClient
     for (const clientInstance of Object.values(result)) {

--- a/src/utils/initializeProviders.ts
+++ b/src/utils/initializeProviders.ts
@@ -50,7 +50,11 @@ export const initializeProviders = async <T extends keyof ProviderConfigMapping>
 
   debugLog('Initializing providers:', getProviderList(providers))
 
-  const initPromises = providers.map((provider) => initClient(provider))
+  const initPromises = providers.map((provider) => {
+    const providerId = typeof provider === 'string'? provider : provider.id
+    initializedProviders[providerId] = null // Set to null to preserve order of providers
+    initClient(provider)
+  })
   await Promise.all(initPromises)
 
   return initializedProviders

--- a/src/utils/initializeProviders.ts
+++ b/src/utils/initializeProviders.ts
@@ -20,12 +20,18 @@ export const initializeProviders = async <T extends keyof ProviderConfigMapping>
   nodeConfig?: NodeConfig,
   algosdkStatic?: typeof algosdk
 ): Promise<SupportedProviders> => {
-  const initializedProviders: SupportedProviders = {}
 
   if (typeof window === 'undefined') {
     debugLog('Window object is not available, skipping initialization')
-    return initializedProviders
+    return {} as SupportedProviders
   }
+
+  // Set all providers to null to preserve order
+  const initializedProviders = providers.reduce((acc, provider) => {
+    const providerId = typeof provider === 'string'? provider : provider.id
+    acc[providerId] = null
+    return acc
+  }, {} as SupportedProviders)
 
   const {
     network = DEFAULT_NETWORK,
@@ -50,11 +56,7 @@ export const initializeProviders = async <T extends keyof ProviderConfigMapping>
 
   debugLog('Initializing providers:', getProviderList(providers))
 
-  const initPromises = providers.map((provider) => {
-    const providerId = typeof provider === 'string'? provider : provider.id
-    initializedProviders[providerId] = null // Set to null to preserve order of providers
-    initClient(provider)
-  })
+  const initPromises = providers.map((provider) => initClient(provider))
   await Promise.all(initPromises)
 
   return initializedProviders


### PR DESCRIPTION
### Description

This is a fix for issue #104. With this fix, the order of the providers when passed into the `useInitializeProviders` hook will determine the order of providers in the `providers` array returned by the `useWallet` hook.

### Checklist

- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
