### PR TITLE
fix(lute): fix signedTxns reconstruction

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "jest": "^29.1.2",
     "jest-canvas-mock": "^2.5.0",
     "jest-environment-jsdom": "^29.3.1",
-    "lute-connect": "^1.1.3",
+    "lute-connect": "^1.2.0",
     "magic-sdk": "^22.0.0",
     "postcss": "^8.4.17",
     "prettier": "^3.2.4",
@@ -112,7 +112,7 @@
     "@perawallet/connect": "^1.2.1",
     "@randlabs/myalgo-connect": "^1.4.2",
     "algosdk": "^2.1.0",
-    "lute-connect": "^1.1.3",
+    "lute-connect": "^1.2.0",
     "magic-sdk": "^22.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/clients/lute/client.ts
+++ b/src/clients/lute/client.ts
@@ -171,7 +171,7 @@ class LuteClient extends BaseClient {
 
     const signedTxns = transactions.reduce<Uint8Array[]>((acc, txn, i) => {
       if (signedIndexes.includes(i)) {
-        const signedByUser = result.shift()
+        const signedByUser = result[i]
         signedByUser && acc.push(signedByUser)
       } else if (returnGroup) {
         acc.push(txn)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11395,10 +11395,10 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
-lute-connect@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/lute-connect/-/lute-connect-1.1.3.tgz#0cdc7169aae0e6189b05d84240fdd59e02a06457"
-  integrity sha512-HMYUDNHx9bokZjSZ1BdvYqGr+oi0JpcxES4xYZhpq3s6O87ZzN/zwJMdWnc2/7g349k3433u8Z4ZiMLTGimt4w==
+lute-connect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lute-connect/-/lute-connect-1.2.0.tgz#78d2bc6d302f073a5e61672f6df2309e516d057b"
+  integrity sha512-irbecoBxkNmSVe12p+leZkksS/7qbHI2etvfxw60t4Lcjmn0XX80GMi+iInhFFRhwg7rxU378P2h6GO8AU+9AQ==
 
 lz-string@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
### Description

There was a bug in the construction of `signedTxns` where it was expecting `result` to only contain txns that the wallet signed. Lute's response has the same length as the request, so `shift()` was not appropriate - a simple index on `result` will do.

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
