### PR TITLE
fix: allow any connected account to be set active

### DIFF
--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -99,7 +99,7 @@ export default function useWallet() {
 
   const selectActiveAccount = (providerId: PROVIDER_ID, address: string) => {
     try {
-      const account = connectedActiveAccounts.find(
+      const account = connectedAccounts.find(
         (acct) => acct.address === address && acct.providerId === providerId
       )
 


### PR DESCRIPTION
### Description

Consider this state:

Defly (active)
- Account A (active)
- Account B

Pera
- Account C
- Account D

If you try to set Account D as the active account, an error is thrown saying no matching account can be found. The reason is that it is only looking for connected accounts from the active provider. My change makes it so it looks through all connected accounts. This allows you to swap to any connected account with a single method call. (provider.setActiveAccount).

### Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

With the way that the tests are setup in useWallet.test.tsx, the activeAccount is hardcoded. What needs to be tested is that the activeAccount changes. I didn't want to make major changes to the test file, so I didn't implement any tests.
