### PR TITLE
feat: support rekeyed signing with kmd

### DIFF
--- a/src/clients/kmd/client.ts
+++ b/src/clients/kmd/client.ts
@@ -197,15 +197,31 @@ class KMDWalletClient extends BaseClient {
         return
       }
       // Not to be signed by our signer, skip it
-      else if (!connectedAccounts.includes(this.algosdk.encodeAddress(dtxn.snd))) {
-        return
+      else {
+        const senderAddress = this.algosdk.encodeAddress(dtxn.snd)
+        const rekeyAddress = dtxn.rekey ? this.algosdk.encodeAddress(dtxn.rekey) : null
+
+        const isSignerConnected = rekeyAddress
+          ? connectedAccounts.includes(rekeyAddress) && connectedAccounts.includes(senderAddress)
+          : connectedAccounts.includes(senderAddress)
+
+        if (!isSignerConnected) {
+          return
+        }
       }
 
       // overwrite with an empty blob
       signedTxns[idx] = new Uint8Array()
 
       const txn = this.algosdk.Transaction.from_obj_for_encoding(dtxn)
-      signingPromises.push(this.#client.signTransaction(token, pw, txn) as Promise<Uint8Array>)
+
+      console.log('signing txn', txn)
+
+      const promise = txn.reKeyTo
+        ? this.#client.signTransactionWithSpecificPublicKey(token, pw, txn, txn.reKeyTo.publicKey)
+        : this.#client.signTransaction(token, pw, txn)
+
+      signingPromises.push(promise as Promise<Uint8Array>)
     })
 
     const signingResults = await Promise.all(signingPromises)

--- a/src/clients/kmd/client.ts
+++ b/src/clients/kmd/client.ts
@@ -215,8 +215,6 @@ class KMDWalletClient extends BaseClient {
 
       const txn = this.algosdk.Transaction.from_obj_for_encoding(dtxn)
 
-      console.log('signing txn', txn)
-
       const promise = txn.reKeyTo
         ? this.#client.signTransactionWithSpecificPublicKey(token, pw, txn, txn.reKeyTo.publicKey)
         : this.#client.signTransaction(token, pw, txn)


### PR DESCRIPTION
### Description

This adds support for rekeyed signing to the kmd (Key Management Daemon) provider.

If a transaction in the group contains a `reKeyTo` property (and the specified account is connected) it is passed to kmd's `signTransactionWithSpecificPublicKey` method for signing.

Closes https://github.com/TxnLab/use-wallet/issues/120

### Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
