### PR TITLE
feat(core): signTransactions response should match length of txnGroup

### DIFF
--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -91,7 +91,7 @@ export const useWallet = () => {
   const signTransactions = <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     if (!activeWallet) {
       throw new Error('No active wallet')
     }

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -110,7 +110,7 @@ export function useWallet() {
   const signTransactions = <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     const wallet = activeWallet()
     if (!wallet) {
       throw new Error('No active wallet')

--- a/packages/use-wallet-vue/src/useWallet.ts
+++ b/packages/use-wallet-vue/src/useWallet.ts
@@ -107,7 +107,7 @@ export function useWallet() {
   const signTransactions = <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     if (!activeWallet.value) {
       throw new Error('No active wallet')
     }

--- a/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
@@ -314,6 +314,7 @@ describe('ExodusWallet', () => {
 
       it('should determine which transactions to sign based on indexesToSign', async () => {
         const [gtxn1, gtxn2, gtxn3, gtxn4] = algosdk.assignGroupID([txn1, txn2, txn3, txn4])
+        const txnGroup = [gtxn1, gtxn2, gtxn3, gtxn4]
         const indexesToSign = [0, 1, 3]
 
         const gtxn1String = byteArrayToBase64(gtxn1.toByte())
@@ -323,21 +324,18 @@ describe('ExodusWallet', () => {
         // Mock signTxns to return "signed" (not really) base64 transactions or null
         mockSignTxns.mockResolvedValueOnce([gtxn1String, gtxn2String, null, gtxn4String])
 
-        const result = await wallet.signTransactions([gtxn1, gtxn2, gtxn3, gtxn4], indexesToSign)
+        await expect(wallet.signTransactions(txnGroup, indexesToSign)).resolves.toEqual([
+          base64ToByteArray(gtxn1String),
+          base64ToByteArray(gtxn2String),
+          null,
+          base64ToByteArray(gtxn4String)
+        ])
 
         expect(mockSignTxns).toHaveBeenCalledWith([
           { txn: byteArrayToBase64(gtxn1.toByte()) },
           { txn: byteArrayToBase64(gtxn2.toByte()) },
           { txn: byteArrayToBase64(gtxn3.toByte()), signers: [] },
           { txn: byteArrayToBase64(gtxn4.toByte()) }
-        ])
-
-        // Only encoded "signed" transactions should be returned
-        expect(result).toHaveLength(indexesToSign.length)
-        expect(result).toEqual([
-          base64ToByteArray(gtxn1String),
-          base64ToByteArray(gtxn2String),
-          base64ToByteArray(gtxn4String)
         ])
       })
 

--- a/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
@@ -388,6 +388,7 @@ describe('KibisisWallet', () => {
 
       it('should determine which transactions to sign based on indexesToSign', async () => {
         const [gtxn1, gtxn2, gtxn3, gtxn4] = algosdk.assignGroupID([txn1, txn2, txn3, txn4])
+        const txnGroup = [gtxn1, gtxn2, gtxn3, gtxn4]
         const indexesToSign = [0, 1, 3]
 
         const gtxn1String = byteArrayToBase64(gtxn1.toByte())
@@ -396,21 +397,18 @@ describe('KibisisWallet', () => {
 
         mockSignTransactionsResponseOnce([gtxn1String, gtxn2String, null, gtxn4String])
 
-        const result = await wallet.signTransactions([gtxn1, gtxn2, gtxn3, gtxn4], indexesToSign)
+        await expect(wallet.signTransactions(txnGroup, indexesToSign)).resolves.toEqual([
+          base64ToByteArray(gtxn1String),
+          base64ToByteArray(gtxn2String),
+          null,
+          base64ToByteArray(gtxn4String)
+        ])
 
         expect(wallet['_signTransactions']).toHaveBeenCalledWith([
           { txn: byteArrayToBase64(gtxn1.toByte()) },
           { txn: byteArrayToBase64(gtxn2.toByte()) },
           { txn: byteArrayToBase64(gtxn3.toByte()), signers: [] },
           { txn: byteArrayToBase64(gtxn4.toByte()) }
-        ])
-
-        // Only encoded "signed" transactions should be returned
-        expect(result).toHaveLength(indexesToSign.length)
-        expect(result).toEqual([
-          base64ToByteArray(gtxn1String),
-          base64ToByteArray(gtxn2String),
-          base64ToByteArray(gtxn4String)
         ])
       })
 

--- a/packages/use-wallet/src/__tests__/wallets/lute.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/lute.test.ts
@@ -287,6 +287,7 @@ describe('LuteWallet', () => {
 
       it('should determine which transactions to sign based on indexesToSign', async () => {
         const [gtxn1, gtxn2, gtxn3, gtxn4] = algosdk.assignGroupID([txn1, txn2, txn3, txn4])
+        const txnGroup = [gtxn1, gtxn2, gtxn3, gtxn4]
         const indexesToSign = [0, 1, 3]
 
         // Mock signTxns to return "signed" (not really) encoded transactions or null
@@ -297,7 +298,12 @@ describe('LuteWallet', () => {
           gtxn4.toByte()
         ])
 
-        const result = await wallet.signTransactions([gtxn1, gtxn2, gtxn3, gtxn4], indexesToSign)
+        await expect(wallet.signTransactions(txnGroup, indexesToSign)).resolves.toEqual([
+          gtxn1.toByte(),
+          gtxn2.toByte(),
+          null,
+          gtxn4.toByte()
+        ])
 
         expect(mockLuteConnect.signTxns).toHaveBeenCalledWith([
           { txn: byteArrayToBase64(gtxn1.toByte()) },
@@ -305,10 +311,6 @@ describe('LuteWallet', () => {
           { txn: byteArrayToBase64(gtxn3.toByte()), signers: [] },
           { txn: byteArrayToBase64(gtxn4.toByte()) }
         ])
-
-        // Only encoded "signed" transactions should be returned
-        expect(result).toHaveLength(indexesToSign.length)
-        expect(result).toEqual([gtxn1.toByte(), gtxn2.toByte(), gtxn4.toByte()])
       })
 
       it('should only send transactions with connected signers for signature', async () => {

--- a/packages/use-wallet/src/__tests__/wallets/magic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/magic.test.ts
@@ -398,6 +398,7 @@ describe('MagicAuth', () => {
 
       it('should determine which transactions to sign based on indexesToSign', async () => {
         const [gtxn1, gtxn2, gtxn3, gtxn4] = algosdk.assignGroupID([txn1, txn2, txn3, txn4])
+        const txnGroup = [gtxn1, gtxn2, gtxn3, gtxn4]
         const indexesToSign = [0, 1, 3]
 
         const gtxn1String = byteArrayToBase64(gtxn1.toByte())
@@ -412,21 +413,18 @@ describe('MagicAuth', () => {
           gtxn4String
         ])
 
-        const result = await wallet.signTransactions([gtxn1, gtxn2, gtxn3, gtxn4], indexesToSign)
+        await expect(wallet.signTransactions(txnGroup, indexesToSign)).resolves.toEqual([
+          base64ToByteArray(gtxn1String),
+          base64ToByteArray(gtxn2String),
+          null,
+          base64ToByteArray(gtxn4String)
+        ])
 
         expect(mockMagicClient.algorand.signGroupTransactionV2).toHaveBeenCalledWith([
           { txn: byteArrayToBase64(gtxn1.toByte()) },
           { txn: byteArrayToBase64(gtxn2.toByte()) },
           { txn: byteArrayToBase64(gtxn3.toByte()), signers: [] },
           { txn: byteArrayToBase64(gtxn4.toByte()) }
-        ])
-
-        // Only encoded "signed" transactions should be returned
-        expect(result).toHaveLength(indexesToSign.length)
-        expect(result).toEqual([
-          base64ToByteArray(gtxn1String),
-          base64ToByteArray(gtxn2String),
-          base64ToByteArray(gtxn4String)
         ])
       })
 

--- a/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
@@ -299,6 +299,8 @@ describe('PeraWallet', () => {
     const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
     const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
 
+    const sTxn = new Uint8Array([1, 2, 3, 4])
+
     beforeEach(async () => {
       // Mock two connected accounts
       mockPeraWallet.connect.mockResolvedValueOnce([connectedAcct1, connectedAcct2])
@@ -308,6 +310,8 @@ describe('PeraWallet', () => {
 
     describe('signTransactions', () => {
       it('should process and sign a single algosdk.Transaction', async () => {
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn])
+
         await wallet.signTransactions([txn1])
 
         expect(mockPeraWallet.signTransaction).toHaveBeenCalledWith([[{ txn: txn1 }]])
@@ -315,6 +319,9 @@ describe('PeraWallet', () => {
 
       it('should process and sign a single algosdk.Transaction group', async () => {
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([txn1, txn2, txn3])
+
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn, sTxn])
+
         await wallet.signTransactions([gtxn1, gtxn2, gtxn3])
 
         expect(mockPeraWallet.signTransaction).toHaveBeenCalledWith([
@@ -325,6 +332,8 @@ describe('PeraWallet', () => {
       it('should process and sign multiple algosdk.Transaction groups', async () => {
         const [g1txn1, g1txn2] = algosdk.assignGroupID([txn1, txn2])
         const [g2txn1, g2txn2] = algosdk.assignGroupID([txn3, txn4])
+
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn, sTxn, sTxn, sTxn])
 
         await wallet.signTransactions([
           [g1txn1, g1txn2],
@@ -338,6 +347,9 @@ describe('PeraWallet', () => {
 
       it('should process and sign a single encoded transaction', async () => {
         const encodedTxn = txn1.toByte()
+
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn])
+
         await wallet.signTransactions([encodedTxn])
 
         expect(mockPeraWallet.signTransaction).toHaveBeenCalledWith([
@@ -348,6 +360,8 @@ describe('PeraWallet', () => {
       it('should process and sign a single encoded transaction group', async () => {
         const txnGroup = algosdk.assignGroupID([txn1, txn2, txn3])
         const [gtxn1, gtxn2, gtxn3] = txnGroup.map((txn) => txn.toByte())
+
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn, sTxn, sTxn])
 
         await wallet.signTransactions([gtxn1, gtxn2, gtxn3])
 
@@ -367,6 +381,8 @@ describe('PeraWallet', () => {
         const txnGroup2 = algosdk.assignGroupID([txn3, txn4])
         const [g2txn1, g2txn2] = txnGroup2.map((txn) => txn.toByte())
 
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn, sTxn, sTxn, sTxn])
+
         await wallet.signTransactions([
           [g1txn1, g1txn2],
           [g2txn1, g2txn2]
@@ -384,9 +400,18 @@ describe('PeraWallet', () => {
 
       it('should determine which transactions to sign based on indexesToSign', async () => {
         const [gtxn1, gtxn2, gtxn3, gtxn4] = algosdk.assignGroupID([txn1, txn2, txn3, txn4])
+
+        const txnGroup = [gtxn1, gtxn2, gtxn3, gtxn4]
         const indexesToSign = [0, 1, 3]
 
-        await wallet.signTransactions([gtxn1, gtxn2, gtxn3, gtxn4], indexesToSign)
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn, sTxn, sTxn])
+
+        await expect(wallet.signTransactions(txnGroup, indexesToSign)).resolves.toEqual([
+          sTxn,
+          sTxn,
+          null,
+          sTxn
+        ])
 
         expect(mockPeraWallet.signTransaction).toHaveBeenCalledWith([
           [{ txn: gtxn1 }, { txn: gtxn2 }, { txn: gtxn3, signers: [] }, { txn: gtxn4 }]
@@ -419,10 +444,29 @@ describe('PeraWallet', () => {
           canSignTxn3
         ])
 
-        await wallet.signTransactions([gtxn1, gtxn2, gtxn3])
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn, sTxn])
+
+        await expect(wallet.signTransactions([gtxn1, gtxn2, gtxn3])).resolves.toEqual([
+          sTxn,
+          null,
+          sTxn
+        ])
 
         expect(mockPeraWallet.signTransaction).toHaveBeenCalledWith([
           [{ txn: gtxn1 }, { txn: gtxn2, signers: [] }, { txn: gtxn3 }]
+        ])
+      })
+
+      it('should insert null values in response for transactions that were not signed', async () => {
+        const txnGroup = algosdk.assignGroupID([txn1, txn2, txn3])
+        const indexesToSign = [0, 2]
+
+        mockPeraWallet.signTransaction.mockResolvedValueOnce([sTxn, sTxn])
+
+        await expect(wallet.signTransactions(txnGroup, indexesToSign)).resolves.toEqual([
+          sTxn,
+          null,
+          sTxn
         ])
       })
     })
@@ -432,7 +476,9 @@ describe('PeraWallet', () => {
         const txnGroup = algosdk.assignGroupID([txn1, txn2])
         const indexesToSign = [1]
 
-        const signTransactionsSpy = vi.spyOn(wallet, 'signTransactions')
+        const signTransactionsSpy = vi
+          .spyOn(wallet, 'signTransactions')
+          .mockImplementationOnce(() => Promise.resolve([sTxn]))
 
         await wallet.transactionSigner(txnGroup, indexesToSign)
 

--- a/packages/use-wallet/src/wallets/base.ts
+++ b/packages/use-wallet/src/wallets/base.ts
@@ -58,7 +58,7 @@ export abstract class BaseWallet {
   public abstract signTransactions<T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]>
+  ): Promise<(Uint8Array | null)[]>
 
   public abstract transactionSigner(
     txnGroup: algosdk.Transaction[],

--- a/packages/use-wallet/src/wallets/base.ts
+++ b/packages/use-wallet/src/wallets/base.ts
@@ -60,10 +60,21 @@ export abstract class BaseWallet {
     indexesToSign?: number[]
   ): Promise<(Uint8Array | null)[]>
 
-  public abstract transactionSigner(
+  public transactionSigner = async (
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
-  ): Promise<Uint8Array[]>
+  ): Promise<Uint8Array[]> => {
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
+
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
+  }
 
   // ---------- Derived Properties ------------------------------------ //
 

--- a/packages/use-wallet/src/wallets/custom.ts
+++ b/packages/use-wallet/src/wallets/custom.ts
@@ -12,7 +12,7 @@ export type CustomProvider = {
   signTransactions?<T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]>
+  ): Promise<(Uint8Array | null)[]>
   transactionSigner?(
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
@@ -137,7 +137,7 @@ export class CustomWallet extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     if (!this.provider.signTransactions) {
       throw new Error(`[${this.metadata.name}] Method not supported: signTransactions`)
     }

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -198,7 +198,7 @@ export class DeflyWallet extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     let txnsToSign: SignerTransaction[] = []
 
     // Determine type and process transactions for signing
@@ -214,13 +214,36 @@ export class DeflyWallet extends BaseWallet {
 
     // Sign transactions
     const signedTxns = await client.signTransaction([txnsToSign])
-    return signedTxns
+
+    // ARC-0001 - Return null for unsigned transactions
+    const result = txnsToSign.reduce<(Uint8Array | null)[]>((acc, txn) => {
+      if (txn.signers && txn.signers.length == 0) {
+        acc.push(null)
+      } else {
+        const signedTxn = signedTxns.shift()
+        if (signedTxn) {
+          acc.push(signedTxn)
+        }
+      }
+      return acc
+    }, [])
+
+    return result
   }
 
   public transactionSigner = async (
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
   ): Promise<Uint8Array[]> => {
-    return this.signTransactions(txnGroup, indexesToSign)
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
+
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
   }
 }

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -230,20 +230,4 @@ export class DeflyWallet extends BaseWallet {
 
     return result
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/exodus.ts
+++ b/packages/use-wallet/src/wallets/exodus.ts
@@ -229,7 +229,7 @@ export class ExodusWallet extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     let txnsToSign: WalletTransaction[] = []
 
     // Determine type and process transactions for signing
@@ -246,22 +246,30 @@ export class ExodusWallet extends BaseWallet {
     // Sign transactions
     const signTxnsResult = await client.signTxns(txnsToSign)
 
-    // Filter out null values and convert to Uint8Array[]
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        const signedTxn = base64ToByteArray(value)
-        acc.push(signedTxn)
+    // Convert base64 to Uint8Array
+    const result = signTxnsResult.map((value) => {
+      if (value === null) {
+        return null
       }
-      return acc
-    }, [])
+      return base64ToByteArray(value)
+    })
 
-    return signedTxns
+    return result
   }
 
   public transactionSigner = async (
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
   ): Promise<Uint8Array[]> => {
-    return this.signTransactions(txnGroup, indexesToSign)
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
+
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
   }
 }

--- a/packages/use-wallet/src/wallets/exodus.ts
+++ b/packages/use-wallet/src/wallets/exodus.ts
@@ -256,20 +256,4 @@ export class ExodusWallet extends BaseWallet {
 
     return result
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/kibisis.ts
+++ b/packages/use-wallet/src/wallets/kibisis.ts
@@ -498,20 +498,4 @@ export class KibisisWallet extends BaseWallet {
       throw error
     }
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/kmd.ts
+++ b/packages/use-wallet/src/wallets/kmd.ts
@@ -242,22 +242,6 @@ export class KmdWallet extends BaseWallet {
     return signedTxns
   }
 
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
-
   private async fetchWalletId(): Promise<string> {
     console.info(`[${this.metadata.name}] Fetching wallet data...`)
     const client = this.client || (await this.initializeClient())

--- a/packages/use-wallet/src/wallets/kmd.ts
+++ b/packages/use-wallet/src/wallets/kmd.ts
@@ -213,7 +213,7 @@ export class KmdWallet extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     let txnsToSign: algosdk.Transaction[] = []
 
     // Determine type and process transactions for signing
@@ -246,7 +246,16 @@ export class KmdWallet extends BaseWallet {
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
   ): Promise<Uint8Array[]> => {
-    return this.signTransactions(txnGroup, indexesToSign)
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
+
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
   }
 
   private async fetchWalletId(): Promise<string> {

--- a/packages/use-wallet/src/wallets/lute.ts
+++ b/packages/use-wallet/src/wallets/lute.ts
@@ -185,7 +185,7 @@ export class LuteWallet extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     try {
       let txnsToSign: WalletTransaction[] = []
 
@@ -203,15 +203,7 @@ export class LuteWallet extends BaseWallet {
       // Sign transactions
       const signTxnsResult = await client.signTxns(txnsToSign)
 
-      // Filter out null values
-      const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-        if (value !== null) {
-          acc.push(value)
-        }
-        return acc
-      }, [])
-
-      return signedTxns
+      return signTxnsResult
     } catch (error) {
       if (isSignTxnsError(error)) {
         throw new SignTxnsError(error.message, error.code)
@@ -224,6 +216,15 @@ export class LuteWallet extends BaseWallet {
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
   ): Promise<Uint8Array[]> => {
-    return this.signTransactions(txnGroup, indexesToSign)
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
+
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
   }
 }

--- a/packages/use-wallet/src/wallets/lute.ts
+++ b/packages/use-wallet/src/wallets/lute.ts
@@ -211,20 +211,4 @@ export class LuteWallet extends BaseWallet {
       throw error
     }
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/magic.ts
+++ b/packages/use-wallet/src/wallets/magic.ts
@@ -290,20 +290,4 @@ export class MagicAuth extends BaseWallet {
 
     return result
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -192,7 +192,7 @@ export class MnemonicWallet extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     // Throw error if MainNet is active
     this.checkMainnet()
 
@@ -216,9 +216,15 @@ export class MnemonicWallet extends BaseWallet {
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
   ): Promise<Uint8Array[]> => {
-    // Throw error if MainNet is active
-    this.checkMainnet()
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
 
-    return this.signTransactions(txnGroup, indexesToSign)
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
   }
 }

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -211,20 +211,4 @@ export class MnemonicWallet extends BaseWallet {
     const signedTxns = txnsToSign.map((txn) => txn.signTxn(this.account!.sk))
     return signedTxns
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -235,20 +235,4 @@ export class PeraWallet extends BaseWallet {
 
     return result
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -203,7 +203,7 @@ export class PeraWallet extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     let txnsToSign: SignerTransaction[] = []
 
     // Determine type and process transactions for signing
@@ -219,13 +219,36 @@ export class PeraWallet extends BaseWallet {
 
     // Sign transactions
     const signedTxns = await client.signTransaction([txnsToSign])
-    return signedTxns
+
+    // ARC-0001 - Return null for unsigned transactions
+    const result = txnsToSign.reduce<(Uint8Array | null)[]>((acc, txn) => {
+      if (txn.signers && txn.signers.length == 0) {
+        acc.push(null)
+      } else {
+        const signedTxn = signedTxns.shift()
+        if (signedTxn) {
+          acc.push(signedTxn)
+        }
+      }
+      return acc
+    }, [])
+
+    return result
   }
 
   public transactionSigner = async (
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
   ): Promise<Uint8Array[]> => {
-    return this.signTransactions(txnGroup, indexesToSign)
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
+
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
   }
 }

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -206,7 +206,7 @@ export class PeraWallet extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     let txnsToSign: SignerTransaction[] = []
 
     // Determine type and process transactions for signing
@@ -222,13 +222,36 @@ export class PeraWallet extends BaseWallet {
 
     // Sign transactions
     const signedTxns = await client.signTransaction([txnsToSign])
-    return signedTxns
+
+    // ARC-0001 - Return null for unsigned transactions
+    const result = txnsToSign.reduce<(Uint8Array | null)[]>((acc, txn) => {
+      if (txn.signers && txn.signers.length == 0) {
+        acc.push(null)
+      } else {
+        const signedTxn = signedTxns.shift()
+        if (signedTxn) {
+          acc.push(signedTxn)
+        }
+      }
+      return acc
+    }, [])
+
+    return result
   }
 
   public transactionSigner = async (
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
   ): Promise<Uint8Array[]> => {
-    return this.signTransactions(txnGroup, indexesToSign)
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
+
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
   }
 }

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -238,20 +238,4 @@ export class PeraWallet extends BaseWallet {
 
     return result
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -549,20 +549,4 @@ export class WalletConnect extends BaseWallet {
       throw error
     }
   }
-
-  public transactionSigner = async (
-    txnGroup: algosdk.Transaction[],
-    indexesToSign: number[]
-  ): Promise<Uint8Array[]> => {
-    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
-
-    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
-      if (value !== null) {
-        acc.push(value)
-      }
-      return acc
-    }, [])
-
-    return signedTxns
-  }
 }

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -489,7 +489,7 @@ export class WalletConnect extends BaseWallet {
   public signTransactions = async <T extends algosdk.Transaction[] | Uint8Array[]>(
     txnGroup: T | T[],
     indexesToSign?: number[]
-  ): Promise<Uint8Array[]> => {
+  ): Promise<(Uint8Array | null)[]> => {
     try {
       if (!this.session) {
         throw new SessionError(`No session found!`)
@@ -518,7 +518,7 @@ export class WalletConnect extends BaseWallet {
         request
       })
 
-      // Filter out nullish values
+      // Filter out unsigned transactions, convert base64 strings to Uint8Array
       const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
         if (value) {
           const signedTxn = typeof value === 'string' ? base64ToByteArray(value) : value
@@ -527,7 +527,20 @@ export class WalletConnect extends BaseWallet {
         return acc
       }, [])
 
-      return signedTxns
+      // ARC-0001 - Return null for unsigned transactions
+      const result = txnsToSign.reduce<(Uint8Array | null)[]>((acc, txn) => {
+        if (txn.signers && txn.signers.length == 0) {
+          acc.push(null)
+        } else {
+          const signedTxn = signedTxns.shift()
+          if (signedTxn) {
+            acc.push(signedTxn)
+          }
+        }
+        return acc
+      }, [])
+
+      return result
     } catch (error) {
       if (error instanceof SessionError) {
         this.onDisconnect()
@@ -541,6 +554,15 @@ export class WalletConnect extends BaseWallet {
     txnGroup: algosdk.Transaction[],
     indexesToSign: number[]
   ): Promise<Uint8Array[]> => {
-    return this.signTransactions(txnGroup, indexesToSign)
+    const signTxnsResult = await this.signTransactions(txnGroup, indexesToSign)
+
+    const signedTxns = signTxnsResult.reduce<Uint8Array[]>((acc, value) => {
+      if (value !== null) {
+        acc.push(value)
+      }
+      return acc
+    }, [])
+
+    return signedTxns
   }
 }


### PR DESCRIPTION
See https://forum.algorand.org/t/signtxnsfunction-arc-0001-vs-transactionsigner-algosdk-response-types/12120