### PR TITLE
feat(webpack): add fallback for optional wallet dependencies

### DIFF
--- a/examples/nextjs/next.config.mjs
+++ b/examples/nextjs/next.config.mjs
@@ -1,3 +1,5 @@
+import { webpackFallback } from '@txnlab/use-wallet-react'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   webpack: (config, { isServer }) => {
@@ -14,16 +16,7 @@ const nextConfig = {
     if (!isServer) {
       config.resolve.fallback = {
         ...config.resolve.fallback,
-        '@agoralabs-sh/avm-web-provider': false,
-        '@algorandfoundation/liquid-auth-use-wallet-client': false,
-        '@blockshake/defly-connect': false,
-        '@magic-ext/algorand': false,
-        '@perawallet/connect': false,
-        '@perawallet/connect-beta': false,
-        '@walletconnect/modal': false,
-        '@walletconnect/sign-client': false,
-        'lute-connect': false,
-        'magic-sdk': false
+        ...webpackFallback
       }
     }
     return config

--- a/packages/use-wallet/src/index.ts
+++ b/packages/use-wallet/src/index.ts
@@ -3,4 +3,5 @@ export { WalletManager, WalletManagerConfig, WalletManagerOptions } from './mana
 export { NetworkId } from './network'
 export { State, WalletState, defaultState } from './store'
 export { StorageAdapter } from './storage'
+export { webpackFallback } from './webpack'
 export * from './wallets'

--- a/packages/use-wallet/src/webpack.ts
+++ b/packages/use-wallet/src/webpack.ts
@@ -1,0 +1,19 @@
+/**
+ * Fallback configuration for Webpack to handle optional wallet dependencies.
+ * This allows applications to build without these packages installed,
+ * enabling users to include only the wallet packages they need.
+ * Each package is set to 'false', which means Webpack will provide an empty module
+ * if the package is not found, preventing build errors for unused wallets.
+ */
+export const webpackFallback = {
+  '@agoralabs-sh/avm-web-provider': false,
+  '@algorandfoundation/liquid-auth-use-wallet-client': false,
+  '@blockshake/defly-connect': false,
+  '@magic-ext/algorand': false,
+  '@perawallet/connect': false,
+  '@perawallet/connect-beta': false,
+  '@walletconnect/modal': false,
+  '@walletconnect/sign-client': false,
+  'lute-connect': false,
+  'magic-sdk': false
+}


### PR DESCRIPTION
## Description

This PR introduces a `webpackFallback` object to handle optional wallet dependencies in Next.js applications using `@txnlab/use-wallet`. This allows applications to build without these packages installed, enabling users to include only the wallet packages they need.

## Details

- Add `webpackFallback` object in `src/webpack.ts`
- Export `webpackFallback` from the main `src/index.ts` file
- Update Next.js example app to use the new `webpackFallback`

This change simplifies the configuration process for Next.js applications and ensures that the fallback configuration is maintained within the `@txnlab/use-wallet` library, making it easier to keep up-to-date as new optional dependencies are added.