### PR TITLE
chore: add algosdk to devDependencies, sync versions

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -13,7 +13,7 @@
     "@txnlab/use-wallet-react": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
-    "algosdk": "^2.7.0",
+    "algosdk": "2.8.0",
     "lute-connect": "^1.2.0",
     "next": "14.1.0",
     "react": "^18",

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -17,7 +17,7 @@
     "@txnlab/use-wallet-vue": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
-    "algosdk": "^2.7.0",
+    "algosdk": "2.8.0",
     "lute-connect": "^1.2.0",
     "nuxt": "^3.10.2",
     "vue": "^3.4.19",

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -14,7 +14,7 @@
     "@txnlab/use-wallet-react": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
-    "algosdk": "^2.7.0",
+    "algosdk": "2.8.0",
     "lute-connect": "^1.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/solid-ts/package.json
+++ b/examples/solid-ts/package.json
@@ -15,7 +15,7 @@
     "@txnlab/use-wallet-solid": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
-    "algosdk": "^2.7.0",
+    "algosdk": "2.8.0",
     "lute-connect": "^1.2.0",
     "solid-js": "^1.8.11"
   },

--- a/examples/vanilla-ts/package.json
+++ b/examples/vanilla-ts/package.json
@@ -19,7 +19,7 @@
     "@txnlab/use-wallet": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
-    "algosdk": "^2.7.0",
+    "algosdk": "2.8.0",
     "lute-connect": "^1.2.0"
   }
 }

--- a/examples/vue-ts/package.json
+++ b/examples/vue-ts/package.json
@@ -14,7 +14,7 @@
     "@txnlab/use-wallet-vue": "workspace:*",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
-    "algosdk": "^2.7.0",
+    "algosdk": "2.8.0",
     "lute-connect": "^1.2.0",
     "vue": "^3.3.11"
   },

--- a/packages/use-wallet-react/package.json
+++ b/packages/use-wallet-react/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.45",
-    "algosdk": "2.7.0",
+    "algosdk": "2.8.0",
     "jsdom": "^24.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/use-wallet-solid/package.json
+++ b/packages/use-wallet-solid/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.5",
-    "algosdk": "2.7.0",
+    "algosdk": "2.8.0",
     "solid-js": "^1.8.11",
     "tsup": "^8.0.0",
     "tsup-preset-solid": "^2.2.0",

