### PR TITLE
feat(wallets): add WalletConnect v1 session management

### DIFF
--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -38,7 +38,8 @@ vi.mock('src/logger', () => {
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/custom.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/custom.test.ts
@@ -22,7 +22,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/defly.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/defly.test.ts
@@ -23,7 +23,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 
@@ -87,9 +88,14 @@ describe('DeflyWallet', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
+    let mockWalletConnectData: string | null = null
+
     vi.mocked(StorageAdapter.getItem).mockImplementation((key: string) => {
       if (key === LOCAL_STORAGE_KEY && mockInitialState !== null) {
         return JSON.stringify(mockInitialState)
+      }
+      if (key === 'walletconnect') {
+        return mockWalletConnectData
       }
       return null
     })
@@ -97,6 +103,15 @@ describe('DeflyWallet', () => {
     vi.mocked(StorageAdapter.setItem).mockImplementation((key: string, value: string) => {
       if (key === LOCAL_STORAGE_KEY) {
         mockInitialState = JSON.parse(value)
+      }
+      if (key.startsWith('walletconnect-')) {
+        mockWalletConnectData = value
+      }
+    })
+
+    vi.mocked(StorageAdapter.removeItem).mockImplementation((key: string) => {
+      if (key === 'walletconnect') {
+        mockWalletConnectData = null
       }
     })
 
@@ -198,6 +213,99 @@ describe('DeflyWallet', () => {
       }
 
       expect(store.state.wallets[WalletId.DEFLY]).toBeUndefined()
+    })
+  })
+
+  describe('manageWalletConnectSession', () => {
+    it('should backup WalletConnect session when connecting', async () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+      mockDeflyWallet.connect.mockResolvedValueOnce([account1.address])
+
+      // Set Pera as the active wallet
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.PERA
+      }))
+
+      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
+
+      await wallet.connect()
+
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('backup')
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
+      expect(StorageAdapter.setItem).toHaveBeenCalledWith(
+        `walletconnect-${WalletId.PERA}`,
+        mockWalletConnectData
+      )
+      expect(StorageAdapter.removeItem).toHaveBeenCalledWith('walletconnect')
+    })
+
+    it('should not backup WalletConnect session if no data exists', async () => {
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(null)
+      mockDeflyWallet.connect.mockResolvedValueOnce([account1.address])
+
+      await wallet.connect()
+
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
+      expect(StorageAdapter.setItem).not.toHaveBeenCalled()
+      expect(StorageAdapter.removeItem).not.toHaveBeenCalled()
+    })
+
+    it('should not backup WalletConnect session when Pera is already active', async () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+      mockDeflyWallet.connect.mockResolvedValueOnce([account1.address])
+
+      // Set Defly as the active wallet
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.DEFLY
+      }))
+
+      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
+
+      await wallet.connect()
+
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('backup')
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
+      expect(StorageAdapter.setItem).not.toHaveBeenCalled()
+      expect(StorageAdapter.removeItem).not.toHaveBeenCalled()
+    })
+
+    it('should restore WalletConnect session when setting active', async () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.PERA,
+        wallets: {
+          ...state.wallets,
+          [WalletId.DEFLY]: { accounts: [account1], activeAccount: account1 },
+          [WalletId.PERA]: { accounts: [account2], activeAccount: account2 }
+        }
+      }))
+
+      wallet.setActive()
+
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
+      expect(StorageAdapter.setItem).toHaveBeenCalledWith(
+        `walletconnect-${WalletId.PERA}`,
+        mockWalletConnectData
+      )
+      expect(StorageAdapter.removeItem).toHaveBeenCalledWith('walletconnect')
+      expect(store.state.activeWallet).toBe(WalletId.DEFLY)
+    })
+
+    it('should not restore WalletConnect session if no backup exists', () => {
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(null)
+
+      wallet.setActive()
+
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith(`walletconnect-${WalletId.DEFLY}`)
+      expect(StorageAdapter.setItem).not.toHaveBeenCalled()
+      expect(StorageAdapter.removeItem).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
@@ -24,7 +24,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
@@ -33,7 +33,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
@@ -23,7 +23,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/lute.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/lute.test.ts
@@ -24,7 +24,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/magic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/magic.test.ts
@@ -24,7 +24,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
@@ -29,7 +29,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/pera.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera.test.ts
@@ -169,6 +169,29 @@ describe('PeraWallet', () => {
 
       expect(mockPeraWallet.connector.on).toHaveBeenCalledWith('disconnect', expect.any(Function))
     })
+
+    it('should backup WalletConnect session when connecting and another wallet is active', async () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
+
+      // Set Defly as the active wallet
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.DEFLY
+      }))
+
+      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
+
+      await wallet.connect()
+
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('backup', WalletId.DEFLY)
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
+      expect(StorageAdapter.setItem).toHaveBeenCalledWith(
+        `walletconnect-${WalletId.DEFLY}`,
+        mockWalletConnectData
+      )
+    })
   })
 
   describe('disconnect', () => {
@@ -183,6 +206,87 @@ describe('PeraWallet', () => {
       expect(wallet.isConnected).toBe(false)
     })
 
+    it('should backup and restore active wallet session when disconnecting non-active wallet', async () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
+      await wallet.connect()
+
+      // Set Defly as the active wallet
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.DEFLY
+      }))
+
+      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
+
+      await wallet.disconnect()
+
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('backup', WalletId.DEFLY)
+      expect(mockPeraWallet.disconnect).toHaveBeenCalled()
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('restore', WalletId.DEFLY)
+      expect(store.state.wallets[WalletId.PERA]).toBeUndefined()
+    })
+
+    it('should not backup or restore session when disconnecting active wallet', async () => {
+      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
+      await wallet.connect()
+
+      // Set Pera as the active wallet
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.PERA
+      }))
+
+      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
+
+      await wallet.disconnect()
+
+      expect(manageWalletConnectSessionSpy).not.toHaveBeenCalled()
+      expect(mockPeraWallet.disconnect).toHaveBeenCalled()
+      expect(store.state.wallets[WalletId.PERA]).toBeUndefined()
+    })
+
+    it('should backup active wallet, restore inactive wallet, disconnect, and restore active wallet when disconnecting an inactive wallet', async () => {
+      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
+      await wallet.connect()
+
+      // Set Defly as the active wallet
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.DEFLY
+      }))
+
+      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
+
+      await wallet.disconnect()
+
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('backup', WalletId.DEFLY)
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('restore', WalletId.PERA)
+      expect(mockPeraWallet.disconnect).toHaveBeenCalled()
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('restore', WalletId.DEFLY)
+      expect(store.state.wallets[WalletId.PERA]).toBeUndefined()
+    })
+
+    it('should not remove backup when disconnecting the active wallet', async () => {
+      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
+      await wallet.connect()
+
+      // Set Pera as the active wallet
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.PERA
+      }))
+
+      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
+
+      await wallet.disconnect()
+
+      expect(manageWalletConnectSessionSpy).not.toHaveBeenCalled()
+      expect(mockPeraWallet.disconnect).toHaveBeenCalled()
+      expect(store.state.wallets[WalletId.PERA]).toBeUndefined()
+    })
+
     it('should throw an error if client.disconnect fails', async () => {
       mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
       mockPeraWallet.disconnect.mockRejectedValueOnce(new Error('Disconnect error'))
@@ -191,9 +295,8 @@ describe('PeraWallet', () => {
 
       await expect(wallet.disconnect()).rejects.toThrow('Disconnect error')
 
-      // Should still update store/state
-      expect(store.state.wallets[WalletId.PERA]).toBeUndefined()
-      expect(wallet.isConnected).toBe(false)
+      expect(store.state.wallets[WalletId.PERA]).toBeDefined()
+      expect(wallet.isConnected).toBe(true)
     })
   })
 
@@ -213,99 +316,6 @@ describe('PeraWallet', () => {
       }
 
       expect(store.state.wallets[WalletId.PERA]).toBeUndefined()
-    })
-  })
-
-  describe('manageWalletConnectSession', () => {
-    it('should backup WalletConnect session when connecting', async () => {
-      const mockWalletConnectData = 'mockWalletConnectData'
-      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
-      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
-
-      // Set Defly as the active wallet
-      store.setState((state) => ({
-        ...state,
-        activeWallet: WalletId.DEFLY
-      }))
-
-      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
-
-      await wallet.connect()
-
-      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('backup')
-      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
-      expect(StorageAdapter.setItem).toHaveBeenCalledWith(
-        `walletconnect-${WalletId.DEFLY}`,
-        mockWalletConnectData
-      )
-      expect(StorageAdapter.removeItem).toHaveBeenCalledWith('walletconnect')
-    })
-
-    it('should not backup WalletConnect session if no data exists', async () => {
-      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(null)
-      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
-
-      await wallet.connect()
-
-      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
-      expect(StorageAdapter.setItem).not.toHaveBeenCalled()
-      expect(StorageAdapter.removeItem).not.toHaveBeenCalled()
-    })
-
-    it('should not backup WalletConnect session when Pera is already active', async () => {
-      const mockWalletConnectData = 'mockWalletConnectData'
-      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
-      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
-
-      // Set Pera as the active wallet
-      store.setState((state) => ({
-        ...state,
-        activeWallet: WalletId.PERA
-      }))
-
-      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
-
-      await wallet.connect()
-
-      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('backup')
-      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
-      expect(StorageAdapter.setItem).not.toHaveBeenCalled()
-      expect(StorageAdapter.removeItem).not.toHaveBeenCalled()
-    })
-
-    it('should restore WalletConnect session when setting active', async () => {
-      const mockWalletConnectData = 'mockWalletConnectData'
-      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
-
-      store.setState((state) => ({
-        ...state,
-        activeWallet: WalletId.DEFLY,
-        wallets: {
-          ...state.wallets,
-          [WalletId.DEFLY]: { accounts: [account1], activeAccount: account1 },
-          [WalletId.PERA]: { accounts: [account2], activeAccount: account2 }
-        }
-      }))
-
-      wallet.setActive()
-
-      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
-      expect(StorageAdapter.setItem).toHaveBeenCalledWith(
-        `walletconnect-${WalletId.DEFLY}`,
-        mockWalletConnectData
-      )
-      expect(StorageAdapter.removeItem).toHaveBeenCalledWith('walletconnect')
-      expect(store.state.activeWallet).toBe(WalletId.PERA)
-    })
-
-    it('should not restore WalletConnect session if no backup exists', () => {
-      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(null)
-
-      wallet.setActive()
-
-      expect(StorageAdapter.getItem).toHaveBeenCalledWith(`walletconnect-${WalletId.PERA}`)
-      expect(StorageAdapter.setItem).not.toHaveBeenCalled()
-      expect(StorageAdapter.removeItem).not.toHaveBeenCalled()
     })
   })
 
@@ -438,6 +448,94 @@ describe('PeraWallet', () => {
       await expect(wallet.resumeSession()).rejects.toThrow('No accounts found!')
       expect(store.state.wallets[WalletId.PERA]).toBeUndefined()
       expect(wallet.isConnected).toBe(false)
+    })
+  })
+
+  describe('setActive', () => {
+    it('should set the wallet as active', async () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+      mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
+
+      await wallet.connect()
+      wallet.setActive()
+
+      expect(store.state.activeWallet).toBe(WalletId.PERA)
+      expect(StorageAdapter.setItem).toHaveBeenCalledWith('walletconnect', mockWalletConnectData)
+      expect(StorageAdapter.removeItem).toHaveBeenCalledWith(`walletconnect-${WalletId.PERA}`)
+    })
+
+    it('should backup current active wallet session and restore Pera session when setting active', async () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+
+      store.setState((state) => ({
+        ...state,
+        activeWallet: WalletId.DEFLY,
+        wallets: {
+          ...state.wallets,
+          [WalletId.DEFLY]: { accounts: [account1], activeAccount: account1 },
+          [WalletId.PERA]: { accounts: [account2], activeAccount: account2 }
+        }
+      }))
+
+      const manageWalletConnectSessionSpy = vi.spyOn(wallet, 'manageWalletConnectSession' as any)
+
+      wallet.setActive()
+
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('backup', WalletId.DEFLY)
+      expect(manageWalletConnectSessionSpy).toHaveBeenCalledWith('restore')
+      expect(store.state.activeWallet).toBe(WalletId.PERA)
+    })
+  })
+
+  describe('manageWalletConnectSession', () => {
+    it('should backup WalletConnect session', async () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+
+      // @ts-expect-error - Accessing private method for testing
+      wallet.manageWalletConnectSession('backup', WalletId.DEFLY)
+
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
+      expect(StorageAdapter.setItem).toHaveBeenCalledWith(
+        `walletconnect-${WalletId.DEFLY}`,
+        mockWalletConnectData
+      )
+    })
+
+    it('should not backup WalletConnect session if no data exists', async () => {
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(null)
+
+      // @ts-expect-error - Accessing private method for testing
+      wallet.manageWalletConnectSession('backup', WalletId.DEFLY)
+
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith('walletconnect')
+      expect(StorageAdapter.setItem).not.toHaveBeenCalled()
+      expect(StorageAdapter.removeItem).not.toHaveBeenCalled()
+    })
+
+    it('should restore WalletConnect session', () => {
+      const mockWalletConnectData = 'mockWalletConnectData'
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(mockWalletConnectData)
+
+      // @ts-expect-error - Accessing private method for testing
+      wallet.manageWalletConnectSession('restore')
+
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith(`walletconnect-${WalletId.PERA}`)
+      expect(StorageAdapter.setItem).toHaveBeenCalledWith('walletconnect', mockWalletConnectData)
+      expect(StorageAdapter.removeItem).toHaveBeenCalledWith(`walletconnect-${WalletId.PERA}`)
+    })
+
+    it('should not restore WalletConnect session if no backup exists', () => {
+      vi.mocked(StorageAdapter.getItem).mockReturnValueOnce(null)
+
+      // @ts-expect-error - Accessing private method for testing
+      wallet.manageWalletConnectSession('restore')
+
+      expect(StorageAdapter.getItem).toHaveBeenCalledWith(`walletconnect-${WalletId.PERA}`)
+      expect(StorageAdapter.setItem).not.toHaveBeenCalled()
+      expect(StorageAdapter.removeItem).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
@@ -23,7 +23,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
@@ -27,7 +27,8 @@ vi.mock('src/logger', () => ({
 vi.mock('src/storage', () => ({
   StorageAdapter: {
     getItem: vi.fn(),
-    setItem: vi.fn()
+    setItem: vi.fn(),
+    removeItem: vi.fn()
   }
 }))
 

--- a/packages/use-wallet/src/storage.ts
+++ b/packages/use-wallet/src/storage.ts
@@ -12,4 +12,11 @@ export class StorageAdapter {
     }
     localStorage.setItem(key, value)
   }
+
+  static removeItem(key: string): void {
+    if (typeof window === 'undefined') {
+      return
+    }
+    localStorage.removeItem(key)
+  }
 }

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -10,7 +10,6 @@ import type {
   WalletConstructor,
   WalletId
 } from 'src/wallets/types'
-import { StorageAdapter } from 'src/storage'
 
 export interface DeflyWalletConnectOptions {
   bridge?: string
@@ -63,30 +62,12 @@ export class DeflyWallet extends BaseWallet {
     return client
   }
 
-  private manageWalletConnectSession(action: 'backup' | 'restore'): void {
-    if (action === 'backup') {
-      const data = StorageAdapter.getItem('walletconnect')
-      if (data) {
-        const currentActiveWallet = this.store.state.activeWallet
-        if (currentActiveWallet && currentActiveWallet !== this.id) {
-          StorageAdapter.setItem(`walletconnect-${currentActiveWallet}`, data)
-          StorageAdapter.removeItem('walletconnect')
-          this.logger.debug(`Backed up WalletConnect session for ${currentActiveWallet}`)
-        }
-      }
-    } else if (action === 'restore') {
-      const data = StorageAdapter.getItem(`walletconnect-${this.id}`)
-      if (data) {
-        StorageAdapter.setItem('walletconnect', data)
-        StorageAdapter.removeItem(`walletconnect-${this.id}`)
-        this.logger.debug(`Restored WalletConnect session for ${this.id}`)
-      }
-    }
-  }
-
   public connect = async (): Promise<WalletAccount[]> => {
     this.logger.info('Connecting...')
-    this.manageWalletConnectSession('backup')
+    const currentActiveWallet = this.store.state.activeWallet
+    if (currentActiveWallet && currentActiveWallet !== this.id) {
+      this.manageWalletConnectSession('backup', currentActiveWallet)
+    }
     const client = this.client || (await this.initializeClient())
     const accounts = await client.connect()
 
@@ -121,15 +102,30 @@ export class DeflyWallet extends BaseWallet {
 
   public disconnect = async (): Promise<void> => {
     this.logger.info('Disconnecting...')
-    this.onDisconnect()
     const client = this.client || (await this.initializeClient())
-    await client.disconnect()
-    this.logger.info('Disconnected.')
+
+    const currentActiveWallet = this.store.state.activeWallet
+    if (currentActiveWallet && currentActiveWallet !== this.id) {
+      this.manageWalletConnectSession('backup', currentActiveWallet)
+      this.manageWalletConnectSession('restore', this.id)
+      await client.disconnect()
+      // Wait for the disconnect to complete (race condition)
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      this.manageWalletConnectSession('restore', currentActiveWallet)
+    } else {
+      await client.disconnect()
+    }
+
+    this.onDisconnect()
+    this.logger.info('Disconnected')
   }
 
   public setActive = (): void => {
     this.logger.info(`Set active wallet: ${this.id}`)
-    this.manageWalletConnectSession('backup')
+    const currentActiveWallet = this.store.state.activeWallet
+    if (currentActiveWallet && currentActiveWallet !== this.id) {
+      this.manageWalletConnectSession('backup', currentActiveWallet)
+    }
     this.manageWalletConnectSession('restore')
     setActiveWallet(this.store, { walletId: this.id })
   }

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -1,5 +1,5 @@
 import algosdk from 'algosdk'
-import { WalletState, addWallet, setAccounts, type State } from 'src/store'
+import { WalletState, addWallet, setAccounts, setActiveWallet, type State } from 'src/store'
 import { compareAccounts, flattenTxnGroup, isSignedTxn, isTransactionArray } from 'src/utils'
 import { BaseWallet } from 'src/wallets/base'
 import type { PeraWalletConnect } from '@perawallet/connect'
@@ -10,6 +10,7 @@ import type {
   WalletConstructor,
   WalletId
 } from 'src/wallets/types'
+import { StorageAdapter } from 'src/storage'
 
 export interface PeraWalletConnectOptions {
   bridge?: string
@@ -67,8 +68,30 @@ export class PeraWallet extends BaseWallet {
     return client
   }
 
+  private manageWalletConnectSession(action: 'backup' | 'restore'): void {
+    if (action === 'backup') {
+      const data = StorageAdapter.getItem('walletconnect')
+      if (data) {
+        const currentActiveWallet = this.store.state.activeWallet
+        if (currentActiveWallet && currentActiveWallet !== this.id) {
+          StorageAdapter.setItem(`walletconnect-${currentActiveWallet}`, data)
+          StorageAdapter.removeItem('walletconnect')
+          this.logger.debug(`Backed up WalletConnect session for ${currentActiveWallet}`)
+        }
+      }
+    } else if (action === 'restore') {
+      const data = StorageAdapter.getItem(`walletconnect-${this.id}`)
+      if (data) {
+        StorageAdapter.setItem('walletconnect', data)
+        StorageAdapter.removeItem(`walletconnect-${this.id}`)
+        this.logger.debug(`Restored WalletConnect session for ${this.id}`)
+      }
+    }
+  }
+
   public connect = async (): Promise<WalletAccount[]> => {
     this.logger.info('Connecting...')
+    this.manageWalletConnectSession('backup')
     const client = this.client || (await this.initializeClient())
     const accounts = await client.connect()
 
@@ -107,6 +130,13 @@ export class PeraWallet extends BaseWallet {
     const client = this.client || (await this.initializeClient())
     await client.disconnect()
     this.logger.info('Disconnected')
+  }
+
+  public setActive = (): void => {
+    this.logger.info(`Set active wallet: ${this.id}`)
+    this.manageWalletConnectSession('backup')
+    this.manageWalletConnectSession('restore')
+    setActiveWallet(this.store, { walletId: this.id })
   }
 
   public resumeSession = async (): Promise<void> => {


### PR DESCRIPTION
## Description

This PR fixes the WalletConnect session management for Defly and Pera wallets, addressing the issues with session persistence and wallet switching described in issue #274. It implements a more robust approach to backing up and restoring WalletConnect sessions, resolving the problems with lost connections and improving overall wallet management reliability.

## Details

- Added `manageWalletConnectSession` method to `BaseWallet` class for centralized session management
- Updated `connect`, `disconnect`, and `setActive` methods in Defly and Pera (v1) wallet classes to use the new session management approach
- Implemented proper session backup and restoration when switching between wallets
- Added a delay after `client.disconnect()` to prevent race conditions
- Updated and expanded test cases to cover new functionality and edge cases

These changes ensure that WalletConnect sessions are properly maintained when connecting multiple wallets, preventing local storage key collisions and fixing issues caused by lost session data.

Closes #274