### PR TITLE
chore(ci): add v4 branch to workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - 'main'
+    branches: [main, v4]
   push:
-    branches:
-      - 'main'
+    branches: [main, v4]
 
 jobs:
   run-ci:


### PR DESCRIPTION
## Description
Updates CI workflow to run on the new `v4` branch, ensuring all PRs and pushes are properly validated.

## Details
- Add `v4` branch to both `pull_request` and `push` triggers in CI workflow
- Ensures code quality checks run on all changes targeting the upcoming major version