### PR TITLE
fix(kibisis): lower get provider timeout from 3 seconds to 0.75 seconds

### DIFF
--- a/src/clients/kibisis/constants.ts
+++ b/src/clients/kibisis/constants.ts
@@ -29,7 +29,7 @@ export const VOI_TESTNET_GENESIS_HASH = 'IXnoWtviVVJW5LGivNFc0Dq14V3kqaXuK2u5OQr
  * timeouts
  */
 export const DEFAULT_REQUEST_TIMEOUT = 180000 // 3 minutes in milliseconds
-export const LOWER_REQUEST_TIMEOUT = 3000 // 3 seconds in milliseconds
+export const LOWER_REQUEST_TIMEOUT = 750 // 0.75 seconds in milliseconds
 export const UPPER_REQUEST_TIMEOUT = 300000 // 5 minutes in milliseconds
 /**
  * icon


### PR DESCRIPTION
### Description

> _Please explain the changes you made here_

Currently, when initializing the Kibisis client, a message is broadcast for discovery of the Kibisis that has a 3 second timeout. However, as the response should be quicker than this, the timeout is unnecessary long which blocks the initialization of other clients.

A 0.75 second timer provides a better compromise.

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
