### PR TITLE
fix(kibisis): replace global object with window

### DIFF
--- a/src/clients/kibisis/utils.test.ts
+++ b/src/clients/kibisis/utils.test.ts
@@ -1,9 +1,19 @@
 import { generateUuid } from './utils'
-import { randomUUID, getRandomValues } from 'crypto'
+import { getRandomValues, randomUUID } from 'crypto'
 
 describe(`${__dirname}/utils`, () => {
   const validUuidRegex =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'crypto', {
+      configurable: true,
+      value: {
+        getRandomValues,
+        randomUUID
+      }
+    })
+  })
 
   describe('generateUuid()', () => {
     it('should generate a valid uuid using the web crypto api', () => {
@@ -13,23 +23,15 @@ describe(`${__dirname}/utils`, () => {
     })
 
     it('should generate a valid uuid without the web crypto api', () => {
-      Object.defineProperty(global, 'crypto', {
-        configurable: true,
-        value: {
-          getRandomValues
-        }
-      })
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      delete window.crypto.randomUUID
 
       const result = generateUuid()
 
       expect(validUuidRegex.test(result)).toBe(true)
 
-      Object.defineProperty(global, 'crypto', {
-        value: {
-          getRandomValues,
-          randomUUID
-        }
-      })
+      window.crypto.randomUUID = randomUUID
     })
   })
 })

--- a/src/clients/kibisis/utils.ts
+++ b/src/clients/kibisis/utils.ts
@@ -7,8 +7,8 @@
  * @see {@link https://stackoverflow.com/a/2117523}
  */
 export function generateUuid(): string {
-  if (global.crypto.randomUUID) {
-    return global.crypto.randomUUID()
+  if (window.crypto.randomUUID) {
+    return window.crypto.randomUUID()
   }
 
   return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, (value) => {
@@ -16,7 +16,7 @@ export function generateUuid(): string {
 
     return (
       valueAsNumber ^
-      (global.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (valueAsNumber / 4)))
+      (window.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (valueAsNumber / 4)))
     ).toString(16)
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,17 +531,7 @@
   resolved "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
 
-"@babel/plugin-proposal-private-property-in-object@^7.12.1":
-  version "7.21.11"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz"
-  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.18.6"
-    "@babel/helper-create-class-features-plugin" "^7.21.0"
-    "@babel/helper-plugin-utils" "^7.20.2"
-    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
-
-"@babel/plugin-proposal-private-property-in-object@^7.21.11":
+"@babel/plugin-proposal-private-property-in-object@^7.12.1", "@babel/plugin-proposal-private-property-in-object@^7.21.11":
   version "7.21.11"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
   integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==


### PR DESCRIPTION
### Description

> _Please explain the changes you made here_

`global` was used to access the Web Crypto API to generate a UUID, but this only works in a Node.js environment and therefore throws a TypeError when run in a browser environment.

This fix changes the `global` reference to `window` to correctly reference the Web Crypto API in a browser environment.

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
