### PR TITLE
fix(magic): remove non-type Magic.link imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,10 +504,9 @@ useEffect(() => {
 - Website - https://lute.app/
 - Install dependency - `npm install lute-connect`
 
-
 ### Kibisis Wallet
 
-***NOTE:** Kibisis is in active development and currently only supports betanet and testnet.*
+**\*NOTE:** Kibisis is in active development and currently only supports betanet and testnet.\*
 
 - Website - https://kibis.is
 - Download - https://kibis.is/#download
@@ -660,7 +659,8 @@ import { PeraWalletConnect } from '@perawallet/connect'
 import { DaffiWalletConnect } from '@daffiwallet/connect'
 import { WalletConnectModalSign } from '@walletconnect/modal-sign-html'
 import LuteConnect from 'lute-connect'
-import { Magic } from 'magic-sdk';
+import { Magic } from 'magic-sdk'
+import { AlgorandExtension } from '@magic-ext/algorand'
 
 export default function App() {
   const providers = useInitializeProviders({
@@ -694,9 +694,10 @@ export default function App() {
       },
       {
         id: PROVIDER_ID.MAGIC,
-        getDynamicClient: Magic,
-        clientOptions: { apiKey: 'API_KEY' },
-      },
+        clientStatic: Magic,
+        extensionStatic: AlgorandExtension,
+        clientOptions: { apiKey: '<API_KEY>' }
+      }
     ],
     nodeConfig: {
       network: 'mainnet',

--- a/src/clients/magic/types.ts
+++ b/src/clients/magic/types.ts
@@ -1,8 +1,8 @@
+import type { AlgorandExtension } from '@magic-ext/algorand'
+import type { SDKBase, InstanceWithExtensions } from '@magic-sdk/provider'
 import type algosdk from 'algosdk'
 import type { Network } from '../../types/node'
 import type { Metadata } from '../../types/wallet'
-import { SDKBase, InstanceWithExtensions } from '@magic-sdk/provider'
-import { AlgorandExtension } from '@magic-ext/algorand'
 
 export type MagicAuthConnectOptions = {
   apiKey: string

--- a/src/components/Example/Example.tsx
+++ b/src/components/Example/Example.tsx
@@ -1,3 +1,4 @@
+import algosdk from 'algosdk'
 import React from 'react'
 import { DeflyWalletConnect } from '@blockshake/defly-connect'
 import { DaffiWalletConnect } from '@daffiwallet/connect'
@@ -6,10 +7,10 @@ import { WalletProvider, PROVIDER_ID, useInitializeProviders, Network } from '..
 import Account from './Account'
 import Connect from './Connect'
 import Transact from './Transact'
-import algosdk from 'algosdk'
 import { ManualGoalSigningAlertPromptProvider } from './TestManualProvider'
 
 const DUMMY_MAGIC_PK = 'pk_live_D17FD8D89621B5F3'
+
 const getDynamicPeraWalletConnect = async () => {
   const PeraWalletConnect = (await import('@perawallet/connect')).PeraWalletConnect
   return PeraWalletConnect
@@ -18,6 +19,11 @@ const getDynamicPeraWalletConnect = async () => {
 const getDynamicMagic = async () => {
   const Magic = (await import('magic-sdk')).Magic
   return Magic
+}
+
+const getDynamicAlgoExtension = async () => {
+  const AlgorandExtension = (await import('@magic-ext/algorand')).AlgorandExtension
+  return AlgorandExtension
 }
 
 export default function ConnectWallet() {
@@ -31,6 +37,7 @@ export default function ConnectWallet() {
       {
         id: PROVIDER_ID.MAGIC,
         getDynamicClient: getDynamicMagic,
+        getDynamicExtension: getDynamicAlgoExtension,
         clientOptions: { apiKey: DUMMY_MAGIC_PK }
       },
       {

--- a/src/testUtils/mockClients.ts
+++ b/src/testUtils/mockClients.ts
@@ -4,6 +4,8 @@ import { DaffiWalletConnect } from '@daffiwallet/connect'
 import { PeraWalletConnect } from '@perawallet/connect'
 import MyAlgoConnect from '@randlabs/myalgo-connect'
 import LuteConnect from 'lute-connect'
+import { Magic } from 'magic-sdk'
+import { AlgorandExtension } from '@magic-ext/algorand'
 import { WalletConnectModalSign } from '@walletconnect/modal-sign-html'
 import algosdk from 'algosdk'
 import AlgoSignerClient from '../clients/algosigner/client'
@@ -23,8 +25,6 @@ import type { Exodus } from '../clients/exodus/types'
 import type { Account, ClientOptions } from '../types'
 import CustomWalletClient from '../clients/custom/client'
 import MagicAuthClient from '../clients/magic/client'
-import { AlgorandExtension } from '@magic-ext/algorand'
-import { Magic } from 'magic-sdk'
 
 type ClientTypeMap = {
   [PROVIDER_ID.ALGOSIGNER]: AlgoSignerClient

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -3,6 +3,8 @@ import type { PeraWalletConnect } from '@perawallet/connect'
 import type { DeflyWalletConnect } from '@blockshake/defly-connect'
 import type { DaffiWalletConnect } from '@daffiwallet/connect'
 import type LuteConnect from 'lute-connect'
+import type { Magic } from 'magic-sdk'
+import type { AlgorandExtension } from '@magic-ext/algorand'
 import type MyAlgoConnect from '@randlabs/myalgo-connect'
 import type {
   WalletConnectModalSign,
@@ -20,7 +22,6 @@ import type { DaffiWalletConnectOptions } from '../clients/daffi/types'
 import type { NonEmptyArray } from './utilities'
 import type BaseClient from '../clients/base'
 import type { CustomOptions } from '../clients/custom/types'
-import { Magic } from 'magic-sdk'
 
 export type ProviderConfigMapping = {
   [PROVIDER_ID.PERA]: {
@@ -87,6 +88,8 @@ export type ProviderConfigMapping = {
     clientOptions?: { apiKey: string }
     clientStatic?: undefined
     getDynamicClient?: () => Promise<typeof Magic>
+    extensionStatic?: typeof AlgorandExtension
+    getDynamicExtension?: () => Promise<typeof AlgorandExtension>
   }
 }
 
@@ -132,10 +135,25 @@ type DynamicClient<T> = {
 
 type OneOfStaticOrDynamicClient<T> = StaticClient<T> | DynamicClient<T>
 
+type StaticAlgoExtension<T> = {
+  extensionStatic: T
+  getDynamicExtension?: undefined
+}
+
+type DynamicAlgoExtension<T> = {
+  extensionStatic?: undefined
+  getDynamicExtension: () => Promise<T>
+}
+
+type OneOfStaticOrDynamicAlgoExtension<T> = StaticAlgoExtension<T> | DynamicAlgoExtension<T>
+
 type ProviderDef =
   | (ProviderConfig<PROVIDER_ID.PERA> & OneOfStaticOrDynamicClient<typeof PeraWalletConnect>)
   | (ProviderConfig<PROVIDER_ID.MAGIC> &
-      OneOfStaticOrDynamicClient<typeof Magic> & { clientOptions: { apiKey: string } })
+      OneOfStaticOrDynamicClient<typeof Magic> &
+      OneOfStaticOrDynamicAlgoExtension<typeof AlgorandExtension> & {
+        clientOptions: { apiKey: string }
+      })
   | (ProviderConfig<PROVIDER_ID.DEFLY> & OneOfStaticOrDynamicClient<typeof DeflyWalletConnect>)
   | (ProviderConfig<PROVIDER_ID.DAFFI> & OneOfStaticOrDynamicClient<typeof DaffiWalletConnect>)
   | (ProviderConfig<PROVIDER_ID.LUTE> &


### PR DESCRIPTION
### Description

The library should not import any SDKs/dependencies for wallet providers (besides type imports). This should be handled by the consuming application on an opt-in basis, depending on which wallets it supports.

The Magic Algorand extension is now (optionally) passed to the `useInitializeProviders` hook's configuration object.

Closes #135

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
