### PR TITLE
fix: allow groups of groups of transactions

### DIFF
--- a/src/clients/kibisis/client.ts
+++ b/src/clients/kibisis/client.ts
@@ -27,6 +27,7 @@ import type {
   GetProvidersResult,
   KibisisClientConstructor,
   ProviderMethods,
+  RawTransactionToSign,
   RequestMessage,
   ResponseError,
   ResponseMessage,
@@ -482,26 +483,29 @@ class KibisisClient extends BaseClient {
     // TODO: the below disable/ignore is necessary as the reduce function throws a TS error for union types (https://github.com/microsoft/TypeScript/issues/36390), however, these can be removed when typescript is updated to 5.2.2+, as the issue has been fixed
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    const transactions: ARC0001SignTxns[] = transactionsOrTransactionGroups.reduce<
-      ARC0001SignTxns[]
-    >((acc: ARC0001SignTxns[], currentValue: Uint8Array | Uint8Array[], index: number) => {
+    const flatTransactions: RawTransactionToSign[] = transactionsOrTransactionGroups.reduce((acc: RawTransactionToSign[], currentValue: Uint8Array | Uint8Array[], index: number) => {
       const toSign = indexesToSign && indexesToSign.includes(index)
 
-      // if an element is an array, concatenate each mapped element as we want a flat (one-dimensional) array to send to the wallet
+      // if an element is an array, concatenate each mapped element as we want a flat (one-dimensional) array to sent to the wallet
       if (Array.isArray(currentValue)) {
         return [
           ...acc,
-          ...currentValue.map((value) =>
-            this.mapRawTransactionToARC0001Transaction(value, connectedAccounts, toSign)
-          )
+          ...currentValue.map((value) => ({
+            toSign,
+            transaction: value,
+          }))
         ]
       }
 
       return [
         ...acc,
-        this.mapRawTransactionToARC0001Transaction(currentValue, connectedAccounts, toSign)
+        {
+          toSign,
+          transaction: currentValue,
+        },
       ]
     }, [])
+    const transactions = await Promise.all(flatTransactions.map(({ toSign, transaction }) => this.mapRawTransactionToARC0001Transaction(transaction, connectedAccounts, toSign)))
     const result = await this.signTxns(transactions)
 
     // null values indicate transactions that were not signed by the provider, as defined in ARC-0001, see https://arc.algorand.foundation/ARCs/arc-0001#semantic-and-security-requirements

--- a/src/clients/kibisis/client.ts
+++ b/src/clients/kibisis/client.ts
@@ -481,7 +481,7 @@ class KibisisClient extends BaseClient {
     const transactions: ARC0001SignTxns[] = transactionsOrTransactionGroups.reduce<ARC0001SignTxns[]>((acc: ARC0001SignTxns[], currentValue: Uint8Array | Uint8Array[], index: number) => {
       const toSign = indexesToSign && indexesToSign.includes(index)
 
-      // if an element is an array, concatenate each mapped element
+      // if an element is an array, concatenate each mapped element as we want a flat (one-dimensional) array to send to the wallet
       if (Array.isArray(currentValue)) {
         return [
           ...acc,

--- a/src/clients/kibisis/client.ts
+++ b/src/clients/kibisis/client.ts
@@ -272,7 +272,11 @@ class KibisisClient extends BaseClient {
    * @returns {Promise<ARC0001SignTxns>} the transaction that is ready to be signed by the wallet.
    * @private
    */
-  private async mapRawTransactionToARC0001Transaction(rawTransaction: Uint8Array, connectedAccounts: string[], toSign?: boolean): Promise<ARC0001SignTxns> {
+  private async mapRawTransactionToARC0001Transaction(
+    rawTransaction: Uint8Array,
+    connectedAccounts: string[],
+    toSign?: boolean
+  ): Promise<ARC0001SignTxns> {
     const decodedTxn = this.algosdk.decodeObj(rawTransaction) as
       | DecodedTransaction
       | DecodedSignedTransaction
@@ -300,10 +304,7 @@ class KibisisClient extends BaseClient {
     }
 
     // if the sender is not authorized or the index has not been included in the to be signed indexes, instruct the provider not to sign by providing an empty signers array
-    if (
-      !connectedAccounts.includes(sender) ||
-      !toSign
-    ) {
+    if (!connectedAccounts.includes(sender) || !toSign) {
       return {
         txn,
         signers: [],
@@ -481,14 +482,18 @@ class KibisisClient extends BaseClient {
     // TODO: the below disable/ignore is necessary as the reduce function throws a TS error for union types (https://github.com/microsoft/TypeScript/issues/36390), however, these can be removed when typescript is updated to 5.2.2+, as the issue has been fixed
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    const transactions: ARC0001SignTxns[] = transactionsOrTransactionGroups.reduce<ARC0001SignTxns[]>((acc: ARC0001SignTxns[], currentValue: Uint8Array | Uint8Array[], index: number) => {
+    const transactions: ARC0001SignTxns[] = transactionsOrTransactionGroups.reduce<
+      ARC0001SignTxns[]
+    >((acc: ARC0001SignTxns[], currentValue: Uint8Array | Uint8Array[], index: number) => {
       const toSign = indexesToSign && indexesToSign.includes(index)
 
       // if an element is an array, concatenate each mapped element as we want a flat (one-dimensional) array to send to the wallet
       if (Array.isArray(currentValue)) {
         return [
           ...acc,
-          ...currentValue.map((value) => this.mapRawTransactionToARC0001Transaction(value, connectedAccounts, toSign))
+          ...currentValue.map((value) =>
+            this.mapRawTransactionToARC0001Transaction(value, connectedAccounts, toSign)
+          )
         ]
       }
 

--- a/src/clients/kibisis/types.ts
+++ b/src/clients/kibisis/types.ts
@@ -1,7 +1,7 @@
 import type algosdk from 'algosdk'
 import type { Metadata, Network } from '../../types'
 
-export interface Arc0001SignTxns {
+export interface ARC0001SignTxns {
   authAddr?: string
   multisig?: string
   signers?: string[]
@@ -9,7 +9,7 @@ export interface Arc0001SignTxns {
   txn: string
 }
 
-export interface Arc0027Account {
+export interface ARC0027Account {
   address: string
   name?: string
 }
@@ -79,7 +79,7 @@ export interface EnableParams {
 }
 
 export interface EnableResult {
-  accounts: Arc0027Account[]
+  accounts: ARC0027Account[]
   genesisHash: string
   genesisId: string
   providerId: string
@@ -100,7 +100,7 @@ export interface GetProvidersResult {
 
 export interface SignTxnsParams {
   providerId: string
-  txns: Arc0001SignTxns[]
+  txns: ARC0001SignTxns[]
 }
 
 export interface SignTxnsResult {

--- a/src/clients/kibisis/types.ts
+++ b/src/clients/kibisis/types.ts
@@ -37,6 +37,11 @@ export type ProviderMethods =
   | 'signBytes'
   | 'signTxns'
 
+export interface RawTransactionToSign {
+  toSign: boolean
+  transaction: Uint8Array
+}
+
 export interface SendRequestWithTimeoutOptions<Params> {
   method: ProviderMethods
   params: Params


### PR DESCRIPTION
### Description

> _Please explain the changes you made here_

The Kibisis client was not handling the case when groups of groups of transactions were being sent.

This fix attempts to rectify this by flattening the transactions before they are transmitted to the Kibisis wallet.

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