--- a/packages/use-wallet-vue/package.json
+++ b/packages/use-wallet-vue/package.json
@@ -42,7 +42,7 @@
     "@txnlab/use-wallet": "workspace:*"
   },
   "devDependencies": {
-    "algosdk": "2.7.0",
+    "algosdk": "2.8.0",
     "tsup": "^8.0.0",
     "typescript": "^5.2.2",
     "vue": "^3.3.13"

--- a/packages/use-wallet/package.json
+++ b/packages/use-wallet/package.json
@@ -51,6 +51,7 @@
     "@walletconnect/modal-core": "^2.6.2",
     "@walletconnect/sign-client": "^2.10.2",
     "@walletconnect/types": "^2.10.2",
+    "algosdk": "2.8.0",
     "lute-connect": "^1.2.0",
     "magic-sdk": "^28.0.3",
     "tsup": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,10 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-react':
         specifier: workspace:*
         version: link:../../packages/use-wallet-react
@@ -75,8 +75,8 @@ importers:
         specifier: ^2.10.2
         version: 2.11.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       lute-connect:
         specifier: ^1.2.0
         version: 1.2.0
@@ -113,10 +113,10 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet':
         specifier: workspace:*
         version: link:../../packages/use-wallet
@@ -130,8 +130,8 @@ importers:
         specifier: ^2.10.2
         version: 2.11.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       lute-connect:
         specifier: ^1.2.0
         version: 1.2.0
@@ -156,10 +156,10 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-react':
         specifier: workspace:*
         version: link:../../packages/use-wallet-react
@@ -170,8 +170,8 @@ importers:
         specifier: ^2.10.2
         version: 2.11.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       lute-connect:
         specifier: ^1.2.0
         version: 1.2.0
@@ -217,10 +217,10 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-solid':
         specifier: workspace:*
         version: link:../../packages/use-wallet-solid
@@ -231,8 +231,8 @@ importers:
         specifier: ^2.10.2
         version: 2.11.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       lute-connect:
         specifier: ^1.2.0
         version: 1.2.0
@@ -254,10 +254,10 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet':
         specifier: workspace:*
         version: link:../../packages/use-wallet
@@ -268,8 +268,8 @@ importers:
         specifier: ^2.10.2
         version: 2.11.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       lute-connect:
         specifier: ^1.2.0
         version: 1.2.0
@@ -288,10 +288,10 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-vue':
         specifier: workspace:*
         version: link:../../packages/use-wallet-vue
@@ -302,8 +302,8 @@ importers:
         specifier: ^2.10.2
         version: 2.11.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       lute-connect:
         specifier: ^1.2.0
         version: 1.2.0
@@ -329,16 +329,13 @@ importers:
       '@tanstack/store':
         specifier: 0.4.1
         version: 0.4.1
-      algosdk:
-        specifier: ^2.7.0
-        version: 2.7.0
     devDependencies:
       '@agoralabs-sh/avm-web-provider':
         specifier: ^1.6.2
         version: 1.6.2
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@magic-ext/algorand':
         specifier: ^23.0.2
         version: 23.0.2
@@ -347,10 +344,10 @@ importers:
         version: 28.0.2(localforage@1.10.0)
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        version: 2.0.11(algosdk@2.8.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@types/node':
         specifier: ^20.6.5
         version: 20.11.30
@@ -366,6 +363,9 @@ importers:
       '@walletconnect/types':
         specifier: ^2.10.2
         version: 2.11.3
+      algosdk:
+        specifier: 2.8.0
+        version: 2.8.0
       lute-connect:
         specifier: ^1.2.0
         version: 1.2.0
@@ -383,16 +383,16 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@magic-ext/algorand':
         specifier: ^23.0.2
         version: 23.0.2
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        version: 2.0.11(algosdk@2.8.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@tanstack/react-store':
         specifier: 0.4.1
         version: 0.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -416,8 +416,8 @@ importers:
         specifier: ^18.2.45
         version: 18.2.70
       algosdk:
-        specifier: 2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       jsdom:
         specifier: ^24.0.0
         version: 24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -438,16 +438,16 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@magic-ext/algorand':
         specifier: ^23.0.2
         version: 23.0.2
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        version: 2.0.11(algosdk@2.8.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@tanstack/solid-store':
         specifier: 0.4.1
         version: 0.4.1(solid-js@1.8.16)
@@ -471,8 +471,8 @@ importers:
         specifier: ^0.8.5
         version: 0.8.7(solid-js@1.8.16)
       algosdk:
-        specifier: 2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       solid-js:
         specifier: ^1.8.11
         version: 1.8.16
@@ -490,16 +490,16 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@magic-ext/algorand':
         specifier: ^23.0.2
         version: 23.0.2
       '@perawallet/connect':
         specifier: ^1.3.4
-        version: 1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.11
-        version: 2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        version: 2.0.11(algosdk@2.8.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@tanstack/vue-store':
         specifier: 0.4.1
         version: 0.4.1(vue@3.4.21(typescript@5.4.3))
@@ -520,8 +520,8 @@ importers:
         version: 28.0.3
     devDependencies:
       algosdk:
-        specifier: 2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       tsup:
         specifier: ^8.0.0
         version: 8.0.2(postcss@8.4.38)(typescript@5.4.3)
@@ -2463,8 +2463,8 @@ packages:
     resolution: {integrity: sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==}
     engines: {node: '>= 10'}
 
-  algosdk@2.7.0:
-    resolution: {integrity: sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==}
+  algosdk@2.8.0:
+    resolution: {integrity: sha512-yjDH/VbQ689hxmn4PFbfXQrn4VZbYCGGzI/RD4ccA0yr55qT/TyAtR/dnq4XXX2pwCKNHbxOfantaJ5kTiwuMQ==}
     engines: {node: '>=18.0.0'}
 
   ansi-colors@4.1.3:
@@ -6955,11 +6955,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
-  '@blockshake/defly-connect@1.1.6(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@blockshake/defly-connect@1.1.6(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@walletconnect/client': 1.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@walletconnect/types': 1.8.0
-      algosdk: 2.7.0
+      algosdk: 2.8.0
       bowser: 2.11.0
       buffer: 6.0.3
       lottie-web: 5.12.2
@@ -7795,14 +7795,14 @@ snapshots:
 
   '@pedrouid/environment@1.0.1': {}
 
-  '@perawallet/connect-beta@2.0.11(algosdk@2.7.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@perawallet/connect-beta@2.0.11(algosdk@2.8.0)(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
       '@evanhahn/lottie-web-light': 5.8.1
       '@json-rpc-tools/utils': 1.7.6
       '@walletconnect/sign-client': 2.12.1(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.12.1
       '@walletconnect/utils': 2.12.1
-      algosdk: 2.7.0
+      algosdk: 2.8.0
       bowser: 2.11.0
       buffer: 6.0.3
       qr-code-styling: 1.6.0-rc.1
@@ -7825,12 +7825,12 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@perawallet/connect@1.3.4(algosdk@2.7.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@perawallet/connect@1.3.4(algosdk@2.8.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@evanhahn/lottie-web-light': 5.8.1
       '@walletconnect/client': 1.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@walletconnect/types': 1.8.0
-      algosdk: 2.7.0
+      algosdk: 2.8.0
       bowser: 2.11.0
       buffer: 6.0.3
       qr-code-styling: 1.6.0-rc.1
@@ -9230,7 +9230,7 @@ snapshots:
 
   algo-msgpack-with-bigint@2.1.1: {}
 
-  algosdk@2.7.0:
+  algosdk@2.8.0:
     dependencies:
       algo-msgpack-with-bigint: 2.1.1
       buffer: 6.0.3


### PR DESCRIPTION
While PR https://github.com/TxnLab/use-wallet/pull/193 moved `algosdk` to `peerDependencies` to ensure the library uses the same version as the consuming application, it also needed to be added to `devDependencies` in the core library to make it available in development.

This also updates all of the example apps and packages to use the same (latest) version, `2.8.0`.