### PR TITLE
fix(core): update algosdk import to resolve CommonJS module issue

### DIFF
--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -1,4 +1,4 @@
-import { Algodv2 } from 'algosdk'
+import algosdk from 'algosdk'
 import { NetworkId, isValidNetworkId } from 'src/network'
 import { WalletId, type WalletAccount } from 'src/wallets'
 import type { Store } from '@tanstack/store'
@@ -14,14 +14,14 @@ export interface State {
   wallets: WalletStateMap
   activeWallet: WalletId | null
   activeNetwork: NetworkId
-  algodClient: Algodv2
+  algodClient: algosdk.Algodv2
 }
 
 export const defaultState: State = {
   wallets: {},
   activeWallet: null,
   activeNetwork: NetworkId.TESTNET,
-  algodClient: new Algodv2('', 'https://testnet-api.4160.nodely.dev/')
+  algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/')
 }
 
 export const LOCAL_STORAGE_KEY = '@txnlab/use-wallet:v3'
@@ -145,7 +145,7 @@ export function setAccounts(
 
 export function setActiveNetwork(
   store: Store<State>,
-  { networkId, algodClient }: { networkId: NetworkId; algodClient: Algodv2 }
+  { networkId, algodClient }: { networkId: NetworkId; algodClient: algosdk.Algodv2 }
 ) {
   store.setState((state) => ({
     ...state,


### PR DESCRIPTION
## Description

This PR updates the import of `Algodv2` from `algosdk` in `src/store.ts` to resolve a SyntaxError occurring in some consuming applications that use CommonJS modules.

## Details

- Changed the import of `algosdk` from named import to default import
- Updated all references to `Algodv2` to use the default import syntax
- Resolves the error: "SyntaxError: Named export 'Algodv2' not found. The requested module 'algosdk' is a CommonJS module, which may not support all module.exports as named exports."

Closes #216