### PR TITLE
fix(core): ensure correct `this` context in public callback methods

### DIFF
--- a/packages/use-wallet/src/wallets/base.ts
+++ b/packages/use-wallet/src/wallets/base.ts
@@ -42,12 +42,12 @@ export abstract class BaseWallet {
   public abstract disconnect(): Promise<void>
   public abstract resumeSession(): Promise<void>
 
-  public setActive(): void {
+  public setActive = (): void => {
     console.info(`[Wallet] Set active wallet: ${this.id}`)
     setActiveWallet(this.store, { walletId: this.id })
   }
 
-  public setActiveAccount(account: string): void {
+  public setActiveAccount = (account: string): void => {
     console.info(`[Wallet] Set active account: ${account}`)
     setActiveAccount(this.store, {
       walletId: this.id,

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -55,7 +55,7 @@ export class DeflyWallet extends BaseWallet {
     return client
   }
 
-  public async connect(): Promise<WalletAccount[]> {
+  public connect = async (): Promise<WalletAccount[]> => {
     console.info('[DeflyWallet] Connecting...')
     try {
       const client = this.client || (await this.initializeClient())
@@ -91,7 +91,7 @@ export class DeflyWallet extends BaseWallet {
     }
   }
 
-  public async disconnect(): Promise<void> {
+  public disconnect = async (): Promise<void> => {
     console.info('[DeflyWallet] Disconnecting...')
     try {
       await this.client?.disconnect()
@@ -101,7 +101,7 @@ export class DeflyWallet extends BaseWallet {
     }
   }
 
-  public async resumeSession(): Promise<void> {
+  public resumeSession = async (): Promise<void> => {
     try {
       const state = this.store.state
       const walletState = state.wallets[this.id]

--- a/packages/use-wallet/src/wallets/exodus.ts
+++ b/packages/use-wallet/src/wallets/exodus.ts
@@ -79,7 +79,7 @@ export class ExodusWallet extends BaseWallet {
     return client
   }
 
-  public async connect(): Promise<WalletAccount[]> {
+  public connect = async (): Promise<WalletAccount[]> => {
     console.info('[ExodusWallet] Connecting...')
     try {
       const client = this.client || (await this.initializeClient())
@@ -115,12 +115,12 @@ export class ExodusWallet extends BaseWallet {
     }
   }
 
-  public async disconnect(): Promise<void> {
+  public disconnect = async (): Promise<void> => {
     console.info('[ExodusWallet] Disconnecting...')
     this.onDisconnect()
   }
 
-  public async resumeSession(): Promise<void> {
+  public resumeSession = async (): Promise<void> => {
     try {
       const state = this.store.state
       const walletState = state.wallets[this.id]

--- a/packages/use-wallet/src/wallets/kibisis.ts
+++ b/packages/use-wallet/src/wallets/kibisis.ts
@@ -388,7 +388,7 @@ export class KibisisWallet extends BaseWallet {
     }
   }
 
-  public async connect(): Promise<WalletAccount[]> {
+  public connect = async (): Promise<WalletAccount[]> => {
     console.info('[KibisisWallet] Connecting...')
     try {
       await this.getSupportedMethods()
@@ -417,12 +417,12 @@ export class KibisisWallet extends BaseWallet {
     }
   }
 
-  public async disconnect(): Promise<void> {
+  public disconnect = async (): Promise<void> => {
     console.info('[KibisisWallet] Disconnecting...')
     this.onDisconnect()
   }
 
-  public resumeSession(): Promise<void> {
+  public resumeSession = (): Promise<void> => {
     return Promise.resolve()
   }
 

--- a/packages/use-wallet/src/wallets/kmd.ts
+++ b/packages/use-wallet/src/wallets/kmd.ts
@@ -94,7 +94,7 @@ export class KmdWallet extends BaseWallet {
     return client
   }
 
-  public async connect(): Promise<WalletAccount[]> {
+  public connect = async (): Promise<WalletAccount[]> => {
     console.info('[KmdWallet] Connecting...')
     try {
       if (!this.client) {
@@ -135,7 +135,7 @@ export class KmdWallet extends BaseWallet {
     }
   }
 
-  public async disconnect(): Promise<void> {
+  public disconnect = async (): Promise<void> => {
     console.info('[KmdWallet] Disconnecting...')
     this.onDisconnect()
   }

--- a/packages/use-wallet/src/wallets/lute.ts
+++ b/packages/use-wallet/src/wallets/lute.ts
@@ -71,7 +71,7 @@ export class LuteWallet extends BaseWallet {
     return genesisId
   }
 
-  public async connect(): Promise<WalletAccount[]> {
+  public connect = async (): Promise<WalletAccount[]> => {
     console.info('[LuteWallet] Connecting...')
     try {
       const client = this.client || (await this.initializeClient())
@@ -104,12 +104,12 @@ export class LuteWallet extends BaseWallet {
     }
   }
 
-  public async disconnect(): Promise<void> {
+  public disconnect = async (): Promise<void> => {
     console.info('[LuteWallet] Disconnecting...')
     this.onDisconnect()
   }
 
-  public async resumeSession(): Promise<void> {
+  public resumeSession = async (): Promise<void> => {
     try {
       const state = this.store.state
       const walletState = state.wallets[this.id]

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -49,7 +49,7 @@ export class MnemonicWallet extends BaseWallet {
     return account
   }
 
-  public async connect(): Promise<WalletAccount[]> {
+  public connect = async (): Promise<WalletAccount[]> => {
     console.info('[MnemonicWallet] Connecting...')
     try {
       const account = this.initializeAccount()
@@ -74,7 +74,7 @@ export class MnemonicWallet extends BaseWallet {
     }
   }
 
-  public async disconnect(): Promise<void> {
+  public disconnect = async (): Promise<void> => {
     console.info('[MnemonicWallet] Disconnecting...')
     try {
       this.account = null
@@ -84,7 +84,7 @@ export class MnemonicWallet extends BaseWallet {
     }
   }
 
-  public async resumeSession(): Promise<void> {
+  public resumeSession = async (): Promise<void> => {
     const state = this.store.state
     const walletState = state.wallets[this.id]
 

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -56,7 +56,7 @@ export class PeraWallet extends BaseWallet {
     return client
   }
 
-  public async connect(): Promise<WalletAccount[]> {
+  public connect = async (): Promise<WalletAccount[]> => {
     console.info('[PeraWallet] Connecting...')
     try {
       const client = this.client || (await this.initializeClient())
@@ -92,7 +92,7 @@ export class PeraWallet extends BaseWallet {
     }
   }
 
-  public async disconnect(): Promise<void> {
+  public disconnect = async (): Promise<void> => {
     console.info('[PeraWallet] Disconnecting...')
     try {
       await this.client?.disconnect()
@@ -102,7 +102,7 @@ export class PeraWallet extends BaseWallet {
     }
   }
 
-  public async resumeSession(): Promise<void> {
+  public resumeSession = async (): Promise<void> => {
     try {
       const state = this.store.state
       const walletState = state.wallets[this.id]

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -167,7 +167,7 @@ export class WalletConnect extends BaseWallet {
     return walletAccounts
   }
 
-  public async connect(): Promise<WalletAccount[]> {
+  public connect = async (): Promise<WalletAccount[]> => {
     console.info('[WalletConnect] Connecting...')
     try {
       const client = this.client || (await this.initializeClient())
@@ -201,7 +201,7 @@ export class WalletConnect extends BaseWallet {
     }
   }
 
-  public async disconnect(): Promise<void> {
+  public disconnect = async (): Promise<void> => {
     console.info('[WalletConnect] Disconnecting...')
     try {
       if (this.client && this.session) {
@@ -216,7 +216,7 @@ export class WalletConnect extends BaseWallet {
     }
   }
 
-  public async resumeSession(): Promise<void> {
+  public resumeSession = async (): Promise<void> => {
     try {
       const state = this.store.state
       const walletState = state.wallets[this.id]


### PR DESCRIPTION
This converts `BaseWallet` public methods used as callbacks to arrow functions to preserve the `this` context across different usage scenarios.

In a React app passing `activeWallet.setActiveAccount` to a component as a prop, the wallet's `this.store` property was undefined. Converting `setActiveAccount` to an arrow function, along with any other methods being called in various (unpredictable) contexts, ensures that they operate with the intended scope.