### PR TITLE
fix(core): perform byte array <-> b64 conversions w/ native JS

### DIFF
--- a/packages/use-wallet/package.json
+++ b/packages/use-wallet/package.json
@@ -39,8 +39,7 @@
   "dependencies": {
     "@tanstack/store": "^0.3.1",
     "@walletconnect/utils": "^2.10.2",
-    "algosdk": "^2.7.0",
-    "buffer": "^6.0.3"
+    "algosdk": "^2.7.0"
   },
   "devDependencies": {
     "@blockshake/defly-connect": "^1.1.6",

--- a/packages/use-wallet/src/utils.ts
+++ b/packages/use-wallet/src/utils.ts
@@ -40,6 +40,30 @@ export function compareAccounts(accounts: WalletAccount[], compareTo: WalletAcco
   return true
 }
 
+export function base64ToByteArray(blob: string): Uint8Array {
+  return stringToByteArray(atob(blob))
+}
+
+export function byteArrayToBase64(array: Uint8Array): string {
+  return btoa(byteArrayToString(array))
+}
+
+export function stringToByteArray(str: string): Uint8Array {
+  const array = new Uint8Array(str.length)
+  for (let i = 0; i < str.length; i++) {
+    array[i] = str.charCodeAt(i)
+  }
+  return array
+}
+
+export function byteArrayToString(array: Uint8Array): string {
+  let result = ''
+  for (let i = 0; i < array.length; i++) {
+    result += String.fromCharCode(array[i])
+  }
+  return result
+}
+
 export function isTransaction(
   item: algosdk.Transaction | algosdk.Transaction[] | Uint8Array | Uint8Array[]
 ): item is algosdk.Transaction | algosdk.Transaction[] {
@@ -122,7 +146,7 @@ export function mergeSignedTxnsWithGroup(
       const signedByUser = signedTxns.shift()
       signedByUser && acc.push(signedByUser)
     } else if (returnGroup) {
-      acc.push(txnGroup[i]!)
+      acc.push(txnGroup[i])
     }
     return acc
   }, [])
@@ -184,7 +208,7 @@ export function generateUuid(): string {
 
     return (
       valueAsNumber ^
-      (window.crypto.getRandomValues(new Uint8Array(1))[0]! & (15 >> (valueAsNumber / 4)))
+      (window.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (valueAsNumber / 4)))
     ).toString(16)
   })
 }

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -70,7 +70,7 @@ export class DeflyWallet extends BaseWallet {
         address
       }))
 
