### PR TITLE
feat: add Custom provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,77 @@ The following examples demonstrate how to use the `use-wallet` v3 library in var
 
 - [Vanilla TypeScript (Vite)](https://github.com/TxnLab/use-wallet/tree/v3/examples/vanilla-ts)
 
+## Custom Provider
+
+If you want to integrate a wallet provider that is not included in the library, or if your application requires any additional custom interactions, you can create a custom provider.
+
+1. Create a new class that implements the `CustomProvider` type
+
+```ts
+import { CustomProvider, WalletAccount } from '@txnlab/use-wallet' // Or any framework adapter
+
+class ExampleProvider implements CustomProvider {
+  /* Required */
+  async connect(args?: Record<string, any>): Promise<WalletAccount[]> {
+    // Must return an array of connected accounts
+    // Optional `args` parameter can be used to pass any additional configuration
+  }
+
+  /* Optional */
+  async disconnect(): Promise<void> {
+    // Disconnect from the wallet provider, if necessary
+  }
+
+  /* Optional */
+  async resumeSession(): Promise<WalletAccount[] | void> {
+    // Reconnect to the wallet provider when the app mounts, if necessary
+    // If an array of accounts is returned, they are checked against the stored accounts
+    // The stored accounts are updated if they differ
+  }
+
+  /* The two signing methods are optional, but you'll want to define at least one! */
+
+  async signTransactions(
+    txnGroup: algosdk.Transaction[] | algosdk.Transaction[][] | Uint8Array[] | Uint8Array[][],
+    indexesToSign?: number[],
+    returnGroup?: boolean
+  ): Promise<Uint8Array[]> {
+    // Sign transactions with the wallet
+    // Return signed transactions only or the original group if `returnGroup` is true
+  }
+
+  async transactionSigner(
+    txnGroup: algosdk.Transaction[],
+    indexesToSign: number[]
+  ): Promise<Uint8Array[]> {
+    // Sign an array of transaction objects with the wallet
+    // Return signed transactions only
+    // Compatible with algosdk's Atomic Transaction Composer
+  }
+}
+```
+
+2. Add the provider to the `WalletManager` configuration
+
+```ts
+const walletManager = new WalletManager({
+  wallets: [
+    // Include the custom provider in the wallets array
+    {
+      id: WalletId.CUSTOM,
+      options: {
+        provider: new ExampleProvider()
+      },
+      metadata: {
+        name: 'Example Wallet'
+        icon: 'data:image/svg+xml;base64,...'
+      }
+    }
+  ],
+  network: NetworkId.TESTNET
+})
+```
+
 ## WalletManager API
 
 The following API is exposed via the `WalletManager` class instance. The framework adapters abstract the `WalletManager` class and expose a similar API via the `useWallet` function.

--- a/packages/use-wallet/src/__tests__/wallets/custom.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/custom.test.ts
@@ -87,6 +87,23 @@ describe('CustomWallet', () => {
     mockInitialState = null
   })
 
+  describe('constructor', () => {
+    it('should throw an error if provider is not defined', () => {
+      expect(
+        () =>
+          new CustomWallet({
+            id: WalletId.CUSTOM,
+            // @ts-expect-error missing provider
+            options: {},
+            metadata: {},
+            getAlgodClient: {} as any,
+            store,
+            subscribe: mockSubscribe
+          })
+      ).toThrowError('[Custom] Missing required option: provider')
+    })
+  })
+
   describe('connect', () => {
     it('should return accounts and update store', async () => {
       vi.mocked(mockProvider.connect).mockResolvedValueOnce([account1, account2])

--- a/packages/use-wallet/src/__tests__/wallets/custom.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/custom.test.ts
@@ -1,0 +1,255 @@
+import { Store } from '@tanstack/store'
+import algosdk from 'algosdk'
+import { StorageAdapter } from 'src/storage'
+import { LOCAL_STORAGE_KEY, State, defaultState } from 'src/store'
+import { CustomProvider, CustomWallet, WalletId } from 'src/wallets'
+
+// Mock storage adapter
+vi.mock('src/storage', () => ({
+  StorageAdapter: {
+    getItem: vi.fn(),
+    setItem: vi.fn()
+  }
+}))
+
+// Spy/suppress console output
+vi.spyOn(console, 'info').mockImplementation(() => {})
+vi.spyOn(console, 'warn').mockImplementation(() => {})
+vi.spyOn(console, 'groupCollapsed').mockImplementation(() => {})
+
+// Mock custom provider
+class MockProvider implements CustomProvider {
+  constructor() {}
+  connect = vi.fn()
+  disconnect = vi.fn()
+  resumeSession = vi.fn()
+  signTransactions = vi.fn()
+  transactionSigner = vi.fn()
+}
+
+const mockProvider = new MockProvider()
+
+describe('CustomWallet', () => {
+  let wallet: CustomWallet
+  let store: Store<State>
+  let mockInitialState: State | null = null
+
+  const account1 = {
+    name: 'Account 1',
+    address: 'mockAddress1'
+  }
+  const account2 = {
+    name: 'Account 2',
+    address: 'mockAddress2'
+  }
+
+  const mockSubscribe: (callback: (state: State) => void) => () => void = vi.fn(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (callback: (state: State) => void) => {
+      return () => console.log('unsubscribe')
+    }
+  )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(StorageAdapter.getItem).mockImplementation((key: string) => {
+      if (key === LOCAL_STORAGE_KEY && mockInitialState !== null) {
+        return JSON.stringify(mockInitialState)
+      }
+      return null
+    })
+
+    vi.mocked(StorageAdapter.setItem).mockImplementation((key: string, value: string) => {
+      if (key === LOCAL_STORAGE_KEY) {
+        mockInitialState = JSON.parse(value)
+      }
+    })
+
+    store = new Store<State>(defaultState)
+    wallet = new CustomWallet({
+      id: WalletId.CUSTOM,
+      options: {
+        provider: mockProvider
+      },
+      metadata: {
+        name: 'Custom Provider',
+        icon: 'mock-icon'
+      },
+      getAlgodClient: {} as any,
+      store,
+      subscribe: mockSubscribe
+    })
+  })
+
+  afterEach(async () => {
+    await wallet.disconnect()
+    mockInitialState = null
+  })
+
+  describe('connect', () => {
+    it('should return accounts and update store', async () => {
+      vi.mocked(mockProvider.connect).mockResolvedValueOnce([account1, account2])
+
+      const accounts = await wallet.connect()
+
+      expect(accounts).toEqual([account1, account2])
+      expect(mockProvider.connect).toHaveBeenCalled()
+      expect(mockProvider.connect).toHaveBeenCalledWith(undefined)
+      expect(wallet.isConnected).toBe(true)
+      expect(store.state.wallets[WalletId.CUSTOM]).toEqual({
+        accounts: [account1, account2],
+        activeAccount: account1
+      })
+    })
+
+    it('should throw an error if no accounts are found', async () => {
+      vi.mocked(mockProvider.connect).mockResolvedValueOnce([])
+
+      await expect(wallet.connect()).rejects.toThrowError('No accounts found!')
+      expect(wallet.isConnected).toBe(false)
+    })
+
+    it('should re-throw an error if thrown by provider', async () => {
+      vi.mocked(mockProvider.connect).mockRejectedValueOnce(new Error('mock error'))
+
+      await expect(wallet.connect()).rejects.toThrowError('mock error')
+      expect(wallet.isConnected).toBe(false)
+    })
+  })
+
+  describe('disconnect', () => {
+    it('should call provider.disconnect and update store', async () => {
+      vi.mocked(mockProvider.connect).mockResolvedValueOnce([account1])
+
+      await wallet.connect()
+      await wallet.disconnect()
+
+      expect(mockProvider.disconnect).toHaveBeenCalled()
+      expect(store.state.wallets[WalletId.CUSTOM]).toBeUndefined()
+      expect(wallet.isConnected).toBe(false)
+    })
+  })
+
+  describe('resumeSession', () => {
+    it('should do nothing if no session is found', async () => {
+      await wallet.resumeSession()
+
+      expect(mockProvider.resumeSession).not.toHaveBeenCalled()
+      expect(wallet.isConnected).toBe(false)
+    })
+
+    it('should call provider.resumeSession if a session is found', async () => {
+      store = new Store<State>({
+        ...defaultState,
+        wallets: {
+          [WalletId.CUSTOM]: {
+            accounts: [account1],
+            activeAccount: account1
+          }
+        }
+      })
+
+      wallet = new CustomWallet({
+        id: WalletId.CUSTOM,
+        options: {
+          provider: mockProvider
+        },
+        metadata: {
+          name: 'Custom Provider',
+          icon: 'mock-icon'
+        },
+        getAlgodClient: {} as any,
+        store,
+        subscribe: mockSubscribe
+      })
+
+      await wallet.resumeSession()
+
+      expect(mockProvider.resumeSession).toHaveBeenCalled()
+      expect(wallet.isConnected).toBe(true)
+    })
+
+    it('should update the store if provider.resumeSession returns different account(s)', async () => {
+      store = new Store<State>({
+        ...defaultState,
+        wallets: {
+          [WalletId.CUSTOM]: {
+            accounts: [account1],
+            activeAccount: account1
+          }
+        }
+      })
+
+      wallet = new CustomWallet({
+        id: WalletId.CUSTOM,
+        options: {
+          provider: mockProvider
+        },
+        metadata: {
+          name: 'Custom Provider',
+          icon: 'mock-icon'
+        },
+        getAlgodClient: {} as any,
+        store,
+        subscribe: mockSubscribe
+      })
+
+      vi.mocked(mockProvider.resumeSession).mockResolvedValueOnce([account2, account1])
+
+      await wallet.resumeSession()
+
+      expect(store.state.wallets[WalletId.CUSTOM]).toEqual({
+        accounts: [account2, account1],
+        activeAccount: account1
+      })
+      expect(wallet.isConnected).toBe(true)
+    })
+  })
+
+  describe('signTransactions', () => {
+    it('should call provider.signTransactions', async () => {
+      const txn = new algosdk.Transaction({
+        from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+        to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+        amount: 1000,
+        fee: 10,
+        firstRound: 51,
+        lastRound: 61,
+        genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
+        genesisID: 'mainnet-v1.0'
+      })
+
+      const txnGroup = [txn]
+      const indexesToSign = [0]
+
+      await wallet.signTransactions(txnGroup, indexesToSign)
+
+      expect(mockProvider.signTransactions).toHaveBeenCalled()
+      expect(mockProvider.signTransactions).toHaveBeenCalledWith(txnGroup, indexesToSign, true)
+    })
+  })
+
+  describe('transactionSigner', () => {
+    it('should call provider.transactionSigner', async () => {
+      const txn = new algosdk.Transaction({
+        from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+        to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+        amount: 1000,
+        fee: 10,
+        firstRound: 51,
+        lastRound: 61,
+        genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
+        genesisID: 'mainnet-v1.0'
+      })
+
+      const txnGroup = [txn]
+      const indexesToSign = [0]
+
+      await wallet.transactionSigner(txnGroup, indexesToSign)
+
+      expect(mockProvider.transactionSigner).toHaveBeenCalled()
+      expect(mockProvider.transactionSigner).toHaveBeenCalledWith(txnGroup, indexesToSign)
+    })
+  })
+})

--- a/packages/use-wallet/src/utils.ts
+++ b/packages/use-wallet/src/utils.ts
@@ -1,5 +1,6 @@
 import algosdk from 'algosdk'
 import { WalletId, type JsonRpcRequest, type WalletAccount, type WalletMap } from './wallets/types'
+import { CustomWallet } from './wallets/custom'
 import { DeflyWallet } from './wallets/defly'
 import { ExodusWallet } from './wallets/exodus'
 import { KibisisWallet } from './wallets/kibisis'
@@ -12,6 +13,7 @@ import { WalletConnect } from './wallets/walletconnect'
 
 export function createWalletMap(): WalletMap {
   return {
+    [WalletId.CUSTOM]: CustomWallet,
     [WalletId.DEFLY]: DeflyWallet,
     [WalletId.EXODUS]: ExodusWallet,
     [WalletId.KIBISIS]: KibisisWallet,

--- a/packages/use-wallet/src/wallets/custom.ts
+++ b/packages/use-wallet/src/wallets/custom.ts
@@ -1,0 +1,142 @@
+import algosdk from 'algosdk'
+import { WalletState, addWallet, setAccounts, type State } from 'src/store'
+import { compareAccounts } from 'src/utils'
+import { BaseWallet } from './base'
+import type { Store } from '@tanstack/store'
+import type { WalletAccount, WalletConstructor, WalletId } from './types'
+
+export type CustomProvider = {
+  connect(args?: Record<string, any>): Promise<WalletAccount[]>
+  disconnect(): Promise<void>
+  resumeSession(): Promise<WalletAccount[] | void>
+  signTransactions(
+    txnGroup: algosdk.Transaction[] | algosdk.Transaction[][] | Uint8Array[] | Uint8Array[][],
+    indexesToSign?: number[],
+    returnGroup?: boolean
+  ): Promise<Uint8Array[]>
+  transactionSigner(txnGroup: algosdk.Transaction[], indexesToSign: number[]): Promise<Uint8Array[]>
+}
+
+export interface CustomWalletOptions {
+  provider: CustomProvider
+}
+
+const svgIcon = `<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect width="24" height="24" fill="gray" />
+</svg>`
+
+export class CustomWallet extends BaseWallet {
+  private provider: CustomProvider
+  protected store: Store<State>
+
+  constructor({
+    id,
+    store,
+    subscribe,
+    getAlgodClient,
+    options,
+    metadata = {}
+  }: WalletConstructor<WalletId.CUSTOM>) {
+    super({ id, metadata, getAlgodClient, store, subscribe })
+    if (!options?.provider) {
+      throw new Error(`[${this.metadata.name}] Missing required option: provider`)
+    }
+    this.provider = options.provider
+    this.store = store
+  }
+
+  static defaultMetadata = {
+    name: 'Custom',
+    icon: `data:image/svg+xml;base64,${btoa(svgIcon)}`
+  }
+
+  public connect = async (args?: Record<string, any>): Promise<WalletAccount[]> => {
+    console.info(`[${this.metadata.name}] Connecting...`)
+    try {
+      const walletAccounts = await this.provider.connect(args)
+
+      if (walletAccounts.length === 0) {
+        throw new Error('No accounts found!')
+      }
+
+      const activeAccount = walletAccounts[0]
+
+      const walletState: WalletState = {
+        accounts: walletAccounts,
+        activeAccount
+      }
+
+      addWallet(this.store, {
+        walletId: this.id,
+        wallet: walletState
+      })
+
+      console.info(`[${this.metadata.name}] ✅ Connected.`, walletState)
+      return walletAccounts
+    } catch (error: any) {
+      console.error(`[${this.metadata.name}] Error connecting:`, error.message || error)
+      throw error
+    }
+  }
+
+  public disconnect = async (): Promise<void> => {
+    console.info(`[${this.metadata.name}] Disconnecting...`)
+    await this.provider.disconnect()
+    this.onDisconnect()
+  }
+
+  public resumeSession = async (): Promise<void> => {
+    try {
+      const state = this.store.state
+      const walletState = state.wallets[this.id]
+
+      // No session to resume
+      if (!walletState) {
+        return
+      }
+
+      console.info(`[${this.metadata.name}] Resuming session...`)
+
+      const result = await this.provider.resumeSession()
+
+      if (Array.isArray(result)) {
+        const walletAccounts = result
+
+        if (walletAccounts.length === 0) {
+          throw new Error(`[${this.metadata.name}] No accounts found!`)
+        }
+
+        const match = compareAccounts(walletAccounts, walletState.accounts)
+
+        if (!match) {
+          console.warn(`[${this.metadata.name}] Session accounts mismatch, updating accounts`, {
+            prev: walletState.accounts,
+            current: walletAccounts
+          })
+          setAccounts(this.store, {
+            walletId: this.id,
+            accounts: walletAccounts
+          })
+        }
+      }
+      console.info(`[${this.metadata.name}] Session resumed.`)
+    } catch (error: any) {
+      console.error(`[${this.metadata.name}] Error resuming session:`, error.message)
+    }
+  }
+
+  public signTransactions = async (
+    txnGroup: algosdk.Transaction[] | algosdk.Transaction[][] | Uint8Array[] | Uint8Array[][],
+    indexesToSign?: number[],
+    returnGroup = true
+  ): Promise<Uint8Array[]> => {
+    return await this.provider.signTransactions(txnGroup, indexesToSign, returnGroup)
+  }
+
+  public transactionSigner = async (
+    txnGroup: algosdk.Transaction[],
+    indexesToSign: number[]
+  ): Promise<Uint8Array[]> => {
+    return await this.provider.transactionSigner(txnGroup, indexesToSign)
+  }
+}

--- a/packages/use-wallet/src/wallets/index.ts
+++ b/packages/use-wallet/src/wallets/index.ts
@@ -1,4 +1,5 @@
 export * from './base'
+export * from './custom'
 export * from './defly'
 export * from './exodus'
 export * from './kmd'

--- a/packages/use-wallet/src/wallets/types.ts
+++ b/packages/use-wallet/src/wallets/types.ts
@@ -1,3 +1,4 @@
+import { CustomWallet, CustomWalletOptions } from './custom'
 import { DeflyWallet, type DeflyWalletConnectOptions } from './defly'
 import { ExodusWallet, type ExodusOptions } from './exodus'
 import { KibisisWallet } from './kibisis'
@@ -13,6 +14,7 @@ import type { State } from 'src/store'
 
 export enum WalletId {
   DEFLY = 'defly',
+  CUSTOM = 'custom',
   EXODUS = 'exodus',
   KIBISIS = 'kibisis',
   KMD = 'kmd',
@@ -24,6 +26,7 @@ export enum WalletId {
 }
 
 export type WalletMap = {
+  [WalletId.CUSTOM]: typeof CustomWallet
   [WalletId.DEFLY]: typeof DeflyWallet
   [WalletId.EXODUS]: typeof ExodusWallet
   [WalletId.KIBISIS]: typeof KibisisWallet
@@ -36,6 +39,7 @@ export type WalletMap = {
 }
 
 export type WalletOptionsMap = {
+  [WalletId.CUSTOM]: CustomWalletOptions
   [WalletId.DEFLY]: DeflyWalletConnectOptions
   [WalletId.EXODUS]: ExodusOptions
   [WalletId.KIBISIS]: Record<string, never>


### PR DESCRIPTION
Adds support for a custom wallet provider defined by the consuming application.

This feature was added to v2 by @robdmoore in https://github.com/TxnLab/use-wallet/pull/106 and has been adapted here for v3.

Closes #162