### PR TITLE
feat: move the algod client to store

### DIFF
--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -94,8 +94,6 @@ export function useWallet() {
     const { token, baseServer, port, headers } = manager().networkConfig[networkId]
     const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
 
-    manager().algodClient = newClient
-
     manager().store.setState((state) => ({
       ...state,
       activeNetwork: networkId,

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -301,7 +301,8 @@ describe('useWallet', () => {
       mockSetAlgodClient(newAlgodClient)
       mockWalletManager.store.setState((state) => ({
         ...state,
-        activeNetwork: networkId
+        activeNetwork: networkId,
+        algodClient: newAlgodClient
       }))
     }
 

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -303,11 +303,10 @@ describe('WalletManager', () => {
 
   describe('savePersistedState', () => {
     it('saves state to local storage', async () => {
-      const stateToSave: State = {
+      const stateToSave: Omit<State, 'algodClient'> = {
         wallets: {},
         activeWallet: null,
-        activeNetwork: NetworkId.MAINNET,
-        algodClient: new Algodv2('', 'https://testnet-api.algonode.cloud/')
+        activeNetwork: NetworkId.MAINNET
       }
 
       const manager = new WalletManager({

--- a/packages/use-wallet/src/__tests__/store.test.ts
+++ b/packages/use-wallet/src/__tests__/store.test.ts
@@ -427,7 +427,7 @@ describe('Mutations', () => {
 
       const networkId = NetworkId.MAINNET
       const algodClient = new Algodv2('', 'https://mainnet-api.algonode.cloud/')
-      setActiveNetwork(store, { networkId }, algodClient)
+      setActiveNetwork(store, { networkId, algodClient })
       expect(store.state.activeNetwork).toBe(networkId)
     })
   })

--- a/packages/use-wallet/src/__tests__/store.test.ts
+++ b/packages/use-wallet/src/__tests__/store.test.ts
@@ -426,7 +426,8 @@ describe('Mutations', () => {
       expect(store.state.activeNetwork).toBe(NetworkId.TESTNET)
 
       const networkId = NetworkId.MAINNET
-      setActiveNetwork(store, { networkId })
+      const algodClient = new Algodv2('', 'https://mainnet-api.algonode.cloud/')
+      setActiveNetwork(store, { networkId }, algodClient)
       expect(store.state.activeNetwork).toBe(networkId)
     })
   })

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -143,10 +143,15 @@ export function setAccounts(
   })
 }
 
-export function setActiveNetwork(store: Store<State>, { networkId }: { networkId: NetworkId }) {
+export function setActiveNetwork(
+  store: Store<State>,
+  { networkId }: { networkId: NetworkId },
+  algodClient: Algodv2
+) {
   store.setState((state) => ({
     ...state,
-    activeNetwork: networkId
+    activeNetwork: networkId,
+    algodClient: algodClient
   }))
 }
 

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -145,13 +145,12 @@ export function setAccounts(
 
 export function setActiveNetwork(
   store: Store<State>,
-  { networkId }: { networkId: NetworkId },
-  algodClient: Algodv2
+  { networkId, algodClient }: { networkId: NetworkId; algodClient: Algodv2 }
 ) {
   store.setState((state) => ({
     ...state,
     activeNetwork: networkId,
-    algodClient: algodClient
+    algodClient
   }))
 }
 


### PR DESCRIPTION
This is to address issue #213 

- replaced the `algodClient` prop on the `WalletManager` with a getter and setter that point to the `store`
- removed `algodClient` from persisted storage - the re-serialization makes it useless anyway
- `setActiveNetwork` on `store` now takes `algodClient` as a parameter
- tests were updated to reflect the changes
