### PR TITLE
fix(core): fix Webpack static analysis issue with dynamic imports

### DIFF
--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -51,7 +51,7 @@ export class DeflyWallet extends BaseWallet {
 
   private async initializeClient(): Promise<DeflyWalletConnect> {
     console.info(`[${this.metadata.name}] Initializing client...`)
-    const module = await import('@blockshake/defly-connect')
+    const module = await import(/* webpackIgnore: true */ '@blockshake/defly-connect')
     const DeflyWalletConnect = module.default
       ? module.default.DeflyWalletConnect
       : module.DeflyWalletConnect

--- a/packages/use-wallet/src/wallets/kibisis.ts
+++ b/packages/use-wallet/src/wallets/kibisis.ts
@@ -208,7 +208,9 @@ export class KibisisWallet extends BaseWallet {
         `[${KibisisWallet.name}]#${_functionName}: initializing @agoralabs-sh/avm-web-provider...`
       )
 
-      this.avmWebProviderSDK = await import('@agoralabs-sh/avm-web-provider')
+      this.avmWebProviderSDK = await import(
+        /* webpackIgnore: true */ '@agoralabs-sh/avm-web-provider'
+      )
 
       if (!this.avmWebProviderSDK) {
         throw new Error(

--- a/packages/use-wallet/src/wallets/lute.ts
+++ b/packages/use-wallet/src/wallets/lute.ts
@@ -55,7 +55,7 @@ export class LuteWallet extends BaseWallet {
 
   private async initializeClient(): Promise<LuteConnect> {
     console.info(`[${this.metadata.name}] Initializing client...`)
-    const module = await import('lute-connect')
+    const module = await import(/* webpackIgnore: true */ 'lute-connect')
     const LuteConnect = module.default
 
     const client = new LuteConnect(this.options.siteName as string)

--- a/packages/use-wallet/src/wallets/magic.ts
+++ b/packages/use-wallet/src/wallets/magic.ts
@@ -71,8 +71,9 @@ export class MagicAuth extends BaseWallet {
 
   private async initializeClient(): Promise<MagicAuthClient> {
     console.info(`[${this.metadata.name}] Initializing client...`)
-    const Magic = (await import('magic-sdk')).Magic
-    const AlgorandExtension = (await import('@magic-ext/algorand')).AlgorandExtension
+    const Magic = (await import(/* webpackIgnore: true */ 'magic-sdk')).Magic
+    const AlgorandExtension = (await import(/* webpackIgnore: true */ '@magic-ext/algorand'))
+      .AlgorandExtension
     const client = new Magic(this.options.apiKey as string, {
       extensions: {
         algorand: new AlgorandExtension({

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -56,7 +56,7 @@ export class PeraWallet extends BaseWallet {
 
   private async initializeClient(): Promise<PeraWalletConnect> {
     console.info(`[${this.metadata.name}] Initializing client...`)
-    const module = await import('@perawallet/connect')
+    const module = await import(/* webpackIgnore: true */ '@perawallet/connect')
     const PeraWalletConnect = module.default
       ? module.default.PeraWalletConnect
       : module.PeraWalletConnect

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -60,7 +60,7 @@ export class PeraWallet extends BaseWallet {
 
   private async initializeClient(): Promise<PeraWalletConnect> {
     console.info(`[${this.metadata.name}] Initializing client...`)
-    const module = await import('@perawallet/connect-beta')
+    const module = await import(/* webpackIgnore: true */ '@perawallet/connect-beta')
 
     const PeraWalletConnect = module.PeraWalletConnect || module.default.PeraWalletConnect
 

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -262,7 +262,8 @@ export class WalletConnect extends BaseWallet {
 
   private async initializeClient(): Promise<SignClient> {
     console.info(`[${this.metadata.name}] Initializing client...`)
-    const SignClient = (await import('@walletconnect/sign-client')).SignClient
+    const SignClient = (await import(/* webpackIgnore: true */ '@walletconnect/sign-client'))
+      .SignClient
     const client = await SignClient.init(this.options)
 
     client.on('session_event', (args) => {
@@ -288,7 +289,8 @@ export class WalletConnect extends BaseWallet {
 
   private async initializeModal(): Promise<WalletConnectModal> {
     console.info(`[${this.metadata.name}] Initializing modal...`)
-    const WalletConnectModal = (await import('@walletconnect/modal')).WalletConnectModal
+    const WalletConnectModal = (await import(/* webpackIgnore: true */ '@walletconnect/modal'))
+      .WalletConnectModal
     const modal = new WalletConnectModal({
       projectId: this.options.projectId,
       chains: this.chains,


### PR DESCRIPTION
## Description

This PR addresses an issue where Webpack's static analysis was attempting to resolve all potential dynamic imports at build time, causing "module not found" errors for optional dependencies that weren't installed.

Adding the [magic comment](https://webpack.js.org/api/module-methods/#magic-comments) `/* webpackIgnore: true */` to all dynamic imports in the core library tells Webpack to ignore these imports during its static analysis phase.

This resolves "module not found" errors for uninstalled optional dependencies in consuming applications with Webpack build systems, particularly Next.js.