### PR TITLE
fix(wallet): limit WalletConnect backup to Defly and Pera

### DIFF
--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -2,14 +2,10 @@ import algosdk from 'algosdk'
 import { WalletState, addWallet, setAccounts, setActiveWallet, type State } from 'src/store'
 import { compareAccounts, flattenTxnGroup, isSignedTxn, isTransactionArray } from 'src/utils'
 import { BaseWallet } from 'src/wallets/base'
+import { WalletId } from 'src/wallets/types'
 import type { DeflyWalletConnect } from '@blockshake/defly-connect'
 import type { Store } from '@tanstack/store'
-import type {
-  SignerTransaction,
-  WalletAccount,
-  WalletConstructor,
-  WalletId
-} from 'src/wallets/types'
+import type { SignerTransaction, WalletAccount, WalletConstructor } from 'src/wallets/types'
 
 export interface DeflyWalletConnectOptions {
   bridge?: string
@@ -123,7 +119,7 @@ export class DeflyWallet extends BaseWallet {
   public setActive = (): void => {
     this.logger.info(`Set active wallet: ${this.id}`)
     const currentActiveWallet = this.store.state.activeWallet
-    if (currentActiveWallet && currentActiveWallet !== this.id) {
+    if (currentActiveWallet && currentActiveWallet === WalletId.PERA) {
       this.manageWalletConnectSession('backup', currentActiveWallet)
     }
     this.manageWalletConnectSession('restore')

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -2,14 +2,10 @@ import algosdk from 'algosdk'
 import { WalletState, addWallet, setAccounts, setActiveWallet, type State } from 'src/store'
 import { compareAccounts, flattenTxnGroup, isSignedTxn, isTransactionArray } from 'src/utils'
 import { BaseWallet } from 'src/wallets/base'
+import { WalletId } from 'src/wallets/types'
 import type { PeraWalletConnect } from '@perawallet/connect'
 import type { Store } from '@tanstack/store'
-import type {
-  SignerTransaction,
-  WalletAccount,
-  WalletConstructor,
-  WalletId
-} from 'src/wallets/types'
+import type { SignerTransaction, WalletAccount, WalletConstructor } from 'src/wallets/types'
 
 export interface PeraWalletConnectOptions {
   bridge?: string
@@ -128,7 +124,7 @@ export class PeraWallet extends BaseWallet {
   public setActive = (): void => {
     this.logger.info(`Set active wallet: ${this.id}`)
     const currentActiveWallet = this.store.state.activeWallet
-    if (currentActiveWallet && currentActiveWallet !== this.id) {
+    if (currentActiveWallet && currentActiveWallet === WalletId.DEFLY) {
       this.manageWalletConnectSession('backup', currentActiveWallet)
     }
     this.manageWalletConnectSession('restore')


### PR DESCRIPTION
## Description

This PR refines the WalletConnect session management fix implemented in PR #275. It addresses an oversight where backups were being created for all wallet types, not just Defly and Pera which use WalletConnect v1.

## Details

- Updated `setActive` method in `DeflyWallet` to only backup Pera wallet sessions
- Updated `setActive` method in `PeraWallet` to only backup Defly wallet sessions
- Ensured WalletConnect sessions are only backed up for relevant wallets (Defly and Pera)

These changes further improve the reliability of wallet switching, ensuring that WalletConnect sessions are managed correctly only for the wallets that require it.

## Related Issues

This PR is part of the ongoing fix for issue #274, further refining the solution to the WalletConnect session management problems.