### PR TITLE
fix(core): remove circular import in store.ts & MnemonicWallet

### DIFF
--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -1,7 +1,7 @@
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { NetworkId, isValidNetworkId } from 'src/network'
-import { WalletId, type WalletAccount } from 'src/wallets'
+import { WalletId, type WalletAccount } from 'src/wallets/types'
 import type { Store } from '@tanstack/store'
 
 export type WalletState = {


### PR DESCRIPTION
I haven't encountered a bug this gnarly in a while. 🤣

The circular import: `src/wallets/mnemonic` imports `src/store`, which imports a few types from `src/wallets`. The `src/wallets/mnemonic` is still loaded when `src/store` imports `src/wallet` despite nothing from `src/wallets/mnemonic` being used.

In short, `src/wallets/mnemonic` imports `src/store`, which indirectly imports `src/wallets/mnemonic`.

This circular import caused an odd issue where the persisted mnemonic had "undefined_mnemonic" as the key in localStorage because `LOCAL_STORAGE_KEY` constant (defined in `src/store.ts` before building the package) was used before it was defined in the `dist/index.js` build output file. The bundler got confused by the circular import and put the modules in the resulting `dist/index.js` in the wrong order.