### PR TITLE
feat(*): migrate to algosdk v3.0.0

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -13,7 +13,7 @@
     "@txnlab/use-wallet-react": "workspace:*",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "lute-connect": "^1.4.1",
     "next": "14.2.15",
     "react": "18.3.1",

--- a/examples/nextjs/src/app/Connect.tsx
+++ b/examples/nextjs/src/app/Connect.tsx
@@ -53,8 +53,8 @@ export function Connect() {
       const suggestedParams = await algodClient.getTransactionParams().do()
 
       const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: activeAddress,
-        to: activeAddress,
+        sender: activeAddress,
+        receiver: activeAddress,
         amount: 0,
         suggestedParams
       })

--- a/examples/nuxt/components/Connect.vue
+++ b/examples/nuxt/components/Connect.vue
@@ -44,8 +44,8 @@ const sendTransaction = async (wallet: Wallet) => {
     const suggestedParams = await algodClient.value.getTransactionParams().do()
 
     const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-      from: wallet.activeAccount.address,
-      to: wallet.activeAccount.address,
+      sender: wallet.activeAccount.address,
+      receiver: wallet.activeAccount.address,
       amount: 0,
       suggestedParams
     })

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -18,7 +18,7 @@
     "@txnlab/use-wallet-vue": "workspace:*",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "lute-connect": "^1.4.1",
     "nuxt": "3.13.2",
     "vue": "3.5.12",

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -15,7 +15,7 @@
     "@txnlab/use-wallet-react": "workspace:*",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "lute-connect": "^1.4.1",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/examples/react-ts/src/Connect.tsx
+++ b/examples/react-ts/src/Connect.tsx
@@ -50,8 +50,8 @@ export function Connect() {
       const suggestedParams = await algodClient.getTransactionParams().do()
 
       const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: activeAddress,
-        to: activeAddress,
+        sender: activeAddress,
+        receiver: activeAddress,
         amount: 0,
         suggestedParams
       })

--- a/examples/solid-ts/package.json
+++ b/examples/solid-ts/package.json
@@ -16,7 +16,7 @@
     "@txnlab/use-wallet-solid": "workspace:*",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "lute-connect": "^1.4.1",
     "solid-js": "1.9.2"
   },

--- a/examples/solid-ts/src/Connect.tsx
+++ b/examples/solid-ts/src/Connect.tsx
@@ -54,8 +54,8 @@ export function Connect() {
       const suggestedParams = await algodClient().getTransactionParams().do()
 
       const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: sender,
-        to: sender,
+        sender: sender,
+        receiver: sender,
         amount: 0,
         suggestedParams
       })

--- a/examples/vanilla-ts/package.json
+++ b/examples/vanilla-ts/package.json
@@ -20,7 +20,7 @@
     "@txnlab/use-wallet": "workspace:*",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "lute-connect": "^1.4.1"
   }
 }

--- a/examples/vanilla-ts/src/WalletComponent.ts
+++ b/examples/vanilla-ts/src/WalletComponent.ts
@@ -41,8 +41,8 @@ export class WalletComponent {
       const suggestedParams = await this.manager.algodClient.getTransactionParams().do()
 
       const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: activeAddress,
-        to: activeAddress,
+        sender: activeAddress,
+        receiver: activeAddress,
         amount: 0,
         suggestedParams
       })

--- a/examples/vue-ts/package.json
+++ b/examples/vue-ts/package.json
@@ -15,7 +15,7 @@
     "@txnlab/use-wallet-vue": "workspace:*",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "lute-connect": "^1.4.1",
     "vue": "3.5.12"
   },

--- a/examples/vue-ts/src/components/Connect.vue
+++ b/examples/vue-ts/src/components/Connect.vue
@@ -37,8 +37,8 @@ const sendTransaction = async (wallet: Wallet) => {
     const suggestedParams = await algodClient.value.getTransactionParams().do()
 
     const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-      from: wallet.activeAccount.address,
-      to: wallet.activeAccount.address,
+      sender: wallet.activeAccount.address,
+      receiver: wallet.activeAccount.address,
       amount: 0,
       suggestedParams
     })

--- a/packages/use-wallet-react/package.json
+++ b/packages/use-wallet-react/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/react": "18.3.11",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "jsdom": "25.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
@@ -57,7 +57,7 @@
     "@walletconnect/modal": "^2.7.0",
     "@perawallet/connect": "^1.3.5",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "^2.7.0",
+    "algosdk": "^3.0.0",
     "lute-connect": "^1.4.1",
     "magic-sdk": "^28.13.0",
     "react": "^17.0.0 || ^18.0.0",

--- a/packages/use-wallet-solid/package.json
+++ b/packages/use-wallet-solid/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "0.8.10",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "solid-js": "1.9.2",
     "tsup": "8.3.0",
     "tsup-preset-solid": "2.2.0",
@@ -79,7 +79,7 @@
     "@perawallet/connect-beta": "^2.0.21",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "^2.7.0",
+    "algosdk": "^3.0.0",
     "lute-connect": "^1.4.1",
     "magic-sdk": "^28.13.0"
   },

--- a/packages/use-wallet-vue/package.json
+++ b/packages/use-wallet-vue/package.json
@@ -42,7 +42,7 @@
     "@txnlab/use-wallet": "workspace:*"
   },
   "devDependencies": {
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "tsup": "8.3.0",
     "typescript": "5.6.3",
     "vue": "3.5.12"
@@ -54,7 +54,7 @@
     "@perawallet/connect-beta": "^2.0.21",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "^2.7.0",
+    "algosdk": "^3.0.0",
     "lute-connect": "^1.4.1",
     "magic-sdk": "^28.13.0",
     "vue": "^3.0.0"

--- a/packages/use-wallet/package.json
+++ b/packages/use-wallet/package.json
@@ -52,7 +52,7 @@
     "@walletconnect/modal-core": "2.7.0",
     "@walletconnect/sign-client": "2.17.1",
     "@walletconnect/types": "2.17.1",
-    "algosdk": "2.9.0",
+    "algosdk": "3.0.0",
     "lute-connect": "1.4.1",
     "magic-sdk": "28.13.0",
     "tsup": "8.3.0",
@@ -66,7 +66,7 @@
     "@perawallet/connect-beta": "^2.0.21",
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.17.1",
-    "algosdk": "^2.7.0",
+    "algosdk": "^3.0.0",
     "lute-connect": "^1.4.1"
   },
   "peerDependenciesMeta": {

--- a/packages/use-wallet/src/__tests__/utils.test.ts
+++ b/packages/use-wallet/src/__tests__/utils.test.ts
@@ -49,59 +49,60 @@ describe('compareAccounts', () => {
 
 describe('isSignedTxn', () => {
   const transaction = new algosdk.Transaction({
-    from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    fee: 10,
-    amount: 847,
-    firstRound: 51,
-    lastRound: 61,
-    genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
-    genesisID: 'testnet-v1.0'
+    type: algosdk.TransactionType.pay,
+    sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+    suggestedParams: {
+      fee: 0,
+      firstValid: 51,
+      lastValid: 61,
+      minFee: 1000,
+      genesisID: 'mainnet-v1.0'
+    },
+    paymentParams: {
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      amount: 847
+    }
   })
 
-  const encodedTxn = {
-    amt: transaction.amount,
-    fee: transaction.fee,
-    fv: transaction.firstRound,
-    lv: transaction.lastRound,
-    snd: Buffer.from(transaction.from.publicKey),
-    type: 'pay',
-    gen: transaction.genesisID,
-    gh: transaction.genesisHash,
-    grp: Buffer.from(new Uint8Array(0))
-  }
+  const encodedTxn = algosdk.encodeMsgpack(transaction)
+  const decodedRawTxn = algosdk.msgpackRawDecode(encodedTxn)
 
-  const encodedSignedTxn = { txn: encodedTxn, sig: Buffer.from('sig') }
+  const txnObj = { txn: decodedRawTxn, sig: Buffer.from('sig') }
 
   it('should return true if the object is a signed transaction', () => {
-    expect(isSignedTxn(encodedSignedTxn)).toBe(true)
+    expect(isSignedTxn(txnObj)).toBe(true)
   })
 
   it('should return false if the object is not a signed transaction', () => {
-    expect(isSignedTxn(encodedTxn)).toBe(false)
+    expect(isSignedTxn(decodedRawTxn)).toBe(false)
   })
 })
 
 describe('isTransaction', () => {
   const transaction = new algosdk.Transaction({
-    from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    fee: 10,
-    amount: 847,
-    firstRound: 51,
-    lastRound: 61,
-    genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
-    genesisID: 'testnet-v1.0'
+    type: algosdk.TransactionType.pay,
+    sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+    suggestedParams: {
+      fee: 0,
+      firstValid: 51,
+      lastValid: 61,
+      minFee: 1000,
+      genesisID: 'mainnet-v1.0'
+    },
+    paymentParams: {
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      amount: 847
+    }
   })
 
-  const uInt8Array = transaction.toByte()
+  const encodedTxn = algosdk.encodeMsgpack(transaction)
 
   it('should return true if the item is a Transaction', () => {
     expect(isTransaction(transaction)).toBe(true)
   })
 
   it('should return false if the item is a Uint8Array', () => {
-    expect(isTransaction(uInt8Array)).toBe(false)
+    expect(isTransaction(encodedTxn)).toBe(false)
   })
 
   it('should return false if the item is an object that is not a Transaction', () => {
@@ -113,23 +114,28 @@ describe('isTransaction', () => {
   })
 
   it('should return false if the item is an array of Uint8Arrays', () => {
-    expect(isTransaction([uInt8Array, uInt8Array])).toBe(false)
+    expect(isTransaction([encodedTxn, encodedTxn])).toBe(false)
   })
 })
 
 describe('isTransactionArray', () => {
   const transaction = new algosdk.Transaction({
-    from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    fee: 10,
-    amount: 847,
-    firstRound: 51,
-    lastRound: 61,
-    genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
-    genesisID: 'testnet-v1.0'
+    type: algosdk.TransactionType.pay,
+    sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+    suggestedParams: {
+      fee: 0,
+      firstValid: 51,
+      lastValid: 61,
+      minFee: 1000,
+      genesisID: 'mainnet-v1.0'
+    },
+    paymentParams: {
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      amount: 847
+    }
   })
 
-  const uInt8Array = transaction.toByte()
+  const encodedTxn = algosdk.encodeMsgpack(transaction)
 
   it('should return true if the item is an array of transactions', () => {
     expect(isTransactionArray([transaction, transaction])).toBe(true)
@@ -144,39 +150,49 @@ describe('isTransactionArray', () => {
   })
 
   it('should return false if the item is a single Uint8Array', () => {
-    expect(isTransactionArray(uInt8Array)).toBe(false)
+    expect(isTransactionArray(encodedTxn)).toBe(false)
   })
 
   it('should return false if the item is an array of Uint8Arrays', () => {
-    expect(isTransactionArray([uInt8Array, uInt8Array])).toBe(false)
+    expect(isTransactionArray([encodedTxn, encodedTxn])).toBe(false)
   })
 
   it('should return false if the item is a nested array of Uint8Arrays', () => {
-    expect(isTransactionArray([[uInt8Array, uInt8Array], [uInt8Array]])).toBe(false)
+    expect(isTransactionArray([[encodedTxn, encodedTxn], [encodedTxn]])).toBe(false)
   })
 })
 
 describe('flattenTxnGroup', () => {
   const transaction1 = new algosdk.Transaction({
-    from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    fee: 10,
-    amount: 847,
-    firstRound: 51,
-    lastRound: 61,
-    genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
-    genesisID: 'testnet-v1.0'
+    type: algosdk.TransactionType.pay,
+    sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+    suggestedParams: {
+      fee: 0,
+      firstValid: 51,
+      lastValid: 61,
+      minFee: 1000,
+      genesisID: 'mainnet-v1.0'
+    },
+    paymentParams: {
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      amount: 847
+    }
   })
 
   const transaction2 = new algosdk.Transaction({
-    from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-    fee: 15,
-    amount: 500,
-    firstRound: 100,
-    lastRound: 200,
-    genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
-    genesisID: 'testnet-v1.0'
+    type: algosdk.TransactionType.pay,
+    sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+    suggestedParams: {
+      fee: 0,
+      firstValid: 100,
+      lastValid: 200,
+      minFee: 1000,
+      genesisID: 'mainnet-v1.0'
+    },
+    paymentParams: {
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      amount: 500
+    }
   })
 
   const nestedTxnGroup = [[transaction1, transaction2], [transaction1]]

--- a/packages/use-wallet/src/__tests__/wallets/custom.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/custom.test.ts
@@ -293,14 +293,19 @@ describe('CustomWallet', () => {
 
   describe('signTransactions', () => {
     const txn = new algosdk.Transaction({
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      amount: 1000,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+      type: algosdk.TransactionType.pay,
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      suggestedParams: {
+        fee: 0,
+        firstValid: 51,
+        lastValid: 61,
+        minFee: 1000,
+        genesisID: 'mainnet-v1.0'
+      },
+      paymentParams: {
+        receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+        amount: 1000
+      }
     })
 
     const txnGroup = [txn]
@@ -337,14 +342,18 @@ describe('CustomWallet', () => {
 
   describe('transactionSigner', () => {
     const txn = new algosdk.Transaction({
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      amount: 1000,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+      type: algosdk.TransactionType.pay,
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      suggestedParams: {
+        fee: 10,
+        firstValid: 51,
+        lastValid: 61,
+        minFee: 10
+      },
+      paymentParams: {
+        receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+        amount: 1000
+      }
     })
 
     const txnGroup = [txn]

--- a/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
@@ -232,21 +232,26 @@ describe('ExodusWallet', () => {
     // Not connected account
     const notConnectedAcct = 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4'
 
-    const txnParams = {
-      from: connectedAcct1,
-      to: connectedAcct2,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = connectedAcct1, receiver = connectedAcct2 }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'mainnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     beforeEach(async () => {
       // Mock two connected accounts
@@ -365,23 +370,9 @@ describe('ExodusWallet', () => {
       })
 
       it('should only send transactions with connected signers for signature', async () => {
-        const canSignTxn1 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct1,
-          amount: 1000
-        })
-
-        const cannotSignTxn2 = new algosdk.Transaction({
-          ...txnParams,
-          from: notConnectedAcct,
-          amount: 2000
-        })
-
-        const canSignTxn3 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct2,
-          amount: 3000
-        })
+        const canSignTxn1 = makePayTxn({ sender: connectedAcct1, amount: 1000 })
+        const cannotSignTxn2 = makePayTxn({ sender: notConnectedAcct, amount: 2000 })
+        const canSignTxn3 = makePayTxn({ sender: connectedAcct2, amount: 3000 })
 
         // Signer for gtxn2 is not a connected account
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([

--- a/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
@@ -284,21 +284,26 @@ describe('KibisisWallet', () => {
   })
 
   describe('signing transactions', () => {
-    const txnParams = {
-      from: ACCOUNT_1,
-      to: ACCOUNT_2,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: TESTNET_GENESIS_HASH,
-      genesisID: 'testnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = ACCOUNT_1, receiver = ACCOUNT_2 }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'mainnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     // Mock signed transactions (base64 strings) returned by Kibisis
     const mockSignedTxns = [byteArrayToBase64(txn1.toByte())]
@@ -439,23 +444,12 @@ describe('KibisisWallet', () => {
       })
 
       it('should only send transactions with connected signers for signature', async () => {
-        const canSignTxn1 = new algosdk.Transaction({
-          ...txnParams,
-          from: ACCOUNT_1,
-          amount: 1000
-        })
+        // Not connected account
+        const notConnectedAcct = 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4'
 
-        const cannotSignTxn2 = new algosdk.Transaction({
-          ...txnParams,
-          from: 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4', // EW64GC is not connected
-          amount: 2000
-        })
-
-        const canSignTxn3 = new algosdk.Transaction({
-          ...txnParams,
-          from: ACCOUNT_2,
-          amount: 3000
-        })
+        const canSignTxn1 = makePayTxn({ sender: ACCOUNT_1, amount: 1000 })
+        const cannotSignTxn2 = makePayTxn({ sender: notConnectedAcct, amount: 2000 })
+        const canSignTxn3 = makePayTxn({ sender: ACCOUNT_2, amount: 3000 })
 
         // Signer for gtxn2 is not a connected account
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([

--- a/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
@@ -213,21 +213,26 @@ describe('KmdWallet', () => {
     // Not connected account
     const notConnectedAcct = 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4'
 
-    const txnParams = {
-      from: connectedAcct1,
-      to: connectedAcct2,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = connectedAcct1, receiver = connectedAcct2 }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'testnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     beforeEach(async () => {
       // Mock two connected accounts
@@ -361,23 +366,9 @@ describe('KmdWallet', () => {
       })
 
       it('should only send transactions with connected signers for signature', async () => {
-        const canSignTxn1 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct1,
-          amount: 1000
-        })
-
-        const cannotSignTxn2 = new algosdk.Transaction({
-          ...txnParams,
-          from: notConnectedAcct,
-          amount: 2000
-        })
-
-        const canSignTxn3 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct2,
-          amount: 3000
-        })
+        const canSignTxn1 = makePayTxn({ sender: connectedAcct1, amount: 1000 })
+        const cannotSignTxn2 = makePayTxn({ sender: notConnectedAcct, amount: 2000 })
+        const canSignTxn3 = makePayTxn({ sender: connectedAcct2, amount: 3000 })
 
         // Signer for gtxn2 is not a connected account
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([

--- a/packages/use-wallet/src/__tests__/wallets/liquid.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/liquid.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest'
 import { Store } from '@tanstack/store'
-import { Transaction } from 'algosdk'
+import { Transaction, TransactionType } from 'algosdk'
 import { logger } from 'src/logger'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
@@ -202,10 +202,9 @@ describe('LiquidWallet', () => {
     const suggestedParams = {
       flatFee: false,
       fee: 0,
-      firstRound: 43564565,
-      lastRound: 43565565,
+      firstValid: 43564565,
+      lastValid: 43565565,
       genesisID: 'testnet-v1.0',
-      genesisHash: 'SGO1GKSzyE7IEPItTxCByx8FmnrCDexi9/cOUJOiI=',
       minFee: 1000
     }
 
@@ -213,10 +212,10 @@ describe('LiquidWallet', () => {
 
     const txnGroup = [
       new Transaction({
-        from: algoAddress,
-        to: algoAddress,
-        amount: 0,
-        suggestedParams
+        type: TransactionType.pay,
+        sender: algoAddress,
+        suggestedParams,
+        paymentParams: { receiver: algoAddress, amount: 0 }
       })
     ]
 

--- a/packages/use-wallet/src/__tests__/wallets/lute.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/lute.test.ts
@@ -55,7 +55,8 @@ function createWalletWithStore(store: Store<State>): LuteWallet {
     getAlgodClient: () =>
       ({
         genesis: () => ({
-          do: () => Promise.resolve({ id: 'mockGenesisID', network: 'mockGenesisNetwork' })
+          do: () =>
+            Promise.resolve(JSON.stringify({ id: 'mockGenesisID', network: 'mockGenesisNetwork' }))
         })
       }) as any,
     store,
@@ -222,21 +223,26 @@ describe('LuteWallet', () => {
     // Not connected account
     const notConnectedAcct = 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4'
 
-    const txnParams = {
-      from: connectedAcct1,
-      to: connectedAcct2,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = connectedAcct1, receiver = connectedAcct2 }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'mainnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     beforeEach(async () => {
       const mockConnect = vi.fn().mockResolvedValue([connectedAcct1, connectedAcct2])
@@ -363,23 +369,9 @@ describe('LuteWallet', () => {
       })
 
       it('should only send transactions with connected signers for signature', async () => {
-        const canSignTxn1 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct1,
-          amount: 1000
-        })
-
-        const cannotSignTxn2 = new algosdk.Transaction({
-          ...txnParams,
-          from: notConnectedAcct,
-          amount: 2000
-        })
-
-        const canSignTxn3 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct2,
-          amount: 3000
-        })
+        const canSignTxn1 = makePayTxn({ sender: connectedAcct1, amount: 1000 })
+        const cannotSignTxn2 = makePayTxn({ sender: notConnectedAcct, amount: 2000 })
+        const canSignTxn3 = makePayTxn({ sender: connectedAcct2, amount: 3000 })
 
         // Signer for gtxn2 is not a connected account
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([

--- a/packages/use-wallet/src/__tests__/wallets/magic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/magic.test.ts
@@ -304,27 +304,32 @@ describe('MagicAuth', () => {
   })
 
   describe('signing transactions', () => {
-    // Connected accounts
+    // Connected account
     const connectedAcct = '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q'
 
     // Not connected account
     const notConnectedAcct = 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4'
 
-    const txnParams = {
-      from: connectedAcct,
-      to: connectedAcct,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = connectedAcct, receiver = connectedAcct }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'mainnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     beforeEach(async () => {
       // Mock two connected accounts
@@ -451,23 +456,9 @@ describe('MagicAuth', () => {
       })
 
       it('should only send transactions with connected signers for signature', async () => {
-        const canSignTxn1 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct,
-          amount: 1000
-        })
-
-        const cannotSignTxn2 = new algosdk.Transaction({
-          ...txnParams,
-          from: notConnectedAcct,
-          amount: 2000
-        })
-
-        const canSignTxn3 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct,
-          amount: 3000
-        })
+        const canSignTxn1 = makePayTxn({ sender: connectedAcct, amount: 1000 })
+        const cannotSignTxn2 = makePayTxn({ sender: notConnectedAcct, amount: 2000 })
+        const canSignTxn3 = makePayTxn({ sender: connectedAcct, amount: 3000 })
 
         // Signer for gtxn2 is not a connected account
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([

--- a/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
@@ -240,21 +240,26 @@ describe('MnemonicWallet', () => {
   })
 
   describe('signing transactions', () => {
-    const txnParams = {
-      from: TEST_ADDRESS,
-      to: TEST_ADDRESS,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = TEST_ADDRESS, receiver = TEST_ADDRESS }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'testnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     beforeEach(async () => {
       await wallet.connect()

--- a/packages/use-wallet/src/__tests__/wallets/pera.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera.test.ts
@@ -547,21 +547,26 @@ describe('PeraWallet', () => {
     // Not connected account
     const notConnectedAcct = 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4'
 
-    const txnParams = {
-      from: connectedAcct1,
-      to: connectedAcct2,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = connectedAcct1, receiver = connectedAcct2 }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'mainnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     const sTxn = new Uint8Array([1, 2, 3, 4])
 
@@ -683,23 +688,9 @@ describe('PeraWallet', () => {
       })
 
       it('should only send transactions with connected signers for signature', async () => {
-        const canSignTxn1 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct1,
-          amount: 1000
-        })
-
-        const cannotSignTxn2 = new algosdk.Transaction({
-          ...txnParams,
-          from: notConnectedAcct,
-          amount: 2000
-        })
-
-        const canSignTxn3 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct2,
-          amount: 3000
-        })
+        const canSignTxn1 = makePayTxn({ sender: connectedAcct1, amount: 1000 })
+        const cannotSignTxn2 = makePayTxn({ sender: notConnectedAcct, amount: 2000 })
+        const canSignTxn3 = makePayTxn({ sender: connectedAcct2, amount: 3000 })
 
         // Signer for gtxn2 is not a connected account
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([

--- a/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
@@ -340,21 +340,26 @@ describe('PeraWallet', () => {
     // Not connected account
     const notConnectedAcct = 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4'
 
-    const txnParams = {
-      from: connectedAcct1,
-      to: connectedAcct2,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = connectedAcct1, receiver = connectedAcct2 }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'mainnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     const sTxn = new Uint8Array([1, 2, 3, 4])
 
@@ -476,23 +481,9 @@ describe('PeraWallet', () => {
       })
 
       it('should only send transactions with connected signers for signature', async () => {
-        const canSignTxn1 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct1,
-          amount: 1000
-        })
-
-        const cannotSignTxn2 = new algosdk.Transaction({
-          ...txnParams,
-          from: notConnectedAcct,
-          amount: 2000
-        })
-
-        const canSignTxn3 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct2,
-          amount: 3000
-        })
+        const canSignTxn1 = makePayTxn({ sender: connectedAcct1, amount: 1000 })
+        const cannotSignTxn2 = makePayTxn({ sender: notConnectedAcct, amount: 2000 })
+        const canSignTxn3 = makePayTxn({ sender: connectedAcct2, amount: 3000 })
 
         // Signer for gtxn2 is not a connected account
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([

--- a/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
@@ -356,21 +356,26 @@ describe('WalletConnect', () => {
     // Not connected account
     const notConnectedAcct = 'EW64GC6F24M7NDSC5R3ES4YUVE3ZXXNMARJHDCCCLIHZU6TBEOC7XRSBG4'
 
-    const txnParams = {
-      from: connectedAcct1,
-      to: connectedAcct2,
-      fee: 10,
-      firstRound: 51,
-      lastRound: 61,
-      genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-      genesisID: 'mainnet-v1.0'
+    const makePayTxn = ({ amount = 1000, sender = connectedAcct1, receiver = connectedAcct2 }) => {
+      return new algosdk.Transaction({
+        type: algosdk.TransactionType.pay,
+        sender,
+        suggestedParams: {
+          fee: 0,
+          firstValid: 51,
+          lastValid: 61,
+          minFee: 1000,
+          genesisID: 'mainnet-v1.0'
+        },
+        paymentParams: { receiver, amount }
+      })
     }
 
     // Transactions used in tests
-    const txn1 = new algosdk.Transaction({ ...txnParams, amount: 1000 })
-    const txn2 = new algosdk.Transaction({ ...txnParams, amount: 2000 })
-    const txn3 = new algosdk.Transaction({ ...txnParams, amount: 3000 })
-    const txn4 = new algosdk.Transaction({ ...txnParams, amount: 4000 })
+    const txn1 = makePayTxn({ amount: 1000 })
+    const txn2 = makePayTxn({ amount: 2000 })
+    const txn3 = makePayTxn({ amount: 3000 })
+    const txn4 = makePayTxn({ amount: 4000 })
 
     const expectedRpcRequest = (params: WalletTransaction[][]) => {
       return {
@@ -525,23 +530,9 @@ describe('WalletConnect', () => {
       })
 
       it('should only send transactions with connected signers for signature', async () => {
-        const canSignTxn1 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct1,
-          amount: 1000
-        })
-
-        const cannotSignTxn2 = new algosdk.Transaction({
-          ...txnParams,
-          from: notConnectedAcct,
-          amount: 2000
-        })
-
-        const canSignTxn3 = new algosdk.Transaction({
-          ...txnParams,
-          from: connectedAcct2,
-          amount: 3000
-        })
+        const canSignTxn1 = makePayTxn({ sender: connectedAcct1, amount: 1000 })
+        const cannotSignTxn2 = makePayTxn({ sender: notConnectedAcct, amount: 2000 })
+        const canSignTxn3 = makePayTxn({ sender: connectedAcct2, amount: 3000 })
 
         // Signer for gtxn2 is not a connected account
         const [gtxn1, gtxn2, gtxn3] = algosdk.assignGroupID([
@@ -599,7 +590,7 @@ describe('WalletConnect', () => {
         })
         await wallet.connect()
 
-        const txn = new algosdk.Transaction(txnParams)
+        const txn = makePayTxn({ amount: 1000 })
         await wallet.signTransactions([txn])
 
         expect(mockSignClient.request).toHaveBeenCalledWith(

--- a/packages/use-wallet/src/utils.ts
+++ b/packages/use-wallet/src/utils.ts
@@ -74,15 +74,29 @@ export function byteArrayToString(array: Uint8Array): string {
   return result
 }
 
-export function isSignedTxn(
-  txnDecodeObj: algosdk.EncodedTransaction | algosdk.EncodedSignedTransaction
-): txnDecodeObj is algosdk.EncodedSignedTransaction {
-  return (txnDecodeObj as algosdk.EncodedSignedTransaction).txn !== undefined
+export function isSignedTxn(txnObj: any): boolean {
+  if (!txnObj || typeof txnObj !== 'object') return false
+  if (!('sig' in txnObj && 'txn' in txnObj)) return false
+
+  // Verify sig is a Uint8Array
+  if (!(txnObj.sig instanceof Uint8Array)) return false
+
+  // Verify txn is an object
+  const txn = txnObj.txn
+  if (!txn || typeof txn !== 'object') return false
+
+  // Check for common transaction properties
+  const hasRequiredProps = 'type' in txn && 'snd' in txn
+
+  return hasRequiredProps
 }
 
 export function isTransaction(item: any): item is algosdk.Transaction {
   return (
-    item && typeof item === 'object' && 'genesisID' in item && typeof item.genesisID === 'string'
+    item &&
+    typeof item === 'object' &&
+    'sender' in item &&
+    (item.sender instanceof algosdk.Address || typeof item.sender === 'string')
   )
 }
 

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -180,7 +180,7 @@ export class DeflyWallet extends BaseWallet {
 
     txnGroup.forEach((txn, index) => {
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = this.addresses.includes(signer)
 
       if (isIndexMatch && canSignTxn) {
@@ -200,18 +200,15 @@ export class DeflyWallet extends BaseWallet {
     const txnsToSign: SignerTransaction[] = []
 
     txnGroup.forEach((txnBuffer, index) => {
-      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
-        | algosdk.EncodedTransaction
-        | algosdk.EncodedSignedTransaction
-
-      const isSigned = isSignedTxn(txnDecodeObj)
+      const decodedObj = algosdk.msgpackRawDecode(txnBuffer)
+      const isSigned = isSignedTxn(decodedObj)
 
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = !isSigned && this.addresses.includes(signer)
 
       if (isIndexMatch && canSignTxn) {

--- a/packages/use-wallet/src/wallets/exodus.ts
+++ b/packages/use-wallet/src/wallets/exodus.ts
@@ -185,7 +185,7 @@ export class ExodusWallet extends BaseWallet {
 
     txnGroup.forEach((txn, index) => {
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = this.addresses.includes(signer)
 
       const txnString = byteArrayToBase64(txn.toByte())
@@ -207,18 +207,15 @@ export class ExodusWallet extends BaseWallet {
     const txnsToSign: WalletTransaction[] = []
 
     txnGroup.forEach((txnBuffer, index) => {
-      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
-        | algosdk.EncodedTransaction
-        | algosdk.EncodedSignedTransaction
-
-      const isSigned = isSignedTxn(txnDecodeObj)
+      const decodedObj = algosdk.msgpackRawDecode(txnBuffer)
+      const isSigned = isSignedTxn(decodedObj)
 
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = !isSigned && this.addresses.includes(signer)
 
       const txnString = byteArrayToBase64(txn.toByte())

--- a/packages/use-wallet/src/wallets/kmd.ts
+++ b/packages/use-wallet/src/wallets/kmd.ts
@@ -179,7 +179,7 @@ export class KmdWallet extends BaseWallet {
 
     txnGroup.forEach((txn, index) => {
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = this.addresses.includes(signer)
 
       if (isIndexMatch && canSignTxn) {
@@ -197,18 +197,15 @@ export class KmdWallet extends BaseWallet {
     const txnsToSign: algosdk.Transaction[] = []
 
     txnGroup.forEach((txnBuffer, index) => {
-      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
-        | algosdk.EncodedTransaction
-        | algosdk.EncodedSignedTransaction
-
-      const isSigned = isSignedTxn(txnDecodeObj)
+      const decodedObj = algosdk.msgpackRawDecode(txnBuffer)
+      const isSigned = isSignedTxn(decodedObj)
 
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = !isSigned && this.addresses.includes(signer)
 
       if (isIndexMatch && canSignTxn) {

--- a/packages/use-wallet/src/wallets/liquid.ts
+++ b/packages/use-wallet/src/wallets/liquid.ts
@@ -139,6 +139,7 @@ export class LiquidWallet extends BaseWallet {
       this.logger.debug('Signing transactions...', { txnGroup, indexesToSign })
 
       const authClient = this.authClient || (await this.initializeClient())
+      // @ts-expect-error - TODO: update liquid-auth-use-wallet-client to use algosdk v3
       return authClient.signTransactions(txnGroup, this.activeAddress, indexesToSign)
     } catch (error) {
       this.logger.error('Error signing transactions', error)

--- a/packages/use-wallet/src/wallets/magic.ts
+++ b/packages/use-wallet/src/wallets/magic.ts
@@ -218,7 +218,7 @@ export class MagicAuth extends BaseWallet {
 
     txnGroup.forEach((txn, index) => {
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = this.addresses.includes(signer)
 
       const txnString = byteArrayToBase64(txn.toByte())
@@ -240,18 +240,15 @@ export class MagicAuth extends BaseWallet {
     const txnsToSign: WalletTransaction[] = []
 
     txnGroup.forEach((txnBuffer, index) => {
-      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
-        | algosdk.EncodedTransaction
-        | algosdk.EncodedSignedTransaction
-
-      const isSigned = isSignedTxn(txnDecodeObj)
+      const decodedObj = algosdk.msgpackRawDecode(txnBuffer)
+      const isSigned = isSignedTxn(decodedObj)
 
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = !isSigned && this.addresses.includes(signer)
 
       const txnString = byteArrayToBase64(txn.toByte())

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -110,7 +110,7 @@ export class MnemonicWallet extends BaseWallet {
 
     const walletAccount = {
       name: `${this.metadata.name} Account`,
-      address: account.addr
+      address: account.addr.toString()
     }
 
     const walletState: WalletState = {
@@ -175,8 +175,8 @@ export class MnemonicWallet extends BaseWallet {
 
     txnGroup.forEach((txn, index) => {
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
-      const canSignTxn = signer === this.account!.addr
+      const signer = txn.sender.toString()
+      const canSignTxn = signer === this.account!.addr.toString()
 
       if (isIndexMatch && canSignTxn) {
         txnsToSign.push(txn)
@@ -193,19 +193,16 @@ export class MnemonicWallet extends BaseWallet {
     const txnsToSign: algosdk.Transaction[] = []
 
     txnGroup.forEach((txnBuffer, index) => {
-      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
-        | algosdk.EncodedTransaction
-        | algosdk.EncodedSignedTransaction
-
-      const isSigned = isSignedTxn(txnDecodeObj)
+      const decodedObj = algosdk.msgpackRawDecode(txnBuffer)
+      const isSigned = isSignedTxn(decodedObj)
 
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
-      const canSignTxn = !isSigned && signer === this.account!.addr
+      const signer = txn.sender.toString()
+      const canSignTxn = !isSigned && signer === this.account!.addr.toString()
 
       if (isIndexMatch && canSignTxn) {
         txnsToSign.push(txn)

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -185,7 +185,7 @@ export class PeraWallet extends BaseWallet {
 
     txnGroup.forEach((txn, index) => {
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = this.addresses.includes(signer)
 
       if (isIndexMatch && canSignTxn) {
@@ -205,18 +205,15 @@ export class PeraWallet extends BaseWallet {
     const txnsToSign: SignerTransaction[] = []
 
     txnGroup.forEach((txnBuffer, index) => {
-      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
-        | algosdk.EncodedTransaction
-        | algosdk.EncodedSignedTransaction
-
-      const isSigned = isSignedTxn(txnDecodeObj)
+      const decodedObj = algosdk.msgpackRawDecode(txnBuffer)
+      const isSigned = isSignedTxn(decodedObj)
 
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = !isSigned && this.addresses.includes(signer)
 
       if (isIndexMatch && canSignTxn) {

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -167,7 +167,7 @@ export class PeraWallet extends BaseWallet {
 
     txnGroup.forEach((txn, index) => {
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = this.addresses.includes(signer)
 
       if (isIndexMatch && canSignTxn) {
@@ -187,18 +187,15 @@ export class PeraWallet extends BaseWallet {
     const txnsToSign: SignerTransaction[] = []
 
     txnGroup.forEach((txnBuffer, index) => {
-      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
-        | algosdk.EncodedTransaction
-        | algosdk.EncodedSignedTransaction
-
-      const isSigned = isSignedTxn(txnDecodeObj)
+      const decodedObj = algosdk.msgpackRawDecode(txnBuffer)
+      const isSigned = isSignedTxn(decodedObj)
 
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = !isSigned && this.addresses.includes(signer)
 
       if (isIndexMatch && canSignTxn) {

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -454,7 +454,7 @@ export class WalletConnect extends BaseWallet {
 
     txnGroup.forEach((txn, index) => {
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = this.addresses.includes(signer)
 
       const txnString = byteArrayToBase64(txn.toByte())
@@ -476,18 +476,15 @@ export class WalletConnect extends BaseWallet {
     const txnsToSign: WalletTransaction[] = []
 
     txnGroup.forEach((txnBuffer, index) => {
-      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
-        | algosdk.EncodedTransaction
-        | algosdk.EncodedSignedTransaction
-
-      const isSigned = isSignedTxn(txnDecodeObj)
+      const decodedObj = algosdk.msgpackRawDecode(txnBuffer)
+      const isSigned = isSignedTxn(decodedObj)
 
       const txn: algosdk.Transaction = isSigned
         ? algosdk.decodeSignedTransaction(txnBuffer).txn
         : algosdk.decodeUnsignedTransaction(txnBuffer)
 
       const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
-      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const signer = txn.sender.toString()
       const canSignTxn = !isSigned && this.addresses.includes(signer)
 
       const txnString = byteArrayToBase64(txn.toByte())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,10 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-react':
         specifier: workspace:*
         version: link:../../packages/use-wallet-react
@@ -75,8 +75,8 @@ importers:
         specifier: ^2.17.1
         version: 2.17.1(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -116,10 +116,10 @@ importers:
         version: 1.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet':
         specifier: workspace:*
         version: link:../../packages/use-wallet
@@ -133,8 +133,8 @@ importers:
         specifier: ^2.17.1
         version: 2.17.1(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -162,10 +162,10 @@ importers:
         version: 1.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-react':
         specifier: workspace:*
         version: link:../../packages/use-wallet-react
@@ -176,8 +176,8 @@ importers:
         specifier: ^2.17.1
         version: 2.17.1(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -226,10 +226,10 @@ importers:
         version: 1.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-solid':
         specifier: workspace:*
         version: link:../../packages/use-wallet-solid
@@ -240,8 +240,8 @@ importers:
         specifier: ^2.17.1
         version: 2.17.1(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -266,10 +266,10 @@ importers:
         version: 1.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet':
         specifier: workspace:*
         version: link:../../packages/use-wallet
@@ -280,8 +280,8 @@ importers:
         specifier: ^2.17.1
         version: 2.17.1(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -303,10 +303,10 @@ importers:
         version: 1.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@txnlab/use-wallet-vue':
         specifier: workspace:*
         version: link:../../packages/use-wallet-vue
@@ -317,8 +317,8 @@ importers:
         specifier: ^2.17.1
         version: 2.17.1(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       lute-connect:
         specifier: ^1.4.1
         version: 1.4.1
@@ -353,7 +353,7 @@ importers:
         version: 1.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@blockshake/defly-connect':
         specifier: 1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@magic-ext/algorand':
         specifier: 23.13.0
         version: 23.13.0
@@ -362,10 +362,10 @@ importers:
         version: 28.13.0(localforage@1.10.0)
       '@perawallet/connect':
         specifier: 1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: 2.0.21
-        version: 2.0.21(algosdk@2.9.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
+        version: 2.0.21(algosdk@3.0.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       '@types/node':
         specifier: 20.11.30
         version: 20.11.30
@@ -382,8 +382,8 @@ importers:
         specifier: 2.17.1
         version: 2.17.1(ioredis@5.4.1)
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       lute-connect:
         specifier: 1.4.1
         version: 1.4.1
@@ -401,16 +401,16 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@magic-ext/algorand':
         specifier: ^23.13.0
         version: 23.13.0
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.21
-        version: 2.0.21(algosdk@2.9.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
+        version: 2.0.21(algosdk@3.0.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       '@tanstack/react-store':
         specifier: 0.5.5
         version: 0.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -434,8 +434,8 @@ importers:
         specifier: 18.3.11
         version: 18.3.11
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       jsdom:
         specifier: 25.0.1
         version: 25.0.1(bufferutil@4.0.8)(canvas@2.11.2)(utf-8-validate@5.0.10)
@@ -456,16 +456,16 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@magic-ext/algorand':
         specifier: ^23.13.0
         version: 23.13.0
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.21
-        version: 2.0.21(algosdk@2.9.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
+        version: 2.0.21(algosdk@3.0.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       '@tanstack/solid-store':
         specifier: 0.5.5
         version: 0.5.5(solid-js@1.9.2)
@@ -489,8 +489,8 @@ importers:
         specifier: 0.8.10
         version: 0.8.10(solid-js@1.9.2)
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       solid-js:
         specifier: 1.9.2
         version: 1.9.2
@@ -508,16 +508,16 @@ importers:
     dependencies:
       '@blockshake/defly-connect':
         specifier: ^1.1.6
-        version: 1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@magic-ext/algorand':
         specifier: ^23.13.0
         version: 23.13.0
       '@perawallet/connect':
         specifier: ^1.3.5
-        version: 1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        version: 1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@perawallet/connect-beta':
         specifier: ^2.0.21
-        version: 2.0.21(algosdk@2.9.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
+        version: 2.0.21(algosdk@3.0.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       '@tanstack/vue-store':
         specifier: 0.5.5
         version: 0.5.5(vue@3.5.12(typescript@5.6.3))
@@ -538,8 +538,8 @@ importers:
         version: 28.13.0
     devDependencies:
       algosdk:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 3.0.0
+        version: 3.0.0
       tsup:
         specifier: 8.3.0
         version: 8.3.0(jiti@2.3.3)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0)
@@ -2394,8 +2394,16 @@ packages:
     resolution: {integrity: sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==}
     engines: {node: '>= 10'}
 
+  algorand-msgpack@1.1.0:
+    resolution: {integrity: sha512-08k7pBQnkaUB5p+jL7f1TRaUIlTSDE0cesFu1mD7llLao+1cAhtvvZmGE3OnisTd0xOn118QMw74SRqddqaYvw==}
+    engines: {node: '>= 14'}
+
   algosdk@2.9.0:
     resolution: {integrity: sha512-o0n0nLMbTX6SFQdMUk2/2sy50jmEmZk5OTPYSh2aAeP8DUPxrhjMPfwGsYNvaO+qk75MixC2eWpfA9vygCQ/Mg==}
+    engines: {node: '>=18.0.0'}
+
+  algosdk@3.0.0:
+    resolution: {integrity: sha512-PIKZ/YvbBpCudduug4KSH1CY/pTotI7/ccbUIbXKtcI9Onevl+57E+K5X4ow4gsCdysZ8zVvSLdxuCcXvsmPOw==}
     engines: {node: '>=18.0.0'}
 
   ansi-colors@4.1.3:
@@ -6780,11 +6788,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
 
-  '@blockshake/defly-connect@1.1.6(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@blockshake/defly-connect@1.1.6(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@walletconnect/client': 1.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@walletconnect/types': 1.8.0
-      algosdk: 2.9.0
+      algosdk: 3.0.0
       bowser: 2.11.0
       buffer: 6.0.3
       lottie-web: 5.12.2
@@ -7650,14 +7658,14 @@ snapshots:
 
   '@pedrouid/environment@1.0.1': {}
 
-  '@perawallet/connect-beta@2.0.21(algosdk@2.9.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)':
+  '@perawallet/connect-beta@2.0.21(algosdk@3.0.0)(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)':
     dependencies:
       '@evanhahn/lottie-web-light': 5.8.1
       '@json-rpc-tools/utils': 1.7.6
       '@walletconnect/sign-client': 2.17.0(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.17.0(ioredis@5.4.1)
       '@walletconnect/utils': 2.17.0(ioredis@5.4.1)
-      algosdk: 2.9.0
+      algosdk: 3.0.0
       bowser: 2.11.0
       buffer: 6.0.3
       qr-code-styling: 1.6.0-rc.1
@@ -7679,12 +7687,12 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@perawallet/connect@1.3.5(algosdk@2.9.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@perawallet/connect@1.3.5(algosdk@3.0.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@evanhahn/lottie-web-light': 5.8.1
       '@walletconnect/client': 1.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@walletconnect/types': 1.8.0
-      algosdk: 2.9.0
+      algosdk: 3.0.0
       bowser: 2.11.0
       buffer: 6.0.3
       qr-code-styling: 1.6.0-rc.1
@@ -8892,10 +8900,23 @@ snapshots:
 
   algo-msgpack-with-bigint@2.1.1: {}
 
+  algorand-msgpack@1.1.0: {}
+
   algosdk@2.9.0:
     dependencies:
       algo-msgpack-with-bigint: 2.1.1
       buffer: 6.0.3
+      hi-base32: 0.5.1
+      js-sha256: 0.9.0
+      js-sha3: 0.8.0
+      js-sha512: 0.8.0
+      json-bigint: 1.0.0
+      tweetnacl: 1.0.3
+      vlq: 2.0.4
+
+  algosdk@3.0.0:
+    dependencies:
+      algorand-msgpack: 1.1.0
       hi-base32: 0.5.1
       js-sha256: 0.9.0
       js-sha3: 0.8.0


### PR DESCRIPTION
## Description

This PR initiates the v4.0.0 release by migrating from `algosdk` v2 to v3. This is a breaking change that requires updates to transaction handling across all packages, establishing the foundation for additional v4 changes.

See the [official migration guide](https://github.com/algorand/js-algorand-sdk/blob/develop/v2_TO_v3_MIGRATION_GUIDE.md) for details about the underlying SDK changes.

⚠️ **Important**: Projects consuming this library will need to update their `algosdk` dependency to `^3.0.0` as it is a required peer dependency for compatibility with v4.

## Details
- Update `package.json` dependencies to `algosdk@3.0.0` across all packages
- Refactor transaction creation to use new type-based construction API
- Update transaction property access (`from` -> `sender`, `firstRound` -> `firstValid`)
- Modify transaction signing and verification logic for v3 compatibility
- Update test suites to use new transaction format and API
- Update all example projects to use new transaction parameter names