### PR TITLE
chore: revert Pera provider to Pera Connect v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Some wallets require additional packages to be installed. The following table li
 | Wallet Provider | Package(s)                                           |
 | --------------- | ---------------------------------------------------- |
 | Defly Wallet    | `@blockshake/defly-connect`                          |
-| Pera Wallet     | `@perawallet/connect-beta`                           |
+| Pera Wallet     | `@perawallet/connect`                                |
 | WalletConnect   | `@walletconnect/modal`, `@walletconnect/sign-client` |
 | Lute Wallet     | `lute-connect`                                       |
 | Magic.link      | `magic-sdk`, `@magic-ext/algorand`                   |
@@ -71,10 +71,7 @@ const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
     WalletId.EXODUS,
-    {
-      id: WalletId.PERA,
-      options: { projectId: '<YOUR_PROJECT_ID>' }
-    },
+    WalletId.PERA,
     {
       id: WalletId.WALLETCONNECT,
       options: { projectId: '<YOUR_PROJECT_ID>' }
@@ -100,7 +97,7 @@ Each wallet you wish to support must be included in the `wallets` array.
 
 To initialize wallets with default options, pass the wallet ID using the `WalletId` enum. To use custom options, pass an object with the `id` and `options` properties.
 
-> **Note:** Pera and WalletConnect's `projectId` option is required. You can obtain a project ID by registering your application at https://cloud.walletconnect.com/
+> **Note:** WalletConnect's `projectId` option is required. You can obtain a project ID by registering your application at https://cloud.walletconnect.com/
 
 > **Note:** Magic's required `apiKey` can be obtained by signing up at https://dashboard.magic.link/signup
 

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@blockshake/defly-connect": "^1.1.6",
-    "@perawallet/connect-beta": "2.0.11",
+    "@perawallet/connect": "^1.3.4",
     "@txnlab/use-wallet-react": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",

--- a/examples/nextjs/src/app/providers.tsx
+++ b/examples/nextjs/src/app/providers.tsx
@@ -6,10 +6,7 @@ const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
     WalletId.EXODUS,
-    {
-      id: WalletId.PERA,
-      options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }
-    },
+    WalletId.PERA,
     {
       id: WalletId.WALLETCONNECT,
       options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@blockshake/defly-connect": "^1.1.6",
-    "@perawallet/connect-beta": "2.0.11",
+    "@perawallet/connect": "^1.3.4",
     "@txnlab/use-wallet": "workspace:*",
     "@txnlab/use-wallet-vue": "workspace:*",
     "@walletconnect/modal": "^2.6.2",

--- a/examples/nuxt/plugins/walletManager.client.ts
+++ b/examples/nuxt/plugins/walletManager.client.ts
@@ -6,10 +6,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     wallets: [
       WalletId.DEFLY,
       WalletId.EXODUS,
-      {
-        id: WalletId.PERA,
-        options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }
-      },
+      WalletId.PERA,
       {
         id: WalletId.WALLETCONNECT,
         options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@blockshake/defly-connect": "^1.1.6",
-    "@perawallet/connect-beta": "2.0.11",
+    "@perawallet/connect": "^1.3.4",
     "@txnlab/use-wallet-react": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",

--- a/examples/react-ts/src/App.tsx
+++ b/examples/react-ts/src/App.tsx
@@ -8,10 +8,7 @@ const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
     WalletId.EXODUS,
-    {
-      id: WalletId.PERA,
-      options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }
-    },
+    WalletId.PERA,
     {
       id: WalletId.WALLETCONNECT,
       options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }

--- a/examples/solid-ts/package.json
+++ b/examples/solid-ts/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@blockshake/defly-connect": "^1.1.6",
-    "@perawallet/connect-beta": "2.0.11",
+    "@perawallet/connect": "^1.3.4",
     "@txnlab/use-wallet-solid": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",

--- a/examples/solid-ts/src/App.tsx
+++ b/examples/solid-ts/src/App.tsx
@@ -8,10 +8,7 @@ const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
     WalletId.EXODUS,
-    {
-      id: WalletId.PERA,
-      options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }
-    },
+    WalletId.PERA,
     {
       id: WalletId.WALLETCONNECT,
       options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }

--- a/examples/vanilla-ts/package.json
+++ b/examples/vanilla-ts/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@blockshake/defly-connect": "^1.1.6",
-    "@perawallet/connect-beta": "2.0.11",
+    "@perawallet/connect": "^1.3.4",
     "@txnlab/use-wallet": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",

--- a/examples/vanilla-ts/src/main.ts
+++ b/examples/vanilla-ts/src/main.ts
@@ -9,10 +9,7 @@ const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
     WalletId.EXODUS,
-    {
-      id: WalletId.PERA,
-      options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }
-    },
+    WalletId.PERA,
     {
       id: WalletId.WALLETCONNECT,
       options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }

--- a/examples/vue-ts/package.json
+++ b/examples/vue-ts/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@blockshake/defly-connect": "^1.1.6",
-    "@perawallet/connect-beta": "2.0.11",
+    "@perawallet/connect": "^1.3.4",
     "@txnlab/use-wallet-vue": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",

--- a/examples/vue-ts/src/main.ts
+++ b/examples/vue-ts/src/main.ts
@@ -9,10 +9,7 @@ app.use(WalletManagerPlugin, {
   wallets: [
     WalletId.DEFLY,
     WalletId.EXODUS,
-    {
-      id: WalletId.PERA,
-      options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }
-    },
+    WalletId.PERA,
     {
       id: WalletId.WALLETCONNECT,
       options: { projectId: 'fcfde0713d43baa0d23be0773c80a72b' }

--- a/packages/use-wallet-react/package.json
+++ b/packages/use-wallet-react/package.json
@@ -55,6 +55,7 @@
     "@magic-ext/algorand": "^23.0.2",
     "@perawallet/connect-beta": "^2.0.11",
     "@walletconnect/modal": "^2.6.2",
+    "@perawallet/connect": "^1.3.4",
     "@walletconnect/sign-client": "^2.10.2",
     "algosdk": "^2.7.0",
     "lute-connect": "^1.2.0",
@@ -67,6 +68,9 @@
       "optional": true
     },
     "@magic-ext/algorand": {
+      "optional": true
+    },
+    "@perawallet/connect": {
       "optional": true
     },
     "@perawallet/connect-beta": {

--- a/packages/use-wallet-solid/package.json
+++ b/packages/use-wallet-solid/package.json
@@ -75,6 +75,7 @@
   "peerDependencies": {
     "@blockshake/defly-connect": "^1.1.6",
     "@magic-ext/algorand": "^23.0.2",
+    "@perawallet/connect": "^1.3.4",
     "@perawallet/connect-beta": "^2.0.11",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
@@ -87,6 +88,9 @@
       "optional": true
     },
     "@magic-ext/algorand": {
+      "optional": true
+    },
+    "@perawallet/connect": {
       "optional": true
     },
     "@perawallet/connect-beta": {

--- a/packages/use-wallet-vue/package.json
+++ b/packages/use-wallet-vue/package.json
@@ -50,6 +50,7 @@
   "peerDependencies": {
     "@blockshake/defly-connect": "^1.1.6",
     "@magic-ext/algorand": "^23.0.2",
+    "@perawallet/connect": "^1.3.4",
     "@perawallet/connect-beta": "^2.0.11",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
@@ -63,6 +64,9 @@
       "optional": true
     },
     "@magic-ext/algorand": {
+      "optional": true
+    },
+    "@perawallet/connect": {
       "optional": true
     },
     "@perawallet/connect-beta": {

--- a/packages/use-wallet/package.json
+++ b/packages/use-wallet/package.json
@@ -45,6 +45,7 @@
     "@blockshake/defly-connect": "^1.1.6",
     "@magic-ext/algorand": "^23.0.2",
     "@magic-sdk/provider": "^28.0.2",
+    "@perawallet/connect": "^1.3.4",
     "@perawallet/connect-beta": "^2.0.11",
     "@types/node": "^20.6.5",
     "@walletconnect/modal": "^2.6.2",
@@ -59,6 +60,7 @@
   "peerDependencies": {
     "@agoralabs-sh/avm-web-provider": "^1.6.2",
     "@blockshake/defly-connect": "^1.1.6",
+    "@perawallet/connect": "^1.3.4",
     "@perawallet/connect-beta": "^2.0.11",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
@@ -69,6 +71,9 @@
       "optional": true
     },
     "@blockshake/defly-connect": {
+      "optional": true
+    },
+    "@perawallet/connect": {
       "optional": true
     },
     "@perawallet/connect-beta": {

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -149,10 +149,7 @@ describe('WalletManager', () => {
       const manager = new WalletManager({
         wallets: [
           {
-            id: WalletId.PERA,
-            options: {
-              projectId: 'mock-project-id'
-            }
+            id: WalletId.PERA
           },
           {
             id: WalletId.WALLETCONNECT,

--- a/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
@@ -2,7 +2,7 @@ import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
-import { PeraWallet } from 'src/wallets/pera'
+import { PeraWallet } from 'src/wallets/pera2'
 import { WalletId } from 'src/wallets/types'
 
 // Mock storage adapter
@@ -25,20 +25,18 @@ const mockPeraWallet = {
   signData: vi.fn()
 }
 
-vi.mock('@perawallet/connect', async (importOriginal) => {
-  const module = await importOriginal<typeof import('@perawallet/connect')>()
+vi.mock('@perawallet/connect-beta', () => {
   return {
-    ...module,
-    default: {
-      ...module,
-      PeraWalletConnect: vi.fn(() => mockPeraWallet)
-    }
+    PeraWalletConnect: vi.fn(() => mockPeraWallet)
   }
 })
 
 function createWalletWithStore(store: Store<State>): PeraWallet {
   return new PeraWallet({
     id: WalletId.PERA,
+    options: {
+      projectId: 'mockProjectId'
+    },
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,

--- a/packages/use-wallet/src/utils.ts
+++ b/packages/use-wallet/src/utils.ts
@@ -9,6 +9,7 @@ import { LuteWallet } from './wallets/lute'
 import { MagicAuth } from './wallets/magic'
 import { MnemonicWallet } from './wallets/mnemonic'
 import { PeraWallet } from './wallets/pera'
+import { PeraWallet as PeraWalletBeta } from './wallets/pera2'
 import { WalletConnect } from './wallets/walletconnect'
 
 export function createWalletMap(): WalletMap {
@@ -22,6 +23,7 @@ export function createWalletMap(): WalletMap {
     [WalletId.MAGIC]: MagicAuth,
     [WalletId.MNEMONIC]: MnemonicWallet,
     [WalletId.PERA]: PeraWallet,
+    [WalletId.PERA2]: PeraWalletBeta,
     [WalletId.WALLETCONNECT]: WalletConnect
   }
 }

--- a/packages/use-wallet/src/wallets/types.ts
+++ b/packages/use-wallet/src/wallets/types.ts
@@ -7,6 +7,10 @@ import { LuteConnectOptions, LuteWallet } from './lute'
 import { MagicAuth, MagicAuthOptions } from './magic'
 import { MnemonicWallet, type MnemonicOptions } from './mnemonic'
 import { PeraWallet, type PeraWalletConnectOptions } from './pera'
+import {
+  PeraWallet as PeraWalletBeta,
+  type PeraWalletConnectOptions as PeraWalletConnectBetaOptions
+} from './pera2'
 import { WalletConnect, type WalletConnectOptions } from './walletconnect'
 import type { Store } from '@tanstack/store'
 import type algosdk from 'algosdk'
@@ -22,6 +26,7 @@ export enum WalletId {
   MAGIC = 'magic',
   MNEMONIC = 'mnemonic',
   PERA = 'pera',
+  PERA2 = 'pera-beta',
   WALLETCONNECT = 'walletconnect'
 }
 
@@ -35,6 +40,7 @@ export type WalletMap = {
   [WalletId.MAGIC]: typeof MagicAuth
   [WalletId.MNEMONIC]: typeof MnemonicWallet
   [WalletId.PERA]: typeof PeraWallet
+  [WalletId.PERA2]: typeof PeraWalletBeta
   [WalletId.WALLETCONNECT]: typeof WalletConnect
 }
 
@@ -48,6 +54,7 @@ export type WalletOptionsMap = {
   [WalletId.MAGIC]: MagicAuthOptions
   [WalletId.MNEMONIC]: MnemonicOptions
   [WalletId.PERA]: PeraWalletConnectOptions
+  [WalletId.PERA2]: PeraWalletConnectBetaOptions
   [WalletId.WALLETCONNECT]: WalletConnectOptions
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,9 @@ importers:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
         version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@perawallet/connect-beta':
-        specifier: 2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-react':
         specifier: workspace:*
         version: link:../../packages/use-wallet-react
@@ -114,9 +114,9 @@ importers:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
         version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@perawallet/connect-beta':
-        specifier: 2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet':
         specifier: workspace:*
         version: link:../../packages/use-wallet
@@ -157,9 +157,9 @@ importers:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
         version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@perawallet/connect-beta':
-        specifier: 2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-react':
         specifier: workspace:*
         version: link:../../packages/use-wallet-react
@@ -218,9 +218,9 @@ importers:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
         version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@perawallet/connect-beta':
-        specifier: 2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-solid':
         specifier: workspace:*
         version: link:../../packages/use-wallet-solid
@@ -255,9 +255,9 @@ importers:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
         version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@perawallet/connect-beta':
-        specifier: 2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet':
         specifier: workspace:*
         version: link:../../packages/use-wallet
@@ -289,9 +289,9 @@ importers:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
         version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@perawallet/connect-beta':
-        specifier: 2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-vue':
         specifier: workspace:*
         version: link:../../packages/use-wallet-vue
@@ -345,6 +345,9 @@ importers:
       '@magic-sdk/provider':
         specifier: ^28.0.2
         version: 28.0.2(localforage@1.10.0)
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.11
         version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -384,6 +387,9 @@ importers:
       '@magic-ext/algorand':
         specifier: ^23.0.2
         version: 23.0.2
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.11
         version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -436,6 +442,9 @@ importers:
       '@magic-ext/algorand':
         specifier: ^23.0.2
         version: 23.0.2
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.11
         version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -485,6 +494,9 @@ importers:
       '@magic-ext/algorand':
         specifier: ^23.0.2
         version: 23.0.2
+      '@perawallet/connect':
+        specifier: ^1.3.4
+        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.11
         version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -1626,6 +1638,11 @@ packages:
 
   '@perawallet/connect-beta@2.0.11':
     resolution: {integrity: sha512-2mIf0WN3B+91mYDM7acO2o8RuLsNv6iI2LgPLkJhqbomMWfmW7QIA8qoFNZky4hK8t/AZUrvZfgQabYjJRQ/ig==}
+    peerDependencies:
+      algosdk: ^2.1.0
+
+  '@perawallet/connect@1.3.4':
+    resolution: {integrity: sha512-PRnD1YEXXoWjTlfWmZCGGHQWn7Zquxh44bXmEtluklq/kTkBOk5CToZWng1J/Ae9g0xMR85B1Y/xwnriFufcpA==}
     peerDependencies:
       algosdk: ^2.1.0
 
@@ -7806,6 +7823,19 @@ snapshots:
       - encoding
       - ioredis
       - uWebSockets.js
+      - utf-8-validate
+
+  '@perawallet/connect@1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@evanhahn/lottie-web-light': 5.8.1
+      '@walletconnect/client': 1.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@walletconnect/types': 1.8.0
+      algosdk: 2.7.0
+      bowser: 2.11.0
+      buffer: 6.0.3
+      qr-code-styling: 1.6.0-rc.1
+    transitivePeerDependencies:
+      - bufferutil
       - utf-8-validate
 
   '@pkgjs/parseargs@0.11.0':


### PR DESCRIPTION
While the testing for the Pera Connect v2 beta so far has been very promising, due to an unresolved issue this reverts the default `PERA` provider back to Pera Connect v1.

A dependency of `@perawallet/connect-beta` – `@walletconnect/sign-client` – is not included in Vite production builds. Vite's dev mode uses esbuild and everything works fine, but for some reason the Rollup production builds omit the Sign client and an error is thrown when you try to connect.

Instead of removing the new provider, it will remain as an undocumented option, `PERA2`, so it can continue to be tested on an opt-in basis.