### PR TITLE
fix(kibisis): remove web crypto api dependency when generating uuid

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -101,17 +101,14 @@ abstract class BaseClient {
 
   groupTransactionsBySender(transactions: TransactionsArray) {
     function groupBySender(objectArray: TxnInfo[]) {
-      return objectArray.reduce(
-        function (acc, obj) {
-          const sender = obj.from
-          if (!acc[sender]) {
-            acc[sender] = []
-          }
-          acc[sender].push(obj)
-          return acc
-        },
-        {} as Record<string, Array<TxnInfo>>
-      )
+      return objectArray.reduce(function (acc, obj) {
+        const sender = obj.from
+        if (!acc[sender]) {
+          acc[sender] = []
+        }
+        acc[sender].push(obj)
+        return acc
+      }, {} as Record<string, Array<TxnInfo>>)
     }
 
     const decodedGroup = transactions.reduce((acc: TxnInfo[], [type, txn], index) => {

--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -101,14 +101,17 @@ abstract class BaseClient {
 
   groupTransactionsBySender(transactions: TransactionsArray) {
     function groupBySender(objectArray: TxnInfo[]) {
-      return objectArray.reduce(function (acc, obj) {
-        const sender = obj.from
-        if (!acc[sender]) {
-          acc[sender] = []
-        }
-        acc[sender].push(obj)
-        return acc
-      }, {} as Record<string, Array<TxnInfo>>)
+      return objectArray.reduce(
+        function (acc, obj) {
+          const sender = obj.from
+          if (!acc[sender]) {
+            acc[sender] = []
+          }
+          acc[sender].push(obj)
+          return acc
+        },
+        {} as Record<string, Array<TxnInfo>>
+      )
     }
 
     const decodedGroup = transactions.reduce((acc: TxnInfo[], [type, txn], index) => {

--- a/src/clients/kibisis/client.ts
+++ b/src/clients/kibisis/client.ts
@@ -35,6 +35,7 @@ import type {
   SignTxnsResult
 } from './types'
 import { DecodedSignedTransaction, DecodedTransaction } from '../../types'
+import { generateUuid } from './utils'
 
 class KibisisClient extends BaseClient {
   genesisHash: string
@@ -153,7 +154,7 @@ class KibisisClient extends BaseClient {
   }: SendRequestWithTimeoutOptions<Params>): Promise<Result | undefined> {
     return new Promise<Result | undefined>((resolve, reject) => {
       const channel = new BroadcastChannel(ARC_0027_CHANNEL_NAME)
-      const requestId = crypto.randomUUID()
+      const requestId = generateUuid()
       // eslint-disable-next-line prefer-const
       let timer: number
 

--- a/src/clients/kibisis/utils.test.ts
+++ b/src/clients/kibisis/utils.test.ts
@@ -1,4 +1,5 @@
 import { generateUuid } from './utils'
+import { randomUUID, getRandomValues } from 'crypto'
 
 describe(`${__dirname}/utils`, () => {
   const validUuidRegex =
@@ -12,20 +13,22 @@ describe(`${__dirname}/utils`, () => {
     })
 
     it('should generate a valid uuid without the web crypto api', () => {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      const cryptoRandomUUID = global.crypto.randomUUID
-
-      Object.defineProperty(global.crypto, 'randomUUID', {
+      Object.defineProperty(global, 'crypto', {
         configurable: true,
-        value: undefined
+        value: {
+          getRandomValues,
+        }
       })
 
       const result = generateUuid()
 
       expect(validUuidRegex.test(result)).toBe(true)
 
-      Object.defineProperty(global.crypto, 'randomUUID', {
-        value: cryptoRandomUUID
+      Object.defineProperty(global, 'crypto', {
+        value: {
+          getRandomValues,
+          randomUUID,
+        }
       })
     })
   })

--- a/src/clients/kibisis/utils.test.ts
+++ b/src/clients/kibisis/utils.test.ts
@@ -1,0 +1,32 @@
+import { generateUuid } from './utils'
+
+describe(`${__dirname}/utils`, () => {
+  const validUuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+  describe('generateUuid()', () => {
+    it('should generate a valid uuid using the web crypto api', () => {
+      const result = generateUuid()
+
+      expect(validUuidRegex.test(result)).toBe(true)
+    })
+
+    it('should generate a valid uuid without the web crypto api', () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const cryptoRandomUUID = crypto.randomUUID
+
+      Object.defineProperty(crypto, 'randomUUID', {
+        configurable: true,
+        value: undefined
+      })
+
+      const result = generateUuid()
+
+      expect(validUuidRegex.test(result)).toBe(true)
+
+      Object.defineProperty(crypto, 'randomUUID', {
+        value: cryptoRandomUUID
+      })
+    })
+  })
+})

--- a/src/clients/kibisis/utils.test.ts
+++ b/src/clients/kibisis/utils.test.ts
@@ -16,7 +16,7 @@ describe(`${__dirname}/utils`, () => {
       Object.defineProperty(global, 'crypto', {
         configurable: true,
         value: {
-          getRandomValues,
+          getRandomValues
         }
       })
 
@@ -27,7 +27,7 @@ describe(`${__dirname}/utils`, () => {
       Object.defineProperty(global, 'crypto', {
         value: {
           getRandomValues,
-          randomUUID,
+          randomUUID
         }
       })
     })

--- a/src/clients/kibisis/utils.test.ts
+++ b/src/clients/kibisis/utils.test.ts
@@ -13,9 +13,9 @@ describe(`${__dirname}/utils`, () => {
 
     it('should generate a valid uuid without the web crypto api', () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      const cryptoRandomUUID = crypto.randomUUID
+      const cryptoRandomUUID = global.crypto.randomUUID
 
-      Object.defineProperty(crypto, 'randomUUID', {
+      Object.defineProperty(global.crypto, 'randomUUID', {
         configurable: true,
         value: undefined
       })
@@ -24,7 +24,7 @@ describe(`${__dirname}/utils`, () => {
 
       expect(validUuidRegex.test(result)).toBe(true)
 
-      Object.defineProperty(crypto, 'randomUUID', {
+      Object.defineProperty(global.crypto, 'randomUUID', {
         value: cryptoRandomUUID
       })
     })

--- a/src/clients/kibisis/utils.ts
+++ b/src/clients/kibisis/utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Generates a UUID version 4 string. This function attempts to use the `crypto.randomUUID()` function from the Web
+ * Crypto API if it is available, otherwise it uses a polyfill method.
+ *
+ * NOTE: `crypto.randomUUID()` is not available in non-secure contexts; only localhost and HTTPS.
+ * @returns {string} a valid UUID version 4 string.
+ * @see {@link https://stackoverflow.com/a/2117523}
+ */
+export function generateUuid(): string {
+  if (crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+
+  return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, (value) => {
+    const valueAsNumber: number = parseInt(value)
+
+    return (
+      valueAsNumber ^
+      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (valueAsNumber / 4)))
+    ).toString(16)
+  })
+}

--- a/src/clients/kibisis/utils.ts
+++ b/src/clients/kibisis/utils.ts
@@ -7,8 +7,8 @@
  * @see {@link https://stackoverflow.com/a/2117523}
  */
 export function generateUuid(): string {
-  if (crypto.randomUUID) {
-    return crypto.randomUUID()
+  if (global.crypto.randomUUID) {
+    return global.crypto.randomUUID()
   }
 
   return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, (value) => {
@@ -16,7 +16,7 @@ export function generateUuid(): string {
 
     return (
       valueAsNumber ^
-      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (valueAsNumber / 4)))
+      (global.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (valueAsNumber / 4)))
     ).toString(16)
   })
 }


### PR DESCRIPTION
### Description

> _Please explain the changes you made here_

The use of [`crypto.randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) does not work in non-secure contexts (only localhost HTTPS), which is causes HTTP environments to fail to load the Kibisis client. 

This fix attempts to polyfill this dependency by checking if the `crypto.randomUUID` exists and uses it, or uses a polyfill algorithm.

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
