### PR TITLE
feat(network): add new network config builder

### DIFF
--- a/examples/nextjs/src/app/providers.tsx
+++ b/examples/nextjs/src/app/providers.tsx
@@ -26,7 +26,7 @@ const walletManager = new WalletManager({
       options: { apiKey: 'pk_live_D17FD8D89621B5F3' }
     }
   ],
-  network: NetworkId.TESTNET
+  defaultNetwork: NetworkId.TESTNET
 })
 
 export function Providers({ children }: { children: React.ReactNode }) {

--- a/examples/nuxt/plugins/walletManager.client.ts
+++ b/examples/nuxt/plugins/walletManager.client.ts
@@ -27,6 +27,6 @@ export default defineNuxtPlugin((nuxtApp) => {
         options: { apiKey: 'pk_live_D17FD8D89621B5F3' }
       }
     ],
-    network: NetworkId.TESTNET
+    defaultNetwork: NetworkId.TESTNET
   })
 })

--- a/examples/react-ts/src/App.tsx
+++ b/examples/react-ts/src/App.tsx
@@ -29,7 +29,7 @@ const walletManager = new WalletManager({
       options: { apiKey: 'pk_live_D17FD8D89621B5F3' }
     }
   ],
-  network: NetworkId.TESTNET
+  defaultNetwork: NetworkId.TESTNET
 })
 
 function App() {

--- a/examples/solid-ts/src/App.tsx
+++ b/examples/solid-ts/src/App.tsx
@@ -29,7 +29,7 @@ const walletManager = new WalletManager({
       options: { apiKey: 'pk_live_D17FD8D89621B5F3' }
     }
   ],
-  network: NetworkId.TESTNET
+  defaultNetwork: NetworkId.TESTNET
 })
 
 function App() {

--- a/examples/vanilla-ts/src/main.ts
+++ b/examples/vanilla-ts/src/main.ts
@@ -30,7 +30,7 @@ const walletManager = new WalletManager({
       options: { apiKey: 'pk_live_D17FD8D89621B5F3' }
     }
   ],
-  network: NetworkId.TESTNET
+  defaultNetwork: NetworkId.TESTNET
 })
 
 const appDiv = document.querySelector<HTMLDivElement>('#app')

--- a/examples/vue-ts/src/main.ts
+++ b/examples/vue-ts/src/main.ts
@@ -30,7 +30,7 @@ app.use(WalletManagerPlugin, {
       options: { apiKey: 'pk_live_D17FD8D89621B5F3' }
     }
   ],
-  network: NetworkId.TESTNET
+  defaultNetwork: NetworkId.TESTNET
 })
 
 app.mount('#app')

--- a/packages/use-wallet-react/package.json
+++ b/packages/use-wallet-react/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsup",
     "start": "tsup src/index.tsx --watch",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest --watch",
     "lint": "eslint -c \"../../.eslintrc.json\" \"**/*.{js,ts}\"",
     "typecheck": "tsc --noEmit"

--- a/packages/use-wallet-react/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-react/src/__tests__/index.test.tsx
@@ -7,7 +7,7 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
-  defaultState,
+  DEFAULT_STATE,
   type State,
   type WalletAccount
 } from '@txnlab/use-wallet'
@@ -52,7 +52,7 @@ vi.mock('@txnlab/use-wallet', async (importOriginal) => {
   }
 })
 
-const mockStore = new Store<State>(defaultState)
+const mockStore = new Store<State>(DEFAULT_STATE)
 
 const mockDeflyWallet = new DeflyWallet({
   id: WalletId.DEFLY,
@@ -180,7 +180,7 @@ describe('useWallet', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockStore.setState(() => defaultState)
+    mockStore.setState(() => DEFAULT_STATE)
 
     mockWalletManager = new WalletManager()
     mockWallets = [

--- a/packages/use-wallet-react/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-react/src/__tests__/index.test.tsx
@@ -7,6 +7,7 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
+  DEFAULT_NETWORKS,
   DEFAULT_STATE,
   type State,
   type WalletAccount
@@ -59,7 +60,8 @@ const mockDeflyWallet = new DeflyWallet({
   metadata: { name: 'Defly', icon: 'icon' },
   getAlgodClient: () => ({}) as any,
   store: mockStore,
-  subscribe: vi.fn()
+  subscribe: vi.fn(),
+  networks: DEFAULT_NETWORKS
 })
 
 const mockMagicAuth = new MagicAuth({
@@ -70,7 +72,8 @@ const mockMagicAuth = new MagicAuth({
   metadata: { name: 'Magic', icon: 'icon' },
   getAlgodClient: () => ({}) as any,
   store: mockStore,
-  subscribe: vi.fn()
+  subscribe: vi.fn(),
+  networks: DEFAULT_NETWORKS
 })
 
 describe('WalletProvider', () => {
@@ -148,7 +151,7 @@ describe('WalletProvider', () => {
 
     const walletManager = new WalletManager({
       wallets: [WalletId.DEFLY],
-      network: NetworkId.TESTNET
+      defaultNetwork: NetworkId.TESTNET
     })
 
     const TestComponent = () => {
@@ -167,7 +170,8 @@ describe('WalletProvider', () => {
     })
 
     expect(walletManager.store.state.activeNetwork).toBe(newNetwork)
-    const { token, baseServer, port, headers } = walletManager.networkConfig[newNetwork]
+    const { algod } = walletManager.networkConfig[newNetwork]
+    const { token, baseServer, port, headers } = algod
     expect(walletManager.algodClient).toEqual(new algosdk.Algodv2(token, baseServer, port, headers))
   })
 })
@@ -469,7 +473,8 @@ describe('useWallet', () => {
     })
 
     expect(result.current.activeNetwork).toBe(newNetwork)
-    const { token, baseServer, port, headers } = mockWalletManager.networkConfig[newNetwork]
+    const { algod } = mockWalletManager.networkConfig[newNetwork]
+    const { token, baseServer, port, headers } = algod
     expect(result.current.algodClient).toEqual(
       new algosdk.Algodv2(token, baseServer, port, headers)
     )

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@tanstack/react-store'
-import { NetworkId, WalletAccount, WalletManager, WalletMetadata } from '@txnlab/use-wallet'
+import { WalletAccount, WalletManager, WalletMetadata } from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
 import * as React from 'react'
 
@@ -37,9 +37,13 @@ export const useWallet = () => {
 
   const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
 
-  const setActiveNetwork = async (networkId: NetworkId): Promise<void> => {
+  const setActiveNetwork = async (networkId: string): Promise<void> => {
     if (networkId === activeNetwork) {
       return
+    }
+
+    if (!manager.networkConfig[networkId]) {
+      throw new Error(`Network "${networkId}" not found in network configuration`)
     }
 
     console.info(`[React] Creating Algodv2 client for ${networkId}...`)

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -44,7 +44,8 @@ export const useWallet = () => {
 
     console.info(`[React] Creating Algodv2 client for ${networkId}...`)
 
-    const { token = '', baseServer, port = '', headers = {} } = manager.networkConfig[networkId]
+    const { algod } = manager.networkConfig[networkId]
+    const { token = '', baseServer, port = '', headers = {} } = algod
     const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
     setAlgodClient(newClient)
 

--- a/packages/use-wallet-solid/package.json
+++ b/packages/use-wallet-solid/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsup",
     "start": "tsup src/index.tsx --watch",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest --watch",
     "lint": "eslint -c \"../../.eslintrc.json\" \"**/*.{js,ts}\"",
     "typecheck": "tsc --noEmit"

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -7,6 +7,7 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
+  DEFAULT_NETWORKS,
   DEFAULT_STATE,
   type State,
   type WalletAccount
@@ -195,7 +196,8 @@ describe('useWallet', () => {
       metadata: { name: 'Defly', icon: 'icon' },
       getAlgodClient: () => ({}) as any,
       store: mockStore,
-      subscribe: vi.fn()
+      subscribe: vi.fn(),
+      networks: DEFAULT_NETWORKS
     })
 
     mockMagicAuth = new MagicAuth({
@@ -203,7 +205,8 @@ describe('useWallet', () => {
       metadata: { name: 'Magic', icon: 'icon' },
       getAlgodClient: () => ({}) as any,
       store: mockStore,
-      subscribe: vi.fn()
+      subscribe: vi.fn(),
+      networks: DEFAULT_NETWORKS
     })
 
     mockWalletManager = new WalletManager()
@@ -394,7 +397,7 @@ describe('useWallet', () => {
 
     const newAlgodClient = new algosdk.Algodv2('', 'https://mainnet-api.4160.nodely.dev/', '')
 
-    mockWalletManager.setActiveNetwork = async (networkId: NetworkId) => {
+    mockWalletManager.setActiveNetwork = async (networkId: string) => {
       mockSetAlgodClient(newAlgodClient)
       mockWalletManager.store.setState((state) => ({
         ...state,

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -7,6 +7,7 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
+  DEFAULT_STATE,
   type State,
   type WalletAccount
 } from '@txnlab/use-wallet'
@@ -187,14 +188,7 @@ describe('useWallet', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    const defaultState = {
-      wallets: {},
-      activeWallet: null,
-      activeNetwork: NetworkId.TESTNET,
-      algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/')
-    }
-
-    mockStore = new Store<State>(defaultState)
+    mockStore = new Store<State>(DEFAULT_STATE)
 
     mockDeflyWallet = new DeflyWallet({
       id: WalletId.DEFLY,

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -8,7 +8,6 @@ import {
   WalletManager,
   WalletId,
   DEFAULT_NETWORKS,
-  DEFAULT_STATE,
   type State,
   type WalletAccount
 } from '@txnlab/use-wallet'
@@ -189,7 +188,14 @@ describe('useWallet', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockStore = new Store<State>(DEFAULT_STATE)
+    const defaultState = {
+      wallets: {},
+      activeWallet: null,
+      activeNetwork: NetworkId.TESTNET,
+      algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/')
+    }
+
+    mockStore = new Store<State>(defaultState)
 
     mockDeflyWallet = new DeflyWallet({
       id: WalletId.DEFLY,

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -91,7 +91,8 @@ export function useWallet() {
 
     console.info(`[Solid] Creating Algodv2 client for ${networkId}...`)
 
-    const { token, baseServer, port, headers } = manager().networkConfig[networkId]
+    const { algod } = manager().networkConfig[networkId]
+    const { token, baseServer, port, headers } = algod
     const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
 
     manager().store.setState((state) => ({

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -2,7 +2,6 @@ import { useStore } from '@tanstack/solid-store'
 import algosdk from 'algosdk'
 import { JSX, createContext, createMemo, onMount, useContext } from 'solid-js'
 import type {
-  NetworkId,
   WalletAccount,
   WalletId,
   WalletManager,
@@ -84,9 +83,13 @@ export function useWallet() {
 
   const activeNetwork = useStore(manager().store, (state) => state.activeNetwork)
 
-  const setActiveNetwork = async (networkId: NetworkId): Promise<void> => {
-    if (activeNetwork() === networkId) {
+  const setActiveNetwork = async (networkId: string): Promise<void> => {
+    if (networkId === activeNetwork()) {
       return
+    }
+
+    if (!manager().networkConfig[networkId]) {
+      throw new Error(`Network "${networkId}" not found in network configuration`)
     }
 
     console.info(`[Solid] Creating Algodv2 client for ${networkId}...`)

--- a/packages/use-wallet-vue/package.json
+++ b/packages/use-wallet-vue/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsup",
     "start": "tsup src/index.ts --watch",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest --watch",
     "lint": "eslint -c \"../../.eslintrc.json\" \"**/*.{js,ts}\"",
     "typecheck": "tsc --noEmit"

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -7,7 +7,7 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
-  defaultState,
+  DEFAULT_STATE,
   type State,
   type WalletAccount
 } from '@txnlab/use-wallet'
@@ -69,7 +69,7 @@ vi.mock('vue', async (importOriginal) => {
   }
 })
 
-const mockStore = new Store<State>(defaultState)
+const mockStore = new Store<State>(DEFAULT_STATE)
 
 const mockDeflyWallet = new DeflyWallet({
   id: WalletId.DEFLY,
@@ -109,7 +109,7 @@ describe('useWallet', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockStore.setState(() => defaultState)
+    mockStore.setState(() => DEFAULT_STATE)
 
     mockWalletManager = new WalletManager()
     mockWallets = [

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -7,6 +7,7 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
+  DEFAULT_NETWORKS,
   DEFAULT_STATE,
   type State,
   type WalletAccount
@@ -76,7 +77,8 @@ const mockDeflyWallet = new DeflyWallet({
   metadata: { name: 'Defly', icon: 'icon' },
   getAlgodClient: () => ({}) as any,
   store: mockStore,
-  subscribe: vi.fn()
+  subscribe: vi.fn(),
+  networks: DEFAULT_NETWORKS
 })
 
 const mockMagicAuth = new MagicAuth({
@@ -87,7 +89,8 @@ const mockMagicAuth = new MagicAuth({
   metadata: { name: 'Magic', icon: 'icon' },
   getAlgodClient: () => ({}) as any,
   store: mockStore,
-  subscribe: vi.fn()
+  subscribe: vi.fn(),
+  networks: DEFAULT_NETWORKS
 })
 
 const mockAlgodClient = ref(new algosdk.Algodv2('token', 'https://server', ''))
@@ -297,7 +300,7 @@ describe('useWallet', () => {
     // Default mainnet algod config
     const newAlgodClient = new algosdk.Algodv2('', 'https://mainnet-api.4160.nodely.dev/', '')
 
-    mockWalletManager.setActiveNetwork = async (networkId: NetworkId) => {
+    mockWalletManager.setActiveNetwork = async (networkId: string) => {
       mockSetAlgodClient(newAlgodClient)
       mockWalletManager.store.setState((state) => ({
         ...state,

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -391,4 +391,31 @@ describe('useWallet', () => {
     expect(wrapper.get('[data-testid="activeWallet"]').text()).toBe(WalletId.DEFLY)
     expect(wrapper.get('[data-testid="activeAddress"]').text()).toBe('address1')
   })
+
+  describe('setActiveNetwork', () => {
+    it('throws error for invalid network', async () => {
+      const { setActiveNetwork } = useWallet()
+
+      await expect(setActiveNetwork('invalid-network')).rejects.toThrow(
+        'Network "invalid-network" not found in network configuration'
+      )
+    })
+
+    it('allows setting custom network that exists in config', async () => {
+      const customNetwork = {
+        name: 'Custom Network',
+        algod: {
+          token: '',
+          baseServer: 'https://custom.network',
+          headers: {}
+        }
+      }
+
+      mockWalletManager.networkConfig['custom-net'] = customNetwork
+      const { setActiveNetwork, activeNetwork } = useWallet()
+
+      await setActiveNetwork('custom-net')
+      expect(activeNetwork.value).toBe('custom-net')
+    })
+  })
 })

--- a/packages/use-wallet-vue/src/__tests__/walletManagerPlugin.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/walletManagerPlugin.test.ts
@@ -34,7 +34,7 @@ describe('WalletManagerPlugin', () => {
   it('provides walletManager, algodClient, and setAlgodClient', () => {
     const options: WalletManagerConfig = {
       wallets: [],
-      network: NetworkId.TESTNET
+      defaultNetwork: NetworkId.TESTNET
     }
     const wrapper = mount(TestComponent, {
       global: {
@@ -52,7 +52,7 @@ describe('WalletManagerPlugin', () => {
   it('initializes with the correct algodClient', () => {
     const options: WalletManagerConfig = {
       wallets: [],
-      network: NetworkId.TESTNET
+      defaultNetwork: NetworkId.TESTNET
     }
     const wrapper = mount(TestComponent, {
       global: {
@@ -68,7 +68,7 @@ describe('WalletManagerPlugin', () => {
   it('setAlgodClient updates the reactive algodClient and manager.algodClient', () => {
     const options: WalletManagerConfig = {
       wallets: [],
-      network: NetworkId.TESTNET
+      defaultNetwork: NetworkId.TESTNET
     }
     const newAlgodClient = new algosdk.Algodv2('mock-token', 'https://mock-server', '')
 
@@ -91,7 +91,7 @@ describe('WalletManagerPlugin', () => {
   it('calls resumeSessions on the walletManager', () => {
     const options: WalletManagerConfig = {
       wallets: [],
-      network: NetworkId.TESTNET
+      defaultNetwork: NetworkId.TESTNET
     }
 
     const wrapper = mount(TestComponent, {

--- a/packages/use-wallet-vue/src/useWallet.ts
+++ b/packages/use-wallet-vue/src/useWallet.ts
@@ -43,7 +43,8 @@ export function useWallet() {
 
     console.info(`[Vue] Creating Algodv2 client for ${networkId}...`)
 
-    const { token, baseServer, port, headers } = manager.networkConfig[networkId]
+    const { algod } = manager.networkConfig[networkId]
+    const { token, baseServer, port, headers } = algod
     const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
     setAlgodClient(newClient)
 

--- a/packages/use-wallet-vue/src/useWallet.ts
+++ b/packages/use-wallet-vue/src/useWallet.ts
@@ -1,10 +1,5 @@
 import { useStore } from '@tanstack/vue-store'
-import {
-  NetworkId,
-  WalletManager,
-  type WalletAccount,
-  type WalletMetadata
-} from '@txnlab/use-wallet'
+import { WalletManager, type WalletAccount, type WalletMetadata } from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
 import { computed, inject, ref } from 'vue'
 
@@ -36,9 +31,13 @@ export function useWallet() {
   }
 
   const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
-  const setActiveNetwork = async (networkId: NetworkId): Promise<void> => {
+  const setActiveNetwork = async (networkId: string): Promise<void> => {
     if (networkId === activeNetwork.value) {
       return
+    }
+
+    if (!manager.networkConfig[networkId]) {
+      throw new Error(`Network "${networkId}" not found in network configuration`)
     }
 
     console.info(`[Vue] Creating Algodv2 client for ${networkId}...`)

--- a/packages/use-wallet/package.json
+++ b/packages/use-wallet/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsup",
     "start": "tsup src/index.ts --watch",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "pnpm run test --watch",
     "lint": "eslint -c \"../../.eslintrc.json\" \"**/*.{js,ts}\"",
     "typecheck": "tsc --noEmit"

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -2,7 +2,7 @@ import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { NetworkConfigBuilder } from 'src/network'
-import { LOCAL_STORAGE_KEY, State, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, DEFAULT_STATE } from 'src/store'
 import { WalletManager } from 'src/manager'
 import { StorageAdapter } from 'src/storage'
 import { BaseWallet } from 'src/wallets/base'
@@ -98,7 +98,7 @@ vi.mock('src/wallets/kibisis', () => ({
   }
 }))
 
-const mockStore = new Store<State>(defaultState)
+const mockStore = new Store<State>(DEFAULT_STATE)
 
 const mockDeflyWallet = new DeflyWallet({
   id: WalletId.DEFLY,
@@ -338,7 +338,7 @@ describe('WalletManager', () => {
       })
 
       // Store initializes with default state if null is returned
-      expect(manager.store.state).toEqual(defaultState)
+      expect(manager.store.state).toEqual(DEFAULT_STATE)
       expect(manager.activeWallet).toBeNull()
       expect(manager.activeNetwork).toBe('testnet')
     })
@@ -356,7 +356,7 @@ describe('WalletManager', () => {
         'Could not load state from local storage: Persisted state is invalid'
       )
       // Store initializes with default state if null is returned
-      expect(manager.store.state).toEqual(defaultState)
+      expect(manager.store.state).toEqual(DEFAULT_STATE)
     })
   })
 

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -152,9 +152,11 @@ describe('WalletManager', () => {
     it('initializes with custom network configurations', () => {
       const networks = new NetworkConfigBuilder()
         .mainnet({
-          token: 'custom-token',
-          baseServer: 'https://custom-server.com',
-          headers: { 'X-API-Key': 'key' }
+          algod: {
+            token: 'custom-token',
+            baseServer: 'https://custom-server.com',
+            headers: { 'X-API-Key': 'key' }
+          }
         })
         .build()
 

--- a/packages/use-wallet/src/__tests__/network.test.ts
+++ b/packages/use-wallet/src/__tests__/network.test.ts
@@ -1,80 +1,135 @@
-import { isAlgodConfig, isNetworkConfigMap, isValidNetworkId, NetworkId } from 'src/network'
+import { NetworkConfigBuilder, isNetworkConfig, createNetworkConfig } from 'src/network'
 
-describe('Network Type Guards', () => {
-  describe('isValidNetworkId', () => {
-    it('returns true for a valid NetworkId', () => {
-      expect(isValidNetworkId(NetworkId.TESTNET)).toBe(true)
+describe('Network Configuration', () => {
+  describe('createNetworkConfig', () => {
+    it('returns default network configurations', () => {
+      const networks = createNetworkConfig()
+
+      expect(networks).toHaveProperty('mainnet')
+      expect(networks).toHaveProperty('testnet')
+      expect(networks).toHaveProperty('betanet')
+      expect(networks).toHaveProperty('fnet')
+      expect(networks).toHaveProperty('localnet')
     })
 
-    it('returns false for an invalid NetworkId', () => {
-      expect(isValidNetworkId('foo')).toBe(false)
+    it('includes correct default values for mainnet', () => {
+      const networks = createNetworkConfig()
+
+      expect(networks.mainnet).toEqual({
+        name: 'MainNet',
+        algod: {
+          token: '',
+          baseServer: 'https://mainnet-api.4160.nodely.dev',
+          headers: {}
+        },
+        isTestnet: false,
+        genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
+        genesisId: 'mainnet-v1.0',
+        caipChainId: 'algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k'
+      })
     })
   })
 
-  describe('isAlgodConfig', () => {
-    it('returns true for a valid AlgodConfig', () => {
-      expect(
-        isAlgodConfig({
-          token: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          baseServer: 'http://localhost',
-          port: 1234,
-          headers: {
-            'X-Foo': 'bar'
+  describe('NetworkConfigBuilder', () => {
+    it('allows customizing default network algod config', () => {
+      const networks = new NetworkConfigBuilder()
+        .mainnet({
+          token: 'custom-token',
+          baseServer: 'custom-server',
+          headers: { 'X-API-Key': 'key' }
+        })
+        .build()
+
+      expect(networks.mainnet.algod).toEqual({
+        token: 'custom-token',
+        baseServer: 'custom-server',
+        headers: { 'X-API-Key': 'key' }
+      })
+      // Other properties should remain unchanged
+      expect(networks.mainnet.name).toBe('MainNet')
+      expect(networks.mainnet.isTestnet).toBe(false)
+    })
+
+    it('allows adding custom networks', () => {
+      const customNetwork = {
+        name: 'Custom Network',
+        algod: {
+          token: 'token',
+          baseServer: 'server',
+          headers: {}
+        },
+        isTestnet: true
+      }
+
+      const networks = new NetworkConfigBuilder().addNetwork('custom', customNetwork).build()
+
+      expect(networks.custom).toEqual(customNetwork)
+      // Default networks should still be present
+      expect(networks.mainnet).toBeDefined()
+    })
+
+    it('prevents overwriting default networks using addNetwork', () => {
+      const builder = new NetworkConfigBuilder()
+
+      expect(() =>
+        builder.addNetwork('mainnet', {
+          name: 'Custom MainNet',
+          algod: {
+            token: '',
+            baseServer: ''
           }
         })
-      ).toBe(true)
-
-      expect(
-        isAlgodConfig({
-          token: '',
-          baseServer: ''
-        })
-      ).toBe(true)
+      ).toThrow('Cannot add network with reserved id "mainnet"')
     })
 
-    it('returns false for an invalid AlgodConfig', () => {
-      expect(
-        isAlgodConfig({
-          baseServer: ''
+    it('maintains all default networks when customizing one', () => {
+      const networks = new NetworkConfigBuilder()
+        .mainnet({
+          token: 'custom-token'
         })
-      ).toBe(false)
+        .build()
 
-      expect(
-        isAlgodConfig({
-          token: ''
-        })
-      ).toBe(false)
-
-      expect(
-        isAlgodConfig({
-          token: '',
-          baseServer: '',
-          foo: ''
-        })
-      ).toBe(false)
+      expect(networks.testnet).toBeDefined()
+      expect(networks.betanet).toBeDefined()
+      expect(networks.fnet).toBeDefined()
+      expect(networks.localnet).toBeDefined()
     })
   })
 
-  describe('isNetworkConfigMap', () => {
-    it('returns true for a valid NetworkConfigMap', () => {
-      const validConfigMap = {
-        [NetworkId.MAINNET]: {
-          token: '',
-          baseServer: ''
-        },
-        [NetworkId.TESTNET]: {
-          token: '',
-          baseServer: ''
+  describe('isNetworkConfig', () => {
+    it('validates correct network configs', () => {
+      const validConfig = {
+        name: 'Test Network',
+        algod: {
+          token: 'token',
+          baseServer: 'server'
         }
       }
-      expect(isNetworkConfigMap(validConfigMap)).toBe(true)
+      expect(isNetworkConfig(validConfig)).toBe(true)
     })
 
-    it('returns false for an invalid NetworkConfigMap', () => {
+    it('validates network configs with optional properties', () => {
+      const validConfig = {
+        name: 'Test Network',
+        algod: {
+          token: 'token',
+          baseServer: 'server'
+        },
+        isTestnet: true,
+        genesisHash: 'hash',
+        genesisId: 'id'
+      }
+      expect(isNetworkConfig(validConfig)).toBe(true)
+    })
+
+    it('rejects invalid network configs', () => {
+      expect(isNetworkConfig(null)).toBe(false)
+      expect(isNetworkConfig({})).toBe(false)
+      expect(isNetworkConfig({ name: 'Test' })).toBe(false)
       expect(
-        isNetworkConfigMap({
-          token: '',
-          baseServer: ''
+        isNetworkConfig({
+          name: 'Test',
+          algod: { baseServer: 'server' }
         })
       ).toBe(false)
     })

--- a/packages/use-wallet/src/__tests__/network.test.ts
+++ b/packages/use-wallet/src/__tests__/network.test.ts
@@ -34,9 +34,11 @@ describe('Network Configuration', () => {
     it('allows customizing default network algod config', () => {
       const networks = new NetworkConfigBuilder()
         .mainnet({
-          token: 'custom-token',
-          baseServer: 'custom-server',
-          headers: { 'X-API-Key': 'key' }
+          algod: {
+            token: 'custom-token',
+            baseServer: 'custom-server',
+            headers: { 'X-API-Key': 'key' }
+          }
         })
         .build()
 
@@ -85,7 +87,10 @@ describe('Network Configuration', () => {
     it('maintains all default networks when customizing one', () => {
       const networks = new NetworkConfigBuilder()
         .mainnet({
-          token: 'custom-token'
+          algod: {
+            token: 'custom-token',
+            baseServer: 'custom-server'
+          }
         })
         .build()
 

--- a/packages/use-wallet/src/__tests__/store.test.ts
+++ b/packages/use-wallet/src/__tests__/store.test.ts
@@ -3,7 +3,7 @@ import { Algodv2 } from 'algosdk'
 import {
   State,
   addWallet,
-  defaultState,
+  DEFAULT_STATE,
   removeWallet,
   setAccounts,
   setActiveAccount,
@@ -30,7 +30,7 @@ describe('Mutations', () => {
   let store: Store<State>
 
   beforeEach(() => {
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
   })
 
   describe('addWallet', () => {
@@ -93,7 +93,7 @@ describe('Mutations', () => {
   describe('removeWallet', () => {
     beforeEach(() => {
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.DEFLY]: {
             accounts: [
@@ -561,13 +561,13 @@ describe('Type Guards', () => {
 
   describe('isValidState', () => {
     it('returns true for a valid state', () => {
-      const defaultState: State = {
+      const DEFAULT_STATE: State = {
         wallets: {},
         activeWallet: null,
         activeNetwork: 'testnet',
         algodClient: new Algodv2('', 'https://testnet-api.4160.nodely.dev/')
       }
-      expect(isValidState(defaultState)).toBe(true)
+      expect(isValidState(DEFAULT_STATE)).toBe(true)
 
       const state: State = {
         wallets: {

--- a/packages/use-wallet/src/__tests__/store.test.ts
+++ b/packages/use-wallet/src/__tests__/store.test.ts
@@ -1,6 +1,5 @@
 import { Store } from '@tanstack/store'
 import { Algodv2 } from 'algosdk'
-import { NetworkId } from 'src/network'
 import {
   State,
   addWallet,
@@ -432,10 +431,10 @@ describe('Mutations', () => {
 
   describe('setActiveNetwork', () => {
     it('should set the active network', () => {
-      // Default network is TESTNET
-      expect(store.state.activeNetwork).toBe(NetworkId.TESTNET)
+      // Default network is testnet
+      expect(store.state.activeNetwork).toBe('testnet')
 
-      const networkId = NetworkId.MAINNET
+      const networkId = 'mainnet'
       const algodClient = new Algodv2('', 'https://mainnet-api.4160.nodely.dev/')
       setActiveNetwork(store, { networkId, algodClient })
       expect(store.state.activeNetwork).toBe(networkId)
@@ -565,7 +564,7 @@ describe('Type Guards', () => {
       const defaultState: State = {
         wallets: {},
         activeWallet: null,
-        activeNetwork: NetworkId.TESTNET,
+        activeNetwork: 'testnet',
         algodClient: new Algodv2('', 'https://testnet-api.4160.nodely.dev/')
       }
       expect(isValidState(defaultState)).toBe(true)
@@ -602,7 +601,7 @@ describe('Type Guards', () => {
           }
         },
         activeWallet: WalletId.DEFLY,
-        activeNetwork: NetworkId.TESTNET,
+        activeNetwork: 'testnet',
         algodClient: new Algodv2('', 'https://testnet-api.4160.nodely.dev/')
       }
       expect(isValidState(state)).toBe(true)
@@ -615,14 +614,14 @@ describe('Type Guards', () => {
       expect(
         isValidState({
           activeWallet: WalletId.DEFLY,
-          activeNetwork: NetworkId.TESTNET
+          activeNetwork: 'testnet'
         })
       ).toBe(false)
 
       expect(
         isValidState({
           wallets: {},
-          activeNetwork: NetworkId.TESTNET
+          activeNetwork: 'testnet'
         })
       ).toBe(false)
 

--- a/packages/use-wallet/src/__tests__/wallets/custom.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/custom.test.ts
@@ -1,6 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, defaultState } from 'src/store'
 import { CustomProvider, CustomWallet, WalletId } from 'src/wallets'
@@ -51,7 +52,8 @@ function createWalletWithStore(store: Store<State>): CustomWallet {
     },
     getAlgodClient: {} as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: {}
   })
 }
 
@@ -196,7 +198,8 @@ describe('CustomWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn()
+        subscribe: vi.fn(),
+        networks: {}
       })
 
       vi.mocked(mockProvider.connect).mockResolvedValueOnce([account1])
@@ -282,7 +285,8 @@ describe('CustomWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn()
+        subscribe: vi.fn(),
+        networks: {}
       })
 
       await wallet.resumeSession()
@@ -331,7 +335,8 @@ describe('CustomWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn()
+        subscribe: vi.fn(),
+        networks: {}
       })
 
       await expect(wallet.signTransactions(txnGroup, indexesToSign)).rejects.toThrowError(
@@ -379,7 +384,8 @@ describe('CustomWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn()
+        subscribe: vi.fn(),
+        networks: DEFAULT_NETWORKS
       })
 
       await expect(wallet.transactionSigner(txnGroup, indexesToSign)).rejects.toThrowError(

--- a/packages/use-wallet/src/__tests__/wallets/custom.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/custom.test.ts
@@ -3,7 +3,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, DEFAULT_STATE } from 'src/store'
 import { CustomProvider, CustomWallet, WalletId } from 'src/wallets'
 import type { Mock } from 'vitest'
 
@@ -101,7 +101,7 @@ describe('CustomWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -222,7 +222,7 @@ describe('CustomWallet', () => {
 
     it('should call provider.resumeSession if a session is found', async () => {
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.CUSTOM]: {
             accounts: [account1],
@@ -241,7 +241,7 @@ describe('CustomWallet', () => {
 
     it('should update the store if provider.resumeSession returns different account(s)', async () => {
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.CUSTOM]: {
             accounts: [account1],
@@ -265,7 +265,7 @@ describe('CustomWallet', () => {
 
     it('should still work if provider.resumeSession is not defined', async () => {
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.CUSTOM]: {
             accounts: [account1],

--- a/packages/use-wallet/src/__tests__/wallets/custom.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/custom.test.ts
@@ -53,7 +53,7 @@ function createWalletWithStore(store: Store<State>): CustomWallet {
     getAlgodClient: {} as any,
     store,
     subscribe: vi.fn(),
-    networks: {}
+    networks: DEFAULT_NETWORKS
   })
 }
 
@@ -199,7 +199,7 @@ describe('CustomWallet', () => {
         getAlgodClient: {} as any,
         store,
         subscribe: vi.fn(),
-        networks: {}
+        networks: DEFAULT_NETWORKS
       })
 
       vi.mocked(mockProvider.connect).mockResolvedValueOnce([account1])
@@ -286,7 +286,7 @@ describe('CustomWallet', () => {
         getAlgodClient: {} as any,
         store,
         subscribe: vi.fn(),
-        networks: {}
+        networks: DEFAULT_NETWORKS
       })
 
       await wallet.resumeSession()
@@ -336,7 +336,7 @@ describe('CustomWallet', () => {
         getAlgodClient: {} as any,
         store,
         subscribe: vi.fn(),
-        networks: {}
+        networks: DEFAULT_NETWORKS
       })
 
       await expect(wallet.signTransactions(txnGroup, indexesToSign)).rejects.toThrowError(

--- a/packages/use-wallet/src/__tests__/wallets/defly.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/defly.test.ts
@@ -3,7 +3,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { DeflyWallet } from 'src/wallets/defly'
 import { WalletId } from 'src/wallets/types'
 import type { Mock } from 'vitest'
@@ -125,7 +125,7 @@ describe('DeflyWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -336,7 +336,7 @@ describe('DeflyWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.DEFLY]: walletState
         }
@@ -373,7 +373,7 @@ describe('DeflyWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.DEFLY]: prevWalletState
         }
@@ -415,7 +415,7 @@ describe('DeflyWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.DEFLY]: walletState
         }
@@ -437,7 +437,7 @@ describe('DeflyWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.DEFLY]: walletState
         }

--- a/packages/use-wallet/src/__tests__/wallets/defly.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/defly.test.ts
@@ -1,6 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { DeflyWallet } from 'src/wallets/defly'
@@ -56,7 +57,8 @@ function createWalletWithStore(store: Store<State>): DeflyWallet {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 
   // @ts-expect-error - Mocking the private client property

--- a/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
@@ -3,7 +3,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
 import { Exodus, ExodusWallet } from 'src/wallets/exodus'
 import { WalletId } from 'src/wallets/types'
@@ -102,7 +102,7 @@ describe('ExodusWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -184,7 +184,7 @@ describe('ExodusWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.EXODUS]: walletState
         }
@@ -208,7 +208,7 @@ describe('ExodusWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.EXODUS]: walletState
         }

--- a/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
@@ -1,6 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
@@ -52,7 +53,8 @@ function createWalletWithStore(store: Store<State>): ExodusWallet {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
@@ -10,6 +10,7 @@ import {
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { defaultState, LOCAL_STORAGE_KEY, State } from 'src/store'
 import { WalletId } from 'src/wallets'
@@ -60,7 +61,8 @@ function createWalletWithStore(store: Store<State>): KibisisWallet {
         })
       }) as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
@@ -12,7 +12,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { defaultState, LOCAL_STORAGE_KEY, State } from 'src/store'
+import { DEFAULT_STATE, LOCAL_STORAGE_KEY, State } from 'src/store'
 import { WalletId } from 'src/wallets'
 import { KibisisWallet, KIBISIS_AVM_WEB_PROVIDER_ID } from 'src/wallets/kibisis'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
@@ -141,7 +141,7 @@ describe('KibisisWallet', () => {
         } as IEnableResult)
       )
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -221,7 +221,7 @@ describe('KibisisWallet', () => {
 
     it(`should call the client's _enable method if Kibisis wallet data is found in the store`, async () => {
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.KIBISIS]: {
             accounts: [account1],
@@ -239,7 +239,7 @@ describe('KibisisWallet', () => {
 
     it(`should not call the client's _enable method if Kibisis wallet data is not found in the store`, async () => {
       // No wallets in store
-      store = new Store<State>(defaultState)
+      store = new Store<State>(DEFAULT_STATE)
       wallet = createWalletWithStore(store)
 
       await wallet.resumeSession()
@@ -251,7 +251,7 @@ describe('KibisisWallet', () => {
     it('should update the store if accounts returned by the client do not match', async () => {
       // Store contains 'account1' and 'account2', with 'account1' as active
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.KIBISIS]: {
             accounts: [account1, account2],

--- a/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
@@ -1,6 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { KmdWallet } from 'src/wallets/kmd'
@@ -53,7 +54,8 @@ function createWalletWithStore(store: Store<State>): KmdWallet {
     metadata: {},
     getAlgodClient: {} as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
@@ -3,7 +3,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { KmdWallet } from 'src/wallets/kmd'
 import { WalletId } from 'src/wallets/types'
 import type { Mock } from 'vitest'
@@ -107,7 +107,7 @@ describe('KmdWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
 
     // Password prompt
@@ -192,7 +192,7 @@ describe('KmdWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.KMD]: walletState
         }

--- a/packages/use-wallet/src/__tests__/wallets/liquid.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/liquid.test.ts
@@ -6,6 +6,7 @@ import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { LiquidWallet } from 'src/wallets/liquid'
 import { WalletId } from 'src/wallets/types'
+import { DEFAULT_NETWORKS } from 'src/network'
 
 // Mock logger
 vi.mock('src/logger', () => ({
@@ -56,7 +57,8 @@ function createWalletWithStore(store: Store<State>): LiquidWallet {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/liquid.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/liquid.test.ts
@@ -3,7 +3,7 @@ import { Store } from '@tanstack/store'
 import { Transaction, TransactionType } from 'algosdk'
 import { logger } from 'src/logger'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { LiquidWallet } from 'src/wallets/liquid'
 import { WalletId } from 'src/wallets/types'
 import { DEFAULT_NETWORKS } from 'src/network'
@@ -102,7 +102,7 @@ describe('LiquidWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -178,7 +178,7 @@ describe('LiquidWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.LIQUID]: walletState
         }

--- a/packages/use-wallet/src/__tests__/wallets/lute.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/lute.test.ts
@@ -2,7 +2,7 @@ import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { byteArrayToBase64 } from 'src/utils'
 import { LuteWallet } from 'src/wallets/lute'
 import { SignTxnsError, WalletId } from 'src/wallets/types'
@@ -131,7 +131,7 @@ describe('LuteWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -202,7 +202,7 @@ describe('LuteWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.LUTE]: walletState
         }

--- a/packages/use-wallet/src/__tests__/wallets/lute.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/lute.test.ts
@@ -44,6 +44,7 @@ vi.mock('lute-connect', () => {
 
 // Import the mocked module
 import LuteConnect from 'lute-connect'
+import { DEFAULT_NETWORKS } from 'src/network'
 
 function createWalletWithStore(store: Store<State>): LuteWallet {
   return new LuteWallet({
@@ -60,7 +61,8 @@ function createWalletWithStore(store: Store<State>): LuteWallet {
         })
       }) as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/lute.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/lute.test.ts
@@ -1,6 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { byteArrayToBase64 } from 'src/utils'
@@ -44,7 +45,6 @@ vi.mock('lute-connect', () => {
 
 // Import the mocked module
 import LuteConnect from 'lute-connect'
-import { DEFAULT_NETWORKS } from 'src/network'
 
 function createWalletWithStore(store: Store<State>): LuteWallet {
   return new LuteWallet({

--- a/packages/use-wallet/src/__tests__/wallets/magic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/magic.test.ts
@@ -3,7 +3,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
 import { MagicAuth } from 'src/wallets/magic'
 import { WalletId } from 'src/wallets/types'
@@ -107,7 +107,7 @@ describe('MagicAuth', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
 
     mockMagicClient.auth.loginWithMagicLink.mockImplementation(() => Promise.resolve())
@@ -208,7 +208,7 @@ describe('MagicAuth', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.MAGIC]: walletState
         }
@@ -241,7 +241,7 @@ describe('MagicAuth', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.MAGIC]: walletState
         }
@@ -278,7 +278,7 @@ describe('MagicAuth', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.MAGIC]: walletState
         }

--- a/packages/use-wallet/src/__tests__/wallets/magic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/magic.test.ts
@@ -1,6 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
@@ -58,7 +59,8 @@ function createWalletWithStore(store: Store<State>): MagicAuth {
     metadata: {},
     getAlgodClient: {} as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
@@ -2,7 +2,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { NetworkId } from 'src/network'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { LOCAL_STORAGE_MNEMONIC_KEY, MnemonicWallet } from 'src/wallets/mnemonic'
@@ -41,7 +41,8 @@ function createWalletWithStore(store: Store<State>, persistToStorage = false): M
     metadata: {},
     getAlgodClient: {} as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 }
 
@@ -61,7 +62,7 @@ describe('MnemonicWallet', () => {
     address: TEST_ADDRESS
   }
 
-  const setActiveNetwork = (networkId: NetworkId) => {
+  const setActiveNetwork = (networkId: string) => {
     store.setState((state) => {
       return {
         ...state,
@@ -138,9 +139,9 @@ describe('MnemonicWallet', () => {
     })
 
     it('should throw an error if active network is MainNet', async () => {
-      setActiveNetwork(NetworkId.MAINNET)
+      setActiveNetwork('mainnet')
 
-      await expect(wallet.connect()).rejects.toThrow('MainNet active network detected. Aborting.')
+      await expect(wallet.connect()).rejects.toThrow('Production network detected. Aborting.')
       expect(store.state.wallets[WalletId.MNEMONIC]).toBeUndefined()
       expect(wallet.isConnected).toBe(false)
     })
@@ -229,11 +230,9 @@ describe('MnemonicWallet', () => {
     })
 
     it('should throw an error if active network is MainNet', async () => {
-      setActiveNetwork(NetworkId.MAINNET)
+      setActiveNetwork('mainnet')
 
-      await expect(wallet.resumeSession()).rejects.toThrow(
-        'MainNet active network detected. Aborting.'
-      )
+      await expect(wallet.resumeSession()).rejects.toThrow('Production network detected. Aborting.')
       expect(store.state.wallets[WalletId.MNEMONIC]).toBeUndefined()
       expect(wallet.isConnected).toBe(false)
     })
@@ -333,10 +332,10 @@ describe('MnemonicWallet', () => {
       })
 
       it('should throw an error if active network is MainNet', async () => {
-        setActiveNetwork(NetworkId.MAINNET)
+        setActiveNetwork('mainnet')
 
         await expect(wallet.signTransactions([])).rejects.toThrow(
-          'MainNet active network detected. Aborting.'
+          'Production network detected. Aborting.'
         )
         expect(store.state.wallets[WalletId.MNEMONIC]).toBeUndefined()
         expect(wallet.isConnected).toBe(false)
@@ -356,10 +355,10 @@ describe('MnemonicWallet', () => {
       })
 
       it('should throw an error if active network is MainNet', async () => {
-        setActiveNetwork(NetworkId.MAINNET)
+        setActiveNetwork('mainnet')
 
         await expect(wallet.transactionSigner([], [])).rejects.toThrow(
-          'MainNet active network detected. Aborting.'
+          'Production network detected. Aborting.'
         )
         expect(store.state.wallets[WalletId.MNEMONIC]).toBeUndefined()
         expect(wallet.isConnected).toBe(false)

--- a/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
@@ -4,7 +4,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { LOCAL_STORAGE_MNEMONIC_KEY, MnemonicWallet } from 'src/wallets/mnemonic'
 import { WalletId } from 'src/wallets/types'
 import type { Mock } from 'vitest'
@@ -101,7 +101,7 @@ describe('MnemonicWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -169,7 +169,7 @@ describe('MnemonicWallet', () => {
 
     it('should disconnect if session is found and persisting to storage is disabled', async () => {
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.MNEMONIC]: {
             accounts: [account1],
@@ -192,7 +192,7 @@ describe('MnemonicWallet', () => {
         activeAccount: account1
       }
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.MNEMONIC]: walletState
         }
@@ -212,7 +212,7 @@ describe('MnemonicWallet', () => {
       global.prompt = vi.fn().mockReturnValue('') // Nothing entered into the mnemonic prompt
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.MNEMONIC]: {
             accounts: [account1],

--- a/packages/use-wallet/src/__tests__/wallets/pera.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera.test.ts
@@ -1,6 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { PeraWallet } from 'src/wallets/pera'
@@ -56,7 +57,8 @@ function createWalletWithStore(store: Store<State>): PeraWallet {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 
   // @ts-expect-error - Mocking the private client property

--- a/packages/use-wallet/src/__tests__/wallets/pera.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera.test.ts
@@ -3,7 +3,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { PeraWallet } from 'src/wallets/pera'
 import { WalletId } from 'src/wallets/types'
 import type { Mock } from 'vitest'
@@ -125,7 +125,7 @@ describe('PeraWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -336,7 +336,7 @@ describe('PeraWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.PERA]: walletState
         }
@@ -373,7 +373,7 @@ describe('PeraWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.PERA]: prevWalletState
         }
@@ -415,7 +415,7 @@ describe('PeraWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.PERA]: walletState
         }
@@ -437,7 +437,7 @@ describe('PeraWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.PERA]: walletState
         }

--- a/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
@@ -1,6 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { PeraWallet } from 'src/wallets/pera2'
@@ -54,7 +55,8 @@ function createWalletWithStore(store: Store<State>): PeraWallet {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 
   // @ts-expect-error - Mocking the private client property

--- a/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
@@ -3,7 +3,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { PeraWallet } from 'src/wallets/pera2'
 import { WalletId } from 'src/wallets/types'
 import type { Mock } from 'vitest'
@@ -109,7 +109,7 @@ describe('PeraWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -217,7 +217,7 @@ describe('PeraWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.PERA2]: walletState
         }
@@ -254,7 +254,7 @@ describe('PeraWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.PERA2]: prevWalletState
         }
@@ -296,7 +296,7 @@ describe('PeraWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.PERA2]: walletState
         }
@@ -318,7 +318,7 @@ describe('PeraWallet', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.PERA2]: walletState
         }

--- a/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
@@ -2,7 +2,7 @@ import { Store } from '@tanstack/store'
 import { ModalCtrl } from '@walletconnect/modal-core'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { NetworkId, caipChainId } from 'src/network'
+import { DEFAULT_NETWORKS, NetworkConfig } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
@@ -58,11 +58,14 @@ vi.spyOn(ModalCtrl, 'subscribe').mockImplementation((_callback: (state: any) => 
   return () => {}
 })
 
-function createMockSession(accounts: string[] = []): SessionTypes.Struct {
+function createMockSession(
+  accounts: string[] = [],
+  networks: Record<string, NetworkConfig>
+): SessionTypes.Struct {
   return {
     namespaces: {
       algorand: {
-        accounts: accounts.map((address) => `${caipChainId[NetworkId.TESTNET]}:${address}`),
+        accounts: accounts.map((address) => `${networks.testnet.caipChainId}:${address}`),
         methods: ['algo_signTxn'],
         events: []
       }
@@ -77,11 +80,7 @@ function createMockSession(accounts: string[] = []): SessionTypes.Struct {
     controller: '',
     requiredNamespaces: {
       algorand: {
-        chains: [
-          caipChainId[NetworkId.MAINNET]!,
-          caipChainId[NetworkId.TESTNET]!,
-          caipChainId[NetworkId.BETANET]!
-        ],
+        chains: [networks.testnet.caipChainId!],
         methods: ['algo_signTxn'],
         events: []
       }
@@ -117,7 +116,8 @@ function createWalletWithStore(store: Store<State>): WalletConnect {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn()
+    subscribe: vi.fn(),
+    networks: DEFAULT_NETWORKS
   })
 }
 
@@ -176,7 +176,10 @@ describe('WalletConnect', () => {
 
   describe('connect', () => {
     it('should initialize client, return accounts, and update store', async () => {
-      const mockSession = createMockSession([account1.address, account2.address])
+      const mockSession = createMockSession(
+        [account1.address, account2.address],
+        wallet.networkConfig
+      )
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
         approval: vi.fn().mockResolvedValue(mockSession)
@@ -193,7 +196,7 @@ describe('WalletConnect', () => {
     })
 
     it('should throw an error if no URI is returned', async () => {
-      const mockSession = createMockSession([])
+      const mockSession = createMockSession([], wallet.networkConfig)
       mockSignClient.connect.mockResolvedValueOnce({
         approval: vi.fn().mockResolvedValue(mockSession)
       })
@@ -205,7 +208,7 @@ describe('WalletConnect', () => {
     })
 
     it('should throw an error if an empty array is returned', async () => {
-      const mockSession = createMockSession([])
+      const mockSession = createMockSession([], wallet.networkConfig)
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
         approval: vi.fn().mockResolvedValue(mockSession)
@@ -218,8 +221,8 @@ describe('WalletConnect', () => {
     })
 
     it('should use the active chain when connecting', async () => {
-      store.setState((state) => ({ ...state, activeNetwork: NetworkId.TESTNET }))
-      const mockSession = createMockSession([account1.address])
+      store.setState((state) => ({ ...state, activeNetwork: 'testnet' }))
+      const mockSession = createMockSession([account1.address], wallet.networkConfig)
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
         approval: vi.fn().mockResolvedValue(mockSession)
@@ -241,7 +244,10 @@ describe('WalletConnect', () => {
 
   describe('disconnect', () => {
     it('should disconnect client and remove wallet from store', async () => {
-      const mockSession = createMockSession([account1.address, account2.address])
+      const mockSession = createMockSession(
+        [account1.address, account2.address],
+        wallet.networkConfig
+      )
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
         approval: vi.fn().mockResolvedValue(mockSession)
@@ -278,7 +284,7 @@ describe('WalletConnect', () => {
 
       wallet = createWalletWithStore(store)
 
-      const mockSession = createMockSession([account1.address])
+      const mockSession = createMockSession([account1.address], wallet.networkConfig)
       mockSignClient.session.get.mockImplementationOnce(() => mockSession)
 
       const mockSessionKey = 'mockSessionKey'
@@ -335,7 +341,7 @@ describe('WalletConnect', () => {
       }
 
       // Client only returns 'GD64YI' on reconnect
-      const mockSession = createMockSession(newAccounts)
+      const mockSession = createMockSession(newAccounts, wallet.networkConfig)
       mockSignClient.session.get.mockImplementationOnce(() => mockSession)
 
       await wallet.resumeSession()
@@ -391,7 +397,10 @@ describe('WalletConnect', () => {
 
     beforeEach(async () => {
       // Mock two connected accounts
-      const mockSession = createMockSession([account1.address, account2.address])
+      const mockSession = createMockSession(
+        [account1.address, account2.address],
+        wallet.networkConfig
+      )
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
         approval: vi.fn().mockResolvedValue(mockSession)
@@ -582,8 +591,8 @@ describe('WalletConnect', () => {
       })
 
       it('should use the active chain when signing transactions', async () => {
-        store.setState((state) => ({ ...state, activeNetwork: NetworkId.MAINNET }))
-        const mockSession = createMockSession([account1.address])
+        store.setState((state) => ({ ...state, activeNetwork: 'mainnet' }))
+        const mockSession = createMockSession([account1.address], wallet.networkConfig)
         mockSignClient.connect.mockResolvedValueOnce({
           uri: 'mock-uri',
           approval: vi.fn().mockResolvedValue(mockSession)
@@ -617,18 +626,18 @@ describe('WalletConnect', () => {
 
   describe('activeChainId', () => {
     it('should return the correct CAIP-2 chain ID for the active network', () => {
-      store.setState((state) => ({ ...state, activeNetwork: NetworkId.MAINNET }))
-      expect(wallet.activeChainId).toBe(caipChainId[NetworkId.MAINNET])
+      store.setState((state) => ({ ...state, activeNetwork: 'mainnet' }))
+      expect(wallet.activeChainId).toBe(wallet.networkConfig.mainnet.caipChainId)
 
-      store.setState((state) => ({ ...state, activeNetwork: NetworkId.TESTNET }))
-      expect(wallet.activeChainId).toBe(caipChainId[NetworkId.TESTNET])
+      store.setState((state) => ({ ...state, activeNetwork: 'testnet' }))
+      expect(wallet.activeChainId).toBe(wallet.networkConfig.testnet.caipChainId)
 
-      store.setState((state) => ({ ...state, activeNetwork: NetworkId.BETANET }))
-      expect(wallet.activeChainId).toBe(caipChainId[NetworkId.BETANET])
+      store.setState((state) => ({ ...state, activeNetwork: 'betanet' }))
+      expect(wallet.activeChainId).toBe(wallet.networkConfig.betanet.caipChainId)
     })
 
     it('should log a warning and return an empty string if no CAIP-2 chain ID is found', () => {
-      store.setState((state) => ({ ...state, activeNetwork: 'invalid-network' as NetworkId }))
+      store.setState((state) => ({ ...state, activeNetwork: 'invalid-network' }))
       expect(wallet.activeChainId).toBe('')
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'No CAIP-2 chain ID found for network: invalid-network'

--- a/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
@@ -4,7 +4,7 @@ import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { DEFAULT_NETWORKS, NetworkConfig } from 'src/network'
 import { StorageAdapter } from 'src/storage'
-import { LOCAL_STORAGE_KEY, State, WalletState, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
 import { WalletConnect } from 'src/wallets/walletconnect'
 import { WalletId, WalletTransaction } from 'src/wallets/types'
@@ -165,7 +165,7 @@ describe('WalletConnect', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    store = new Store<State>(defaultState)
+    store = new Store<State>(DEFAULT_STATE)
     wallet = createWalletWithStore(store)
   })
 
@@ -276,7 +276,7 @@ describe('WalletConnect', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.WALLETCONNECT]: walletState
         }
@@ -317,7 +317,7 @@ describe('WalletConnect', () => {
       }
 
       store = new Store<State>({
-        ...defaultState,
+        ...DEFAULT_STATE,
         wallets: {
           [WalletId.WALLETCONNECT]: prevWalletState
         }

--- a/packages/use-wallet/src/index.ts
+++ b/packages/use-wallet/src/index.ts
@@ -1,7 +1,7 @@
 export { LogLevel } from './logger'
 export { WalletManager, WalletManagerConfig, WalletManagerOptions } from './manager'
 export { NetworkId } from './network'
-export { State, WalletState, defaultState } from './store'
+export { State, WalletState, DEFAULT_STATE } from './store'
 export { StorageAdapter } from './storage'
 export { webpackFallback } from './webpack'
 export * from './wallets'

--- a/packages/use-wallet/src/index.ts
+++ b/packages/use-wallet/src/index.ts
@@ -1,6 +1,6 @@
 export { LogLevel } from './logger'
 export { WalletManager, WalletManagerConfig, WalletManagerOptions } from './manager'
-export { NetworkId } from './network'
+export { NetworkId, DEFAULT_NETWORKS } from './network'
 export { State, WalletState, DEFAULT_STATE } from './store'
 export { StorageAdapter } from './storage'
 export { webpackFallback } from './webpack'

--- a/packages/use-wallet/src/manager.ts
+++ b/packages/use-wallet/src/manager.ts
@@ -4,7 +4,7 @@ import { Logger, LogLevel, logger } from 'src/logger'
 import { createNetworkConfig, isNetworkConfig, type NetworkConfig } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import {
-  defaultState,
+  DEFAULT_STATE,
   isValidState,
   LOCAL_STORAGE_KEY,
   removeWallet,
@@ -88,7 +88,7 @@ export class WalletManager {
 
     // Create initial state
     const initialState: State = {
-      ...defaultState,
+      ...DEFAULT_STATE,
       ...persistedState,
       activeNetwork,
       algodClient

--- a/packages/use-wallet/src/network.ts
+++ b/packages/use-wallet/src/network.ts
@@ -1,19 +1,5 @@
 import algosdk from 'algosdk'
 
-export enum NetworkId {
-  MAINNET = 'mainnet',
-  TESTNET = 'testnet',
-  BETANET = 'betanet',
-  FNET = 'fnet',
-  LOCALNET = 'localnet',
-  VOIMAIN = 'voimain',
-  ARAMIDMAIN = 'aramidmain'
-}
-
-export function isValidNetworkId(networkId: any): networkId is NetworkId {
-  return Object.values(NetworkId).includes(networkId)
-}
-
 export interface AlgodConfig {
   token: string | algosdk.AlgodTokenHeader | algosdk.CustomTokenHeader | algosdk.BaseHTTPClient
   baseServer: string
@@ -21,69 +7,166 @@ export interface AlgodConfig {
   headers?: Record<string, string>
 }
 
-export function isAlgodConfig(config: any): config is AlgodConfig {
-  if (typeof config !== 'object') return false
+export interface NetworkConfig {
+  name: string
+  algod: AlgodConfig
+  genesisHash?: string
+  genesisId?: string
+  isTestnet?: boolean
+  caipChainId?: string
+}
 
-  for (const key of Object.keys(config)) {
-    if (!['token', 'baseServer', 'port', 'headers'].includes(key)) return false
+// Default configurations
+export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
+  mainnet: {
+    name: 'MainNet',
+    algod: {
+      token: '',
+      baseServer: 'https://mainnet-api.4160.nodely.dev',
+      headers: {}
+    },
+    isTestnet: false,
+    genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
+    genesisId: 'mainnet-v1.0',
+    caipChainId: 'algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k'
+  },
+  testnet: {
+    name: 'TestNet',
+    algod: {
+      token: '',
+      baseServer: 'https://testnet-api.4160.nodely.dev',
+      headers: {}
+    },
+    isTestnet: true,
+    genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
+    genesisId: 'testnet-v1.0',
+    caipChainId: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe'
+  },
+  betanet: {
+    name: 'BetaNet',
+    algod: {
+      token: '',
+      baseServer: 'https://betanet-api.4160.nodely.dev',
+      headers: {}
+    },
+    isTestnet: true,
+    genesisHash: 'mFgazF-2uRS1tMiL9dsj01hJGySEmPN2OvOTQHJ6iQg=',
+    genesisId: 'betanet-v1.0',
+    caipChainId: 'algorand:mFgazF-2uRS1tMiL9dsj01hJGySEmPN2'
+  },
+  fnet: {
+    name: 'FNet',
+    algod: {
+      token: '',
+      baseServer: 'https://fnet-api.4160.nodely.dev',
+      headers: {}
+    },
+    isTestnet: true,
+    genesisHash: 'kUt08LxeVAAGHnh4JoAoAMM9ql_hBwSoRrQQKWSVgxk=',
+    genesisId: 'fnet-v1.0',
+    caipChainId: 'algorand:kUt08LxeVAAGHnh4JoAoAMM9ql_hBwSo'
+  },
+  localnet: {
+    name: 'LocalNet',
+    algod: {
+      token: 'a'.repeat(64),
+      baseServer: 'http://localhost',
+      port: 4001,
+      headers: {}
+    },
+    isTestnet: true
+  }
+}
+
+export class NetworkConfigBuilder {
+  private networks: Map<string, NetworkConfig>
+
+  constructor() {
+    // Initialize with default networks
+    this.networks = new Map(Object.entries(DEFAULT_NETWORKS))
   }
 
+  // Methods to customize default networks
+  mainnet(config: Partial<AlgodConfig>) {
+    this.networks.set('mainnet', {
+      ...DEFAULT_NETWORKS.mainnet,
+      algod: { ...DEFAULT_NETWORKS.mainnet.algod, ...config }
+    })
+    return this
+  }
+
+  testnet(config: Partial<AlgodConfig>) {
+    this.networks.set('testnet', {
+      ...DEFAULT_NETWORKS.testnet,
+      algod: { ...DEFAULT_NETWORKS.testnet.algod, ...config }
+    })
+    return this
+  }
+
+  betanet(config: Partial<AlgodConfig>) {
+    this.networks.set('betanet', {
+      ...DEFAULT_NETWORKS.betanet,
+      algod: { ...DEFAULT_NETWORKS.betanet.algod, ...config }
+    })
+    return this
+  }
+
+  fnet(config: Partial<AlgodConfig>) {
+    this.networks.set('fnet', {
+      ...DEFAULT_NETWORKS.fnet,
+      algod: { ...DEFAULT_NETWORKS.fnet.algod, ...config }
+    })
+    return this
+  }
+
+  localnet(config: Partial<AlgodConfig>) {
+    this.networks.set('localnet', {
+      ...DEFAULT_NETWORKS.localnet,
+      algod: { ...DEFAULT_NETWORKS.localnet.algod, ...config }
+    })
+    return this
+  }
+
+  // Method to add custom networks (still needs full NetworkConfig)
+  addNetwork(id: string, config: NetworkConfig) {
+    if (DEFAULT_NETWORKS[id]) {
+      throw new Error(
+        `Cannot add network with reserved id "${id}". Use the ${id}() method instead.`
+      )
+    }
+    this.networks.set(id, config)
+    return this
+  }
+
+  build() {
+    return Object.fromEntries(this.networks)
+  }
+}
+
+// Create a default builder with common presets
+export const createNetworkConfig = () => new NetworkConfigBuilder().build()
+
+// Type guard for runtime validation
+export function isNetworkConfig(config: unknown): config is NetworkConfig {
+  if (typeof config !== 'object' || config === null) return false
+
+  const { name, algod, isTestnet, genesisHash, genesisId } = config as NetworkConfig
+
   return (
-    typeof config.token === 'string' &&
-    typeof config.baseServer === 'string' &&
-    ['string', 'number', 'undefined'].includes(typeof config.port) &&
-    ['object', 'undefined'].includes(typeof config.headers)
+    typeof name === 'string' &&
+    typeof algod === 'object' &&
+    typeof algod.token === 'string' &&
+    typeof algod.baseServer === 'string' &&
+    (isTestnet === undefined || typeof isTestnet === 'boolean') &&
+    (genesisHash === undefined || typeof genesisHash === 'string') &&
+    (genesisId === undefined || typeof genesisId === 'string')
   )
 }
 
-export type NetworkConfigMap = Record<NetworkId, AlgodConfig>
-
-export function isNetworkConfigMap(config: NetworkConfig): config is NetworkConfigMap {
-  const networkKeys = Object.values(NetworkId) as string[]
-  return Object.keys(config).some((key) => networkKeys.includes(key))
-}
-
-export type NetworkConfig = Partial<AlgodConfig> | Partial<Record<NetworkId, Partial<AlgodConfig>>>
-
-export const nodeServerMap = {
-  [NetworkId.MAINNET]: 'https://mainnet-api.4160.nodely.dev',
-  [NetworkId.TESTNET]: 'https://testnet-api.4160.nodely.dev',
-  [NetworkId.BETANET]: 'https://betanet-api.4160.nodely.dev',
-  [NetworkId.FNET]: 'https://fnet-api.4160.nodely.dev',
-  [NetworkId.VOIMAIN]: 'https://mainnet-api.voi.nodely.dev',
-  [NetworkId.ARAMIDMAIN]: 'https://algod.aramidmain.a-wallet.net'
-}
-
-export function createDefaultNetworkConfig(): NetworkConfigMap {
-  const localnetConfig: AlgodConfig = {
-    token: 'a'.repeat(64),
-    baseServer: 'http://localhost',
-    port: 4001,
-    headers: {}
-  }
-
-  return Object.values(NetworkId).reduce((configMap, value) => {
-    const network = value as NetworkId
-    const isLocalnet = network === NetworkId.LOCALNET
-
-    configMap[network] = isLocalnet
-      ? localnetConfig
-      : {
-          token: '',
-          baseServer: nodeServerMap[network],
-          port: '',
-          headers: {}
-        }
-
-    return configMap
-  }, {} as NetworkConfigMap)
-}
-
-export const caipChainId: Partial<Record<NetworkId, string>> = {
-  [NetworkId.MAINNET]: 'algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k',
-  [NetworkId.TESTNET]: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe',
-  [NetworkId.BETANET]: 'algorand:mFgazF-2uRS1tMiL9dsj01hJGySEmPN2',
-  [NetworkId.FNET]: 'algorand:kUt08LxeVAAGHnh4JoAoAMM9ql_hBwSo',
-  [NetworkId.VOIMAIN]: 'algorand:r20fSQI8gWe_kFZziNonSPCXLwcQmH_n',
-  [NetworkId.ARAMIDMAIN]: 'algorand:PgeQVJJgx_LYKJfIEz7dbfNPuXmDyJ-O'
+export enum NetworkId {
+  MAINNET = 'mainnet',
+  TESTNET = 'testnet',
+  BETANET = 'betanet',
+  FNET = 'fnet',
+  LOCALNET = 'localnet'
 }

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -1,6 +1,5 @@
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { NetworkId, isValidNetworkId } from 'src/network'
 import { WalletId, type WalletAccount } from 'src/wallets/types'
 import type { Store } from '@tanstack/store'
 
@@ -14,14 +13,14 @@ export type WalletStateMap = Partial<Record<WalletId, WalletState>>
 export interface State {
   wallets: WalletStateMap
   activeWallet: WalletId | null
-  activeNetwork: NetworkId
+  activeNetwork: string
   algodClient: algosdk.Algodv2
 }
 
 export const defaultState: State = {
   wallets: {},
   activeWallet: null,
-  activeNetwork: NetworkId.TESTNET,
+  activeNetwork: 'testnet',
   algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/')
 }
 
@@ -146,7 +145,7 @@ export function setAccounts(
 
 export function setActiveNetwork(
   store: Store<State>,
-  { networkId, algodClient }: { networkId: NetworkId; algodClient: algosdk.Algodv2 }
+  { networkId, algodClient }: { networkId: string; algodClient: algosdk.Algodv2 }
 ) {
   store.setState((state) => ({
     ...state,
@@ -187,7 +186,7 @@ export function isValidState(state: any): state is State {
     if (!isValidWalletId(walletId) || !isValidWalletState(wallet)) return false
   }
   if (state.activeWallet !== null && !isValidWalletId(state.activeWallet)) return false
-  if (!isValidNetworkId(state.activeNetwork)) return false
+  if (typeof state.activeNetwork !== 'string') return false
 
   return true
 }

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -17,7 +17,7 @@ export interface State {
   algodClient: algosdk.Algodv2
 }
 
-export const defaultState: State = {
+export const DEFAULT_STATE: State = {
   wallets: {},
   activeWallet: null,
   activeNetwork: 'testnet',

--- a/packages/use-wallet/src/utils.ts
+++ b/packages/use-wallet/src/utils.ts
@@ -137,6 +137,7 @@ export function formatJsonRpcRequest<T = any>(method: string, params: T): JsonRp
   }
 }
 
+// @todo: remove
 export function deepMerge(target: any, source: any): any {
   const isObject = (obj: any) => obj && typeof obj === 'object'
 

--- a/packages/use-wallet/src/wallets/base.ts
+++ b/packages/use-wallet/src/wallets/base.ts
@@ -3,8 +3,8 @@ import { StorageAdapter } from 'src/storage'
 import { setActiveWallet, setActiveAccount, removeWallet, type State } from 'src/store'
 import type { Store } from '@tanstack/store'
 import type algosdk from 'algosdk'
-import type { NetworkId } from 'src/network'
 import type { WalletAccount, WalletConstructor, WalletId, WalletMetadata } from 'src/wallets/types'
+import { NetworkConfig } from 'src/network'
 
 interface WalletConstructorType {
   new (...args: any[]): BaseWallet
@@ -14,6 +14,7 @@ interface WalletConstructorType {
 export abstract class BaseWallet {
   readonly id: WalletId
   readonly metadata: WalletMetadata
+  protected readonly networks: Record<string, NetworkConfig>
 
   protected store: Store<State>
   protected getAlgodClient: () => algosdk.Algodv2
@@ -27,12 +28,14 @@ export abstract class BaseWallet {
     metadata,
     store,
     subscribe,
-    getAlgodClient
+    getAlgodClient,
+    networks
   }: WalletConstructor<WalletId>) {
     this.id = id
     this.store = store
     this.subscribe = subscribe
     this.getAlgodClient = getAlgodClient
+    this.networks = networks
 
     const ctor = this.constructor as WalletConstructorType
     this.metadata = { ...ctor.defaultMetadata, ...metadata }
@@ -109,7 +112,7 @@ export abstract class BaseWallet {
     return this.activeAccount?.address ?? null
   }
 
-  public get activeNetwork(): NetworkId {
+  public get activeNetwork(): string {
     const state = this.store.state
     return state.activeNetwork
   }
@@ -123,6 +126,14 @@ export abstract class BaseWallet {
   public get isActive(): boolean {
     const state = this.store.state
     return state.activeWallet === this.id
+  }
+
+  protected get activeNetworkConfig(): NetworkConfig {
+    const config = this.networks[this.activeNetwork]
+    if (!config) {
+      throw new Error(`No configuration found for network: ${this.activeNetwork}`)
+    }
+    return config
   }
 
   // ---------- Protected Methods ------------------------------------- //

--- a/packages/use-wallet/src/wallets/base.ts
+++ b/packages/use-wallet/src/wallets/base.ts
@@ -1,10 +1,10 @@
 import { logger } from 'src/logger'
+import { NetworkConfig } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { setActiveWallet, setActiveAccount, removeWallet, type State } from 'src/store'
 import type { Store } from '@tanstack/store'
 import type algosdk from 'algosdk'
 import type { WalletAccount, WalletConstructor, WalletId, WalletMetadata } from 'src/wallets/types'
-import { NetworkConfig } from 'src/network'
 
 interface WalletConstructorType {
   new (...args: any[]): BaseWallet
@@ -126,6 +126,11 @@ export abstract class BaseWallet {
   public get isActive(): boolean {
     const state = this.store.state
     return state.activeWallet === this.id
+  }
+
+  // Make networks accessible for testing
+  public get networkConfig(): Record<string, NetworkConfig> {
+    return this.networks
   }
 
   protected get activeNetworkConfig(): NetworkConfig {

--- a/packages/use-wallet/src/wallets/custom.ts
+++ b/packages/use-wallet/src/wallets/custom.ts
@@ -38,10 +38,11 @@ export class CustomWallet extends BaseWallet {
     store,
     subscribe,
     getAlgodClient,
+    networks,
     options,
     metadata = {}
   }: WalletConstructor<WalletId.CUSTOM>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
     if (!options?.provider) {
       this.logger.error('Missing required option: provider')
       throw new Error('Missing required option: provider')

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -33,9 +33,10 @@ export class DeflyWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options = {},
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.DEFLY>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
     this.options = options
     this.store = store
   }

--- a/packages/use-wallet/src/wallets/exodus.ts
+++ b/packages/use-wallet/src/wallets/exodus.ts
@@ -90,9 +90,10 @@ export class ExodusWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options = {},
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.EXODUS>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
     this.options = options
     this.store = store
   }

--- a/packages/use-wallet/src/wallets/kibisis.ts
+++ b/packages/use-wallet/src/wallets/kibisis.ts
@@ -37,9 +37,10 @@ export class KibisisWallet extends BaseWallet {
     store,
     subscribe,
     getAlgodClient,
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.KIBISIS>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
 
     this.store = store
   }
@@ -183,9 +184,15 @@ export class KibisisWallet extends BaseWallet {
   }
 
   private async _getGenesisHash(): Promise<string> {
+    // First try to get from network config
+    const network = this.activeNetworkConfig
+    if (network.genesisHash) {
+      return network.genesisHash
+    }
+
+    // Fallback to API request
     const algodClient = this.getAlgodClient()
     const version = await algodClient.versionsCheck().do()
-
     return algosdk.bytesToBase64(version.genesisHashB64)
   }
 

--- a/packages/use-wallet/src/wallets/kmd.ts
+++ b/packages/use-wallet/src/wallets/kmd.ts
@@ -69,10 +69,11 @@ export class KmdWallet extends BaseWallet {
     store,
     subscribe,
     getAlgodClient,
+    networks,
     options,
     metadata = {}
   }: WalletConstructor<WalletId.KMD>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
 
     const {
       token = 'a'.repeat(64),

--- a/packages/use-wallet/src/wallets/liquid.ts
+++ b/packages/use-wallet/src/wallets/liquid.ts
@@ -35,9 +35,10 @@ export class LiquidWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.LIQUID>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
 
     this.store = store
     this.options = options ?? {

--- a/packages/use-wallet/src/wallets/lute.ts
+++ b/packages/use-wallet/src/wallets/lute.ts
@@ -38,9 +38,10 @@ export class LuteWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.LUTE>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
     if (!options?.siteName) {
       this.logger.error('Missing required option: siteName')
       throw new Error('Missing required option: siteName')
@@ -66,14 +67,17 @@ export class LuteWallet extends BaseWallet {
   }
 
   private async getGenesisId(): Promise<string> {
+    const network = this.activeNetworkConfig
+    if (network.genesisId) {
+      return network.genesisId
+    }
+
     const algodClient = this.getAlgodClient()
     const genesisStr = await algodClient.genesis().do()
     const genesis = algosdk.parseJSON(genesisStr, {
       intDecoding: algosdk.IntDecoding.MIXED
     })
-    const genesisId = `${genesis.network}-${genesis.id}`
-
-    return genesisId
+    return `${genesis.network}-${genesis.id}`
   }
 
   public connect = async (): Promise<WalletAccount[]> => {

--- a/packages/use-wallet/src/wallets/magic.ts
+++ b/packages/use-wallet/src/wallets/magic.ts
@@ -54,9 +54,10 @@ export class MagicAuth extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.MAGIC>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
     if (!options?.apiKey) {
       this.logger.error('Missing required option: apiKey')
       throw new Error('Missing required option: apiKey')

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -1,5 +1,4 @@
 import algosdk from 'algosdk'
-import { NetworkId } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, WalletState, addWallet, type State } from 'src/store'
 import { flattenTxnGroup, isSignedTxn, isTransactionArray } from 'src/utils'
@@ -32,9 +31,10 @@ export class MnemonicWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.MNEMONIC>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
 
     const { persistToStorage = false } = options || {}
     this.options = { persistToStorage }
@@ -67,12 +67,12 @@ export class MnemonicWallet extends BaseWallet {
 
   private checkMainnet(): void {
     try {
-      const network = this.activeNetwork
-      if (network === NetworkId.MAINNET) {
+      const network = this.activeNetworkConfig
+      if (!network.isTestnet) {
         this.logger.warn(
           'The Mnemonic wallet provider is insecure and intended for testing only. Any private key mnemonics used should never hold real Algos (i.e., on MainNet).'
         )
-        throw new Error('MainNet active network detected. Aborting.')
+        throw new Error('Production network detected. Aborting.')
       }
     } catch (error) {
       this.disconnect()

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -38,9 +38,10 @@ export class PeraWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options = {},
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.PERA>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
     this.options = options
     this.store = store
   }

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -43,9 +43,10 @@ export class PeraWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.PERA2>) {
-    super({ id, metadata, getAlgodClient, store, subscribe })
+    super({ id, metadata, getAlgodClient, store, subscribe, networks })
     if (!options?.projectId) {
       this.logger.error('Missing required option: projectId')
       throw new Error('Missing required option: projectId')

--- a/packages/use-wallet/src/wallets/types.ts
+++ b/packages/use-wallet/src/wallets/types.ts
@@ -17,6 +17,7 @@ import { BiatecWallet } from './biatec'
 import type { Store } from '@tanstack/store'
 import type algosdk from 'algosdk'
 import type { State } from 'src/store'
+import type { NetworkConfig } from 'src/network'
 
 export enum WalletId {
   BIATEC = 'biatec',
@@ -100,6 +101,7 @@ export interface BaseWalletConstructor {
   getAlgodClient: () => algosdk.Algodv2
   store: Store<State>
   subscribe: (callback: (state: State) => void) => () => void
+  networks: Record<string, NetworkConfig>
 }
 
 export type WalletConstructor<T extends keyof WalletOptionsMap> = BaseWalletConstructor & {

--- a/packages/use-wallet/src/wallets/types.ts
+++ b/packages/use-wallet/src/wallets/types.ts
@@ -16,8 +16,8 @@ import { WalletConnect, type WalletConnectOptions } from './walletconnect'
 import { BiatecWallet } from './biatec'
 import type { Store } from '@tanstack/store'
 import type algosdk from 'algosdk'
-import type { State } from 'src/store'
 import type { NetworkConfig } from 'src/network'
+import type { State } from 'src/store'
 
 export enum WalletId {
   BIATEC = 'biatec',

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -20,7 +20,6 @@ import type {
   WalletId,
   WalletTransaction
 } from 'src/wallets/types'
-import { NetworkConfig } from 'src/network'
 
 interface SignClientOptions {
   projectId: string
@@ -361,11 +360,6 @@ export class WalletConnect extends BaseWallet {
       return ''
     }
     return network.caipChainId
-  }
-
-  // Make networks accessible for testing
-  public get networkConfig(): Record<string, NetworkConfig> {
-    return this.networks
   }
 
   public connect = async (): Promise<WalletAccount[]> => {


### PR DESCRIPTION
## Description

This PR introduces the `NetworkConfigBuilder` to enable customizable network configurations and support for custom networks. It provides a more flexible way to configure network settings, including CAIP-2 chain IDs, and allows applications to define their own networks beyond the default options:

1. mainnet
2. testnet
3. betanet
4. fnet
5. localnet

## Examples

### Using default network configurations
```ts
const manager = new WalletManager({
  wallets: [WalletId.DEFLY, WalletId.KIBISIS],
  defaultNetwork: NetworkId.MAINNET, // property renamed from `network`
})

// Above is equivalent to:
const manager = new WalletManager({
  wallets: [WalletId.DEFLY, WalletId.KIBISIS],
  defaultNetwork: 'mainnet', // string or `NetworkId` enum both valid
  networks: new NetworkConfigBuilder().build() // replaces deprecated `algod` property
})
```

### Adding a custom configuration
```ts
const networks = new NetworkConfigBuilder()
  .mainnet({
    algod: {
      token: process.env.MAINNET_TOKEN,
      baseServer: 'https://my-mainnet-node.com'
    }
  })
  .fnet({
    algod: {
      token: process.env.FNET_TOKEN,
      baseServer: 'https://my-fnet-node.com'
    }
  })
  .build()

const manager = new WalletManager({
  wallets: [WalletId.DEFLY, WalletId.KIBISIS],
  defaultNetwork: NetworkId.MAINNET,
  networks,
})
```

### Adding a custom network
```ts
const networks = new NetworkConfigBuilder()
  .addNetwork('voi', {
    name: 'Voi Network',
    algod: {
      token: '',
      baseServer: 'https://mainnet-api.voi.nodely.dev',
    },
    isTestnet: false
  })
  .build()

const manager = new WalletManager({
  wallets: [WalletId.KIBISIS],
  defaultNetwork: 'voi',
  networks,
})
```

⚠️ **BREAKING CHANGES:** Network configuration now requires using `NetworkConfigBuilder` instead of the `NetworkId`-keyed mapped object from v3. While `NetworkId` is still exported for use with the `defaultNetwork` property, network configurations must be created using the new builder pattern.

## Details
- Add `NetworkConfigBuilder` for creating and customizing network configurations
- Add support for CAIP-2 chain IDs in network configurations
- Add `isTestnet` flag to network configurations
- Update all wallet implementations to use new network config system
- Add `network` property to wallet constructor calls
- Update manager tests to use new network configuration approach
- Add support for custom networks via `NetworkConfigBuilder`
- Update network-related test assertions
- Add proper genesis hash/ID handling from network configs
- Maintain `NetworkId` enum for `defaultNetwork` configuration
- Rename config property `network` to `defaultNetwork`
- Rename config property `algod` to `networks`

Closes #214 