### PR TITLE
fix: move algosdk to peer

### DIFF
--- a/packages/use-wallet/package.json
+++ b/packages/use-wallet/package.json
@@ -37,8 +37,7 @@
     "dist"
   ],
   "dependencies": {
-    "@tanstack/store": "0.4.1",
-    "algosdk": "2.7.0"
+    "@tanstack/store": "0.4.1"
   },
   "devDependencies": {
     "@agoralabs-sh/avm-web-provider": "^1.6.2",
@@ -64,6 +63,7 @@
     "@perawallet/connect-beta": "^2.0.11",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
+    "algosdk": "^2.7.0",
     "lute-connect": "^1.2.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,7 +330,7 @@ importers:
         specifier: 0.4.1
         version: 0.4.1
       algosdk:
-        specifier: 2.7.0
+        specifier: ^2.7.0
         version: 2.7.0
     devDependencies:
       '@agoralabs-sh/avm-web-provider':


### PR DESCRIPTION
### Description

- moves algosdk to peerDependency
- allows for ^2.7.0 version matching

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

### Issues

- resolves #192 