-      const activeAccount = walletAccounts[0]!
+      const activeAccount = walletAccounts[0]
 
       addWallet(this.store, {
         walletId: this.id,
@@ -163,7 +163,7 @@ export class DeflyWallet extends BaseWallet {
       const isSigned = isSignedTxnObject(txnObject)
       const shouldSign = shouldSignTxnObject(txnObject, this.addresses, indexesToSign, idx)
 
-      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]!
+      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)

--- a/packages/use-wallet/src/wallets/exodus.ts
+++ b/packages/use-wallet/src/wallets/exodus.ts
@@ -1,6 +1,8 @@
 import algosdk from 'algosdk'
 import { addWallet, type State } from 'src/store'
 import {
+  base64ToByteArray,
+  byteArrayToBase64,
   isSignedTxnObject,
   mergeSignedTxnsWithGroup,
   normalizeTxnGroup,
@@ -170,7 +172,7 @@ export class ExodusWallet extends BaseWallet {
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
-      const txnBase64 = Buffer.from(txn.toByte()).toString('base64')
+      const txnBase64 = byteArrayToBase64(txn.toByte())
 
       if (shouldSign) {
         txnsToSign.push({ txn: txnBase64 })
@@ -187,7 +189,7 @@ export class ExodusWallet extends BaseWallet {
     const signedTxnsBase64 = signTxnsResult.filter(Boolean) as string[]
 
     // Convert base64 signed transactions to msgpack
-    const signedTxns = signedTxnsBase64.map((txn) => new Uint8Array(Buffer.from(txn, 'base64')))
+    const signedTxns = signedTxnsBase64.map((txn) => base64ToByteArray(txn))
 
     // Merge signed transactions back into original group
     const txnGroupSigned = mergeSignedTxnsWithGroup(
@@ -209,7 +211,7 @@ export class ExodusWallet extends BaseWallet {
     }
 
     const txnsToSign = txnGroup.reduce<WalletTransaction[]>((acc, txn, idx) => {
-      const txnBase64 = Buffer.from(txn.toByte()).toString('base64')
+      const txnBase64 = byteArrayToBase64(txn.toByte())
 
       if (indexesToSign.includes(idx)) {
         acc.push({ txn: txnBase64 })
@@ -222,7 +224,7 @@ export class ExodusWallet extends BaseWallet {
     const signTxnsResult = await this.client.signTxns(txnsToSign)
     const signedTxnsBase64 = signTxnsResult.filter(Boolean) as string[]
 
-    const signedTxns = signedTxnsBase64.map((txn) => new Uint8Array(Buffer.from(txn, 'base64')))
+    const signedTxns = signedTxnsBase64.map((txn) => base64ToByteArray(txn))
     return signedTxns
   }
 }

--- a/packages/use-wallet/src/wallets/exodus.ts
+++ b/packages/use-wallet/src/wallets/exodus.ts
@@ -94,7 +94,7 @@ export class ExodusWallet extends BaseWallet {
         address
       }))
 
-      const activeAccount = walletAccounts[0]!
+      const activeAccount = walletAccounts[0]
 
       addWallet(this.store, {
         walletId: this.id,
@@ -165,7 +165,7 @@ export class ExodusWallet extends BaseWallet {
       const isSigned = isSignedTxnObject(txnObject)
       const shouldSign = shouldSignTxnObject(txnObject, this.addresses, indexesToSign, idx)
 
-      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]!
+      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)

--- a/packages/use-wallet/src/wallets/kibisis.ts
+++ b/packages/use-wallet/src/wallets/kibisis.ts
@@ -400,7 +400,7 @@ export class KibisisWallet extends BaseWallet {
         address
       }))
 
-      const activeAccount = walletAccounts[0]!
+      const activeAccount = walletAccounts[0]
 
       addWallet(this.store, {
         walletId: this.id,
@@ -449,7 +449,7 @@ export class KibisisWallet extends BaseWallet {
         const isSigned = isSignedTxnObject(txnObject)
         const shouldSign = shouldSignTxnObject(txnObject, this.addresses, indexesToSign, idx)
 
-        const txnBuffer: Uint8Array = msgpackTxnGroup[idx]!
+        const txnBuffer: Uint8Array = msgpackTxnGroup[idx]
         const txn: algosdk.Transaction = isSigned
           ? algosdk.decodeSignedTransaction(txnBuffer).txn
           : algosdk.decodeUnsignedTransaction(txnBuffer)

--- a/packages/use-wallet/src/wallets/kibisis.ts
+++ b/packages/use-wallet/src/wallets/kibisis.ts
@@ -1,6 +1,8 @@
 import algosdk from 'algosdk'
 import { addWallet, type State } from 'src/store'
 import {
+  base64ToByteArray,
+  byteArrayToBase64,
   generateUuid,
   isSignedTxnObject,
   mergeSignedTxnsWithGroup,
@@ -454,7 +456,7 @@ export class KibisisWallet extends BaseWallet {
           ? algosdk.decodeSignedTransaction(txnBuffer).txn
           : algosdk.decodeUnsignedTransaction(txnBuffer)
 
-        const txnBase64 = Buffer.from(txn.toByte()).toString('base64')
+        const txnBase64 = byteArrayToBase64(txn.toByte())
 
         if (shouldSign) {
           txnsToSign.push({ txn: txnBase64 })
@@ -471,7 +473,7 @@ export class KibisisWallet extends BaseWallet {
       const signedTxnsBase64 = signTxnsResult.filter(Boolean) as string[]
 
       // Convert base64 signed transactions to msgpack
-      const signedTxns = signedTxnsBase64.map((txn) => new Uint8Array(Buffer.from(txn, 'base64')))
+      const signedTxns = signedTxnsBase64.map((txn) => base64ToByteArray(txn))
 
       // Merge signed transactions back into original group
       const txnGroupSigned = mergeSignedTxnsWithGroup(
@@ -497,7 +499,7 @@ export class KibisisWallet extends BaseWallet {
   ): Promise<Uint8Array[]> => {
     try {
       const txnsToSign = txnGroup.reduce<Arc0001SignTxns[]>((acc, txn, idx) => {
-        const txnBase64 = Buffer.from(txn.toByte()).toString('base64')
+        const txnBase64 = byteArrayToBase64(txn.toByte())
 
         if (indexesToSign.includes(idx)) {
           acc.push({ txn: txnBase64 })
@@ -510,7 +512,7 @@ export class KibisisWallet extends BaseWallet {
       const signTxnsResult = await this.signTxns(txnsToSign)
       const signedTxnsBase64 = signTxnsResult.filter(Boolean) as string[]
 
-      const signedTxns = signedTxnsBase64.map((txn) => new Uint8Array(Buffer.from(txn, 'base64')))
+      const signedTxns = signedTxnsBase64.map((txn) => base64ToByteArray(txn))
       return signedTxns
     } catch (error: any) {
       console.error(

--- a/packages/use-wallet/src/wallets/kmd.ts
+++ b/packages/use-wallet/src/wallets/kmd.ts
@@ -116,7 +116,7 @@ export class KmdWallet extends BaseWallet {
         address
       }))
 
-      const activeAccount = walletAccounts[0]!
+      const activeAccount = walletAccounts[0]
 
       addWallet(this.store, {
         walletId: this.id,
@@ -186,7 +186,7 @@ export class KmdWallet extends BaseWallet {
       const isSigned = isSignedTxnObject(txnObject)
       const shouldSign = shouldSignTxnObject(txnObject, this.addresses, indexesToSign, idx)
 
-      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]!
+      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)

--- a/packages/use-wallet/src/wallets/lute.ts
+++ b/packages/use-wallet/src/wallets/lute.ts
@@ -1,6 +1,7 @@
 import algosdk from 'algosdk'
 import { addWallet, type State } from 'src/store'
 import {
+  byteArrayToBase64,
   isSignedTxnObject,
   mergeSignedTxnsWithGroup,
   normalizeTxnGroup,
@@ -156,7 +157,7 @@ export class LuteWallet extends BaseWallet {
           ? algosdk.decodeSignedTransaction(txnBuffer).txn
           : algosdk.decodeUnsignedTransaction(txnBuffer)
 
-        const txnBase64 = Buffer.from(txn.toByte()).toString('base64')
+        const txnBase64 = byteArrayToBase64(txn.toByte())
 
         if (shouldSign) {
           txnsToSign.push({ txn: txnBase64 })
@@ -200,7 +201,7 @@ export class LuteWallet extends BaseWallet {
       }
 
       const txnsToSign = txnGroup.reduce<WalletTransaction[]>((acc, txn, idx) => {
-        const txnBase64 = Buffer.from(txn.toByte()).toString('base64')
+        const txnBase64 = byteArrayToBase64(txn.toByte())
 
         if (indexesToSign.includes(idx)) {
           acc.push({ txn: txnBase64 })

--- a/packages/use-wallet/src/wallets/lute.ts
+++ b/packages/use-wallet/src/wallets/lute.ts
@@ -87,7 +87,7 @@ export class LuteWallet extends BaseWallet {
         address
       }))
 
-      const activeAccount = walletAccounts[0]!
+      const activeAccount = walletAccounts[0]
 
       addWallet(this.store, {
         walletId: this.id,
@@ -151,7 +151,7 @@ export class LuteWallet extends BaseWallet {
         const isSigned = isSignedTxnObject(txnObject)
         const shouldSign = shouldSignTxnObject(txnObject, this.addresses, indexesToSign, idx)
 
-        const txnBuffer: Uint8Array = msgpackTxnGroup[idx]!
+        const txnBuffer: Uint8Array = msgpackTxnGroup[idx]
         const txn: algosdk.Transaction = isSigned
           ? algosdk.decodeSignedTransaction(txnBuffer).txn
           : algosdk.decodeUnsignedTransaction(txnBuffer)

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -127,7 +127,7 @@ export class MnemonicWallet extends BaseWallet {
         const signedTxn = txn.signTxn(this.account!.sk)
         txnGroupSigned.push(signedTxn)
       } else if (returnGroup) {
-        txnGroupSigned.push(msgpackTxnGroup[idx]!)
+        txnGroupSigned.push(msgpackTxnGroup[idx])
       }
     })
 

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -71,7 +71,7 @@ export class PeraWallet extends BaseWallet {
         address
       }))
 
-      const activeAccount = walletAccounts[0]!
+      const activeAccount = walletAccounts[0]
 
       addWallet(this.store, {
         walletId: this.id,
@@ -164,7 +164,7 @@ export class PeraWallet extends BaseWallet {
       const isSigned = isSignedTxnObject(txnObject)
       const shouldSign = shouldSignTxnObject(txnObject, this.addresses, indexesToSign, idx)
 
-      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]!
+      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -3,6 +3,8 @@ import algosdk from 'algosdk'
 import { NetworkId, caipChainId } from 'src/network'
 import { addWallet, setAccounts, type State } from 'src/store'
 import {
+  base64ToByteArray,
+  byteArrayToBase64,
   compareAccounts,
   formatJsonRpcRequest,
   isSignedTxnObject,
@@ -276,7 +278,7 @@ export class WalletConnect extends BaseWallet {
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
-      const txnBase64 = Buffer.from(txn.toByte()).toString('base64')
+      const txnBase64 = byteArrayToBase64(txn.toByte())
 
       if (shouldSign) {
         txnsToSign.push({ txn: txnBase64 })
@@ -300,7 +302,7 @@ export class WalletConnect extends BaseWallet {
     const signedTxnsBase64 = signTxnsResult.filter(Boolean) as string[]
 
     // Convert base64 signed transactions to msgpack
-    const signedTxns = signedTxnsBase64.map((txn) => new Uint8Array(Buffer.from(txn, 'base64')))
+    const signedTxns = signedTxnsBase64.map((txn) => base64ToByteArray(txn))
 
     // Merge signed transactions back into original group
     const txnGroupSigned = mergeSignedTxnsWithGroup(
@@ -328,7 +330,7 @@ export class WalletConnect extends BaseWallet {
     }
 
     const txnsToSign = txnGroup.reduce<WalletTransaction[]>((acc, txn, idx) => {
-      const txnBase64 = Buffer.from(txn.toByte()).toString('base64')
+      const txnBase64 = byteArrayToBase64(txn.toByte())
 
       if (indexesToSign.includes(idx)) {
         acc.push({ txn: txnBase64 })
@@ -352,7 +354,7 @@ export class WalletConnect extends BaseWallet {
     const signedTxnsBase64 = signTxnsResult.filter(Boolean) as string[]
 
     // Convert base64 signed transactions to msgpack
-    const signedTxns = signedTxnsBase64.map((txn) => new Uint8Array(Buffer.from(txn, 'base64')))
+    const signedTxns = signedTxnsBase64.map((txn) => base64ToByteArray(txn))
 
     return signedTxns
   }

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -148,7 +148,7 @@ export class WalletConnect extends BaseWallet {
         walletId: this.id,
         wallet: {
           accounts: walletAccounts,
-          activeAccount: walletAccounts[0]!
+          activeAccount: walletAccounts[0]
         }
       })
     } else {
@@ -232,7 +232,7 @@ export class WalletConnect extends BaseWallet {
 
       if (client.session.length) {
         const lastKeyIndex = client.session.keys.length - 1
-        const restoredSession = client.session.get(client.session.keys[lastKeyIndex]!)
+        const restoredSession = client.session.get(client.session.keys[lastKeyIndex])
         this.onSessionConnected(restoredSession)
       }
     } catch (error: any) {
@@ -271,7 +271,7 @@ export class WalletConnect extends BaseWallet {
       const isSigned = isSignedTxnObject(txnObject)
       const shouldSign = shouldSignTxnObject(txnObject, this.addresses, indexesToSign, idx)
 
-      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]!
+      const txnBuffer: Uint8Array = msgpackTxnGroup[idx]
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)

--- a/packages/use-wallet/tsconfig.json
+++ b/packages/use-wallet/tsconfig.json
@@ -8,7 +8,6 @@
     "moduleResolution": "node",
     "allowImportingTsExtensions": true,
     "allowSyntheticDefaultImports": true,
-    "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
     "noEmit": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,9 +298,6 @@ importers:
       algosdk:
         specifier: ^2.7.0
         version: 2.7.0
-      buffer:
-        specifier: ^6.0.3
-        version: 6.0.3
     devDependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6


### PR DESCRIPTION
Instead of requiring consuming applications to use the Node.js `Buffer` API polyfill to convert `Uint8Array` byte arrays to and from base 64 strings, wallet clients will now use native JavaScript methods `atob` and `btoa`.

Credit to PureStake, as utility functions for AlgoSigner were starting points for the functions now being used here: https://github.com/PureStake/algosigner/blob/master/packages/common/src/encoding.ts

### Other Changes

I've also updated the core library's tsconfig to no longer enforce `noUncheckedIndexedAccess`, which forces me to use non-null assertion operators to access numbered array elements. This trade-off for the benefit it provides by strictly enforcing declared object properties doesn't seem worth it. I would've had to use it (again) in the `byteArrayToString` function. See https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess