### PR TITLE
fix(mnemonic): ensure account is initialized when signing transactions

### DIFF
--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -226,6 +226,8 @@ export class MnemonicWallet extends BaseWallet {
       this.logger.debug('Signing transactions...', { txnGroup, indexesToSign })
       let txnsToSign: algosdk.Transaction[] = []
 
+      const account = this.account || this.initializeAccount()
+
       // Determine type and process transactions for signing
       if (isTransactionArray(txnGroup)) {
         const flatTxns: algosdk.Transaction[] = flattenTxnGroup(txnGroup)
@@ -236,7 +238,7 @@ export class MnemonicWallet extends BaseWallet {
       }
 
       // Sign transactions
-      const signedTxns = txnsToSign.map((txn) => txn.signTxn(this.account!.sk))
+      const signedTxns = txnsToSign.map((txn) => txn.signTxn(account.sk))
       this.logger.debug('Transactions signed successfully', { signedTxns })
       return signedTxns
     } catch (error: any) {


### PR DESCRIPTION
This fixes the bug where signing transactions with the mnemonic wallet fails under certain circumstances because the account is not initialized despite being in a valid connection session.

I caught this bug in one of my automated tests where I attempt to sign a transaction after refreshing the page using the mnemonic wallet through `use-wallet-react` with Next.js. It fails with the message: `[Wallet:MNEMONIC] Error signing transactions: Cannot read properties of null (reading 'addr')`. For some reason, the `account` within the `MnemonicWallet` class isn't set despite the session being resumed successfully and the account being accessible through `activeAccount`.

I couldn't pin down exactly why or when this happens. However, I noticed most of the other wallets had the following line in their `signTransactions()` methods and the mnemonic wallet did not have anything similar.

```typescript
const client = this.client || (await this.initializeClient())
```

Once a added the equivalent line in the mnemonic wallet's `signTransactions()` method, the bug went away and I didn't encounter any other issues. It appears I somehow encountered an odd edge case.