### PR TITLE
fix: switching networks should not disconnect wallets

### DIFF
--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -41,8 +41,6 @@ export const useWallet = () => {
     if (networkId === activeNetwork) {
       return
     }
-    // Disconnect any connected wallets
-    await manager.disconnect()
 
     console.info(`[React] Creating Algodv2 client for ${networkId}...`)
 

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -88,8 +88,6 @@ export function useWallet() {
     if (activeNetwork() === networkId) {
       return
     }
-    // Disconnect any connected wallets
-    await manager().disconnect()
 
     console.info(`[Solid] Creating Algodv2 client for ${networkId}...`)
 

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -293,7 +293,9 @@ describe('useWallet', () => {
     const { setActiveNetwork, algodClient } = useWallet()
 
     const newNetwork = NetworkId.MAINNET
-    const newAlgodClient = new algosdk.Algodv2('mock-token', 'https://mock-server', '')
+
+    // Default mainnet algod config
+    const newAlgodClient = new algosdk.Algodv2('', 'https://mainnet-api.algonode.cloud/', '')
 
     mockWalletManager.setActiveNetwork = async (networkId: NetworkId) => {
       mockSetAlgodClient(newAlgodClient)

--- a/packages/use-wallet-vue/src/useWallet.ts
+++ b/packages/use-wallet-vue/src/useWallet.ts
@@ -40,8 +40,6 @@ export function useWallet() {
     if (networkId === activeNetwork.value) {
       return
     }
-    // Disconnect any connected wallets
-    await manager.disconnect()
 
     console.info(`[Vue] Creating Algodv2 client for ${networkId}...`)
 

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -207,35 +207,9 @@ describe('WalletManager', () => {
         [WalletId.KIBISIS, mockKibisisWallet]
       ])
 
-      // Mock isConnected to return true
-      vi.spyOn(mockDeflyWallet, 'isConnected', 'get').mockReturnValue(true)
-      vi.spyOn(mockKibisisWallet, 'isConnected', 'get').mockReturnValue(true)
-
-      const disconnectMock = vi.spyOn(manager, 'disconnect')
-
       await manager.setActiveNetwork(NetworkId.MAINNET)
 
-      expect(disconnectMock).toHaveBeenCalled()
       expect(manager.activeNetwork).toBe(NetworkId.MAINNET)
-    })
-
-    it('does not call disconnect if the network is already active', async () => {
-      const manager = new WalletManager({
-        wallets: [WalletId.DEFLY, WalletId.KIBISIS]
-      })
-      manager._clients = new Map<WalletId, BaseWallet>([
-        [WalletId.DEFLY, mockDeflyWallet],
-        [WalletId.KIBISIS, mockKibisisWallet]
-      ])
-
-      const disconnectMock = vi.spyOn(manager, 'disconnect')
-
-      // Set initial active network
-      manager.store.setState((state) => ({ ...state, activeNetwork: NetworkId.MAINNET }))
-
-      await manager.setActiveNetwork(NetworkId.MAINNET)
-
-      expect(disconnectMock).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/use-wallet/src/manager.ts
+++ b/packages/use-wallet/src/manager.ts
@@ -218,8 +218,6 @@ export class WalletManager {
     if (this.activeNetwork === networkId) {
       return
     }
-    // Disconnect any connected wallets
-    await this.disconnect()
 
     setActiveNetwork(this.store, { networkId })
     this.algodClient = this.createAlgodClient(this.networkConfig[networkId])


### PR DESCRIPTION
This reverts a feature that was added in https://github.com/TxnLab/use-wallet/pull/187 where any connected wallets would be disconnected when switching networks.

Some wallets will not work until you reconnect on the new network, but it should be the app's decision how to handle this.

The `WalletManager` still exposes a public `disconnect` method if this is the desired behavior.