### PR TITLE
Fix: wrap postMessage in timeout to prevent race conditions

### DIFF
--- a/src/clients/kibisis/client.ts
+++ b/src/clients/kibisis/client.ts
@@ -197,12 +197,15 @@ class KibisisClient extends BaseClient {
         } as ResponseError<{ method: ProviderMethods }>)
       }, timeout || DEFAULT_REQUEST_TIMEOUT)
 
-      // broadcast the request
-      channel.postMessage({
-        id: requestId,
-        params,
-        reference
-      } as RequestMessage<Params>)
+      // broadcast the request on the next tick
+      // this allows the channel to be ready before the request is sent
+      window.setTimeout(() => {
+        channel.postMessage({
+          id: requestId,
+          params,
+          reference
+        } as RequestMessage<Params>)
+      }, 0)
     })
   }
 


### PR DESCRIPTION
### Description

There was a race condition where sometimes Kibisis wouldn't show up in the available providers. I believe this was happening because the channel was being created and a listener was being attached and then a message was immediately being posted. I've made a change so that the message being posted happens on the next tick so it actually gives the channel time to setup.

@kieranroneill 

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
