### PR TITLE
fix(ui): use correct `this` context in setActiveNetwork

### DIFF
--- a/packages/use-wallet/src/manager.ts
+++ b/packages/use-wallet/src/manager.ts
@@ -206,7 +206,7 @@ export class WalletManager {
     return this.algodClient
   }
 
-  public setActiveNetwork(networkId: NetworkId): void {
+  public setActiveNetwork = (networkId: NetworkId): void => {
     setActiveNetwork(this.store, { networkId })
     this.algodClient = this.createAlgodClient(this.networkConfig[networkId])
   }


### PR DESCRIPTION
The WalletManager's `setActiveNetwork` method was missed when I was changing wallet client methods to arrow functions in https://github.com/TxnLab/use-wallet/pull/152

This (ha!) update ensures the correct `this` context is used when `setActiveNetwork` is passed as a callback to the framework adapters.