### PR TITLE
fix(nextjs): resolve Webpack "module not found" errors

### DIFF
--- a/examples/nextjs/next.config.mjs
+++ b/examples/nextjs/next.config.mjs
@@ -1,8 +1,30 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  /** @see https://github.com/WalletConnect/walletconnect-monorepo/issues/1908#issuecomment-1487801131 */
-  webpack: (config) => {
+  webpack: (config, { isServer }) => {
+    /** @see https://github.com/WalletConnect/walletconnect-monorepo/issues/1908#issuecomment-1487801131 */
     config.externals.push('pino-pretty', 'lokijs', 'encoding')
+
+    /**
+     * Provide fallbacks for optional wallet dependencies.
+     * This allows the app to build and run without these packages installed,
+     * enabling users to include only the wallet packages they need.
+     * Each package is set to 'false', which means Webpack will provide an empty module
+     * if the package is not found, preventing build errors for unused wallets.
+     */
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        '@agoralabs-sh/avm-web-provider': false,
+        '@blockshake/defly-connect': false,
+        '@magic-ext/algorand': false,
+        '@perawallet/connect': false,
+        '@perawallet/connect-beta': false,
+        '@walletconnect/modal': false,
+        '@walletconnect/sign-client': false,
+        'lute-connect': false,
+        'magic-sdk': false
+      }
+    }
     return config
   }
 }


### PR DESCRIPTION
## Description

This PR addresses the "module not found" errors that occur when using `@txnlab/use-wallet-react` in Next.js applications. These errors were caused by Webpack attempting to resolve optional wallet dependencies, even when they weren't installed or used in the project.

The [first attempt](https://github.com/TxnLab/use-wallet/pull/211) to resolve these errors in the library itself appeared in https://github.com/TxnLab/use-wallet/releases/tag/v3.1.1. It introduced another error and had to be reverted in https://github.com/TxnLab/use-wallet/releases/tag/v3.1.2.

## Solution

- Updated the Next.js example in the monorepo to include a Webpack configuration that provides fallbacks for optional wallet dependencies.
- The solution uses Webpack's `resolve.fallback` configuration to provide empty modules for optional dependencies when they're not found. This is implemented only for client-side bundles to avoid affecting server-side rendering.
- Tested with various combinations of installed and uninstalled wallet packages in a fresh Next.js installation using Create Next App.
- Verified that the Next.js v14 example builds and runs correctly with this configuration.

TODO: Update the documentation to include guidance for Next.js users on how to implement this configuration in their projects.