### PR TITLE
fix(core): fixes isTransactionArray utility function

### DIFF
--- a/packages/use-wallet/src/__tests__/utils.test.ts
+++ b/packages/use-wallet/src/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   flattenTxnGroup,
   formatJsonRpcRequest,
   isSignedTxn,
+  isTransaction,
   isTransactionArray
 } from 'src/utils'
 
@@ -78,6 +79,41 @@ describe('isSignedTxn', () => {
 
   it('should return false if the object is not a signed transaction', () => {
     expect(isSignedTxn(encodedTxn)).toBe(false)
+  })
+})
+
+describe('isTransaction', () => {
+  const transaction = new algosdk.Transaction({
+    from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+    to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+    fee: 10,
+    amount: 847,
+    firstRound: 51,
+    lastRound: 61,
+    genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
+    genesisID: 'testnet-v1.0'
+  })
+
+  const uInt8Array = transaction.toByte()
+
+  it('should return true if the item is a Transaction', () => {
+    expect(isTransaction(transaction)).toBe(true)
+  })
+
+  it('should return false if the item is a Uint8Array', () => {
+    expect(isTransaction(uInt8Array)).toBe(false)
+  })
+
+  it('should return false if the item is an object that is not a Transaction', () => {
+    expect(isTransaction({})).toBe(false)
+  })
+
+  it('should return false if the item is an array of Transactions', () => {
+    expect(isTransaction([transaction, transaction])).toBe(false)
+  })
+
+  it('should return false if the item is an array of Uint8Arrays', () => {
+    expect(isTransaction([uInt8Array, uInt8Array])).toBe(false)
   })
 })
 

--- a/packages/use-wallet/src/utils.ts
+++ b/packages/use-wallet/src/utils.ts
@@ -76,13 +76,28 @@ export function isSignedTxn(
   return (txnDecodeObj as algosdk.EncodedSignedTransaction).txn !== undefined
 }
 
+export function isTransaction(item: any): item is algosdk.Transaction {
+  return (
+    item && typeof item === 'object' && 'genesisID' in item && typeof item.genesisID === 'string'
+  )
+}
+
 export function isTransactionArray(
   txnGroup: any
 ): txnGroup is algosdk.Transaction[] | algosdk.Transaction[][] {
-  return (
-    txnGroup[0] instanceof algosdk.Transaction ||
-    (Array.isArray(txnGroup[0]) && txnGroup[0][0] instanceof algosdk.Transaction)
-  )
+  if (!Array.isArray(txnGroup) || txnGroup.length === 0) {
+    return false
+  }
+
+  if (isTransaction(txnGroup[0])) {
+    return true
+  }
+
+  if (Array.isArray(txnGroup[0]) && txnGroup[0].length > 0 && isTransaction(txnGroup[0][0])) {
+    return true
+  }
+
+  return false
 }
 
 export function flattenTxnGroup<T>(txnGroup: T[]): T extends (infer U)[] ? U[] : T[] {


### PR DESCRIPTION
In a controlled test environment using `instanceof` to verify a transaction is of type `algosdk.Transaction` works, but in a production setting a more "low tech" type guard is necessary.

Now the items (either a normal transaction object or encoded transaction) are checked for a `genesisID` property, which confirms it is an unencoded object.