### PR TITLE
feat: add Defly Web extension wallet provider

### DIFF
--- a/examples/nextjs/src/app/providers.tsx
+++ b/examples/nextjs/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { NetworkId, WalletId, WalletManager, WalletProvider } from '@txnlab/use-
 const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
+    WalletId.DEFLY_WEB,
     WalletId.EXODUS,
     WalletId.PERA,
     {

--- a/examples/nuxt/plugins/walletManager.client.ts
+++ b/examples/nuxt/plugins/walletManager.client.ts
@@ -5,6 +5,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(WalletManagerPlugin, {
     wallets: [
       WalletId.DEFLY,
+      WalletId.DEFLY_WEB,
       WalletId.EXODUS,
       WalletId.PERA,
       {

--- a/examples/react-ts/src/App.tsx
+++ b/examples/react-ts/src/App.tsx
@@ -7,6 +7,7 @@ import './App.css'
 const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
+    WalletId.DEFLY_WEB,
     WalletId.EXODUS,
     WalletId.PERA,
     {

--- a/examples/solid-ts/src/App.tsx
+++ b/examples/solid-ts/src/App.tsx
@@ -7,6 +7,7 @@ import './App.css'
 const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
+    WalletId.DEFLY_WEB,
     WalletId.EXODUS,
     WalletId.PERA,
     {

--- a/examples/vanilla-ts/src/main.ts
+++ b/examples/vanilla-ts/src/main.ts
@@ -8,6 +8,7 @@ import { WalletComponent } from './WalletComponent'
 const walletManager = new WalletManager({
   wallets: [
     WalletId.DEFLY,
+    WalletId.DEFLY_WEB,
     WalletId.EXODUS,
     WalletId.PERA,
     {

--- a/examples/vue-ts/src/main.ts
+++ b/examples/vue-ts/src/main.ts
@@ -8,6 +8,7 @@ const app = createApp(App)
 app.use(WalletManagerPlugin, {
   wallets: [
     WalletId.DEFLY,
+    WalletId.DEFLY_WEB,
     WalletId.EXODUS,
     WalletId.PERA,
     {

--- a/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
@@ -1,8 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import {
   ARC0027MethodCanceledError,
   ARC0027MethodEnum,
+  IARC0001Transaction,
   IDisableResult,
   IEnableResult,
   ISignTransactionsResult
@@ -16,7 +15,14 @@ import { DEFAULT_STATE, LOCAL_STORAGE_KEY, State } from 'src/store'
 import { WalletId } from 'src/wallets'
 import { KibisisWallet, KIBISIS_AVM_WEB_PROVIDER_ID } from 'src/wallets/kibisis'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
-import type { Mock } from 'vitest'
+import type { Mock, MockInstance } from 'vitest'
+
+// Test utility type to expose protected members
+type TestableKibisisWallet = KibisisWallet & {
+  _signTransactions: (txns: IARC0001Transaction[]) => Promise<ISignTransactionsResult>
+  _enable: () => Promise<IEnableResult>
+  _disable: () => Promise<IDisableResult>
+}
 
 // Mock logger
 vi.mock('src/logger', () => ({
@@ -66,14 +72,17 @@ function createWalletWithStore(store: Store<State>): KibisisWallet {
   })
 }
 
-function mockSignTransactionsResponseOnce(stxns: (string | null)[]): void {
-  vi.spyOn(KibisisWallet.prototype, '_signTransactions')
+function mockSignTransactionsResponseOnce(
+  stxns: (string | null)[]
+): MockInstance<(txns: IARC0001Transaction[]) => Promise<ISignTransactionsResult>> {
+  return vi
+    .spyOn(KibisisWallet.prototype as TestableKibisisWallet, '_signTransactions')
     .mockReset()
     .mockImplementationOnce(() =>
       Promise.resolve({
         providerId: KIBISIS_AVM_WEB_PROVIDER_ID,
         stxns
-      } as ISignTransactionsResult)
+      })
     )
 }
 
@@ -121,16 +130,16 @@ describe('KibisisWallet', () => {
     }
     vi.mocked(logger.createScopedLogger).mockReturnValue(mockLogger)
 
-    vi.spyOn(KibisisWallet.prototype, '_disable')
+    vi.spyOn(KibisisWallet.prototype as TestableKibisisWallet, '_disable')
       .mockReset()
       .mockImplementation(() =>
         Promise.resolve({
           genesisHash: TESTNET_GENESIS_HASH,
           genesisId: TESTNET_GENESIS_ID,
           providerId: KIBISIS_AVM_WEB_PROVIDER_ID
-        } as IDisableResult)
+        })
       )
-    vi.spyOn(KibisisWallet.prototype, '_enable')
+    vi.spyOn(KibisisWallet.prototype as TestableKibisisWallet, '_enable')
       .mockReset()
       .mockImplementation(() =>
         Promise.resolve({
@@ -138,7 +147,7 @@ describe('KibisisWallet', () => {
           genesisHash: TESTNET_GENESIS_HASH,
           genesisId: TESTNET_GENESIS_ID,
           providerId: KIBISIS_AVM_WEB_PROVIDER_ID
-        } as IEnableResult)
+        })
       )
 
     store = new Store<State>(DEFAULT_STATE)
@@ -175,7 +184,7 @@ describe('KibisisWallet', () => {
       })
 
       // Mock error response
-      vi.spyOn(KibisisWallet.prototype, '_enable')
+      vi.spyOn(KibisisWallet.prototype as TestableKibisisWallet, '_enable')
         .mockReset()
         .mockImplementationOnce(() => Promise.reject(error))
 
@@ -262,7 +271,7 @@ describe('KibisisWallet', () => {
       wallet = createWalletWithStore(store)
 
       // Client only returns 'account2' on reconnect, 'account1' is missing
-      vi.spyOn(KibisisWallet.prototype, '_enable')
+      vi.spyOn(KibisisWallet.prototype as TestableKibisisWallet, '_enable')
         .mockReset()
         .mockImplementation(() =>
           Promise.resolve({
@@ -311,13 +320,13 @@ describe('KibisisWallet', () => {
     const mockSignedTxns = [byteArrayToBase64(txn1.toByte())]
 
     beforeEach(async () => {
-      vi.spyOn(KibisisWallet.prototype, '_signTransactions')
+      vi.spyOn(KibisisWallet.prototype as TestableKibisisWallet, '_signTransactions')
         .mockReset()
         .mockImplementation(() =>
           Promise.resolve({
             providerId: KIBISIS_AVM_WEB_PROVIDER_ID,
             stxns: mockSignedTxns
-          } as ISignTransactionsResult)
+          })
         )
 
       await wallet.connect()
@@ -341,7 +350,7 @@ describe('KibisisWallet', () => {
         })
 
         // Mock signTxns error response
-        vi.spyOn(KibisisWallet.prototype, '_signTransactions')
+        vi.spyOn(KibisisWallet.prototype as TestableKibisisWallet, '_signTransactions')
           .mockReset()
           .mockImplementationOnce(() => Promise.reject(error))
 

--- a/packages/use-wallet/src/utils.ts
+++ b/packages/use-wallet/src/utils.ts
@@ -3,6 +3,7 @@ import { WalletId, type JsonRpcRequest, type WalletAccount, type WalletMap } fro
 import { BiatecWallet } from './wallets/biatec'
 import { CustomWallet } from './wallets/custom'
 import { DeflyWallet } from './wallets/defly'
+import { DeflyWebWallet } from './wallets/defly-web'
 import { ExodusWallet } from './wallets/exodus'
 import { KibisisWallet } from './wallets/kibisis'
 import { KmdWallet } from './wallets/kmd'
@@ -19,6 +20,7 @@ export function createWalletMap(): WalletMap {
     [WalletId.BIATEC]: BiatecWallet,
     [WalletId.CUSTOM]: CustomWallet,
     [WalletId.DEFLY]: DeflyWallet,
+    [WalletId.DEFLY_WEB]: DeflyWebWallet,
     [WalletId.EXODUS]: ExodusWallet,
     [WalletId.KIBISIS]: KibisisWallet,
     [WalletId.KMD]: KmdWallet,

--- a/packages/use-wallet/src/wallets/avm-web-provider.ts
+++ b/packages/use-wallet/src/wallets/avm-web-provider.ts
@@ -1,0 +1,286 @@
+import algosdk from 'algosdk'
+import { WalletState, addWallet, setAccounts } from 'src/store'
+import {
+  base64ToByteArray,
+  byteArrayToBase64,
+  compareAccounts,
+  flattenTxnGroup,
+  isSignedTxn,
+  isTransactionArray
+} from 'src/utils'
+import { BaseWallet } from 'src/wallets/base'
+import { WalletId, type WalletAccount, type WalletConstructor } from 'src/wallets/types'
+import type AVMWebProviderSDK from '@agoralabs-sh/avm-web-provider'
+
+export function isAVMWebProviderSDKError(error: any): error is AVMWebProviderSDK.BaseARC0027Error {
+  return typeof error === 'object' && 'code' in error && 'message' in error
+}
+
+export abstract class AVMProvider extends BaseWallet {
+  public avmWebClient: AVMWebProviderSDK.AVMWebClient | null = null
+  protected avmWebProviderSDK: typeof AVMWebProviderSDK | null = null
+  protected providerId: string
+
+  constructor(args: WalletConstructor<WalletId> & { providerId: string }) {
+    super(args)
+    this.providerId = args.providerId
+  }
+
+  protected async _initializeAVMWebProviderSDK(): Promise<typeof AVMWebProviderSDK> {
+    if (!this.avmWebProviderSDK) {
+      this.logger.info('Initializing @agoralabs-sh/avm-web-provider...')
+
+      const module = await import('@agoralabs-sh/avm-web-provider')
+      this.avmWebProviderSDK = module.default ? module.default : module
+
+      if (!this.avmWebProviderSDK) {
+        throw new Error(
+          'Failed to initialize, the @agoralabs-sh/avm-web-provider SDK was not provided'
+        )
+      }
+
+      if (!this.avmWebProviderSDK.AVMWebClient) {
+        throw new Error(
+          'Failed to initialize, AVMWebClient missing from @agoralabs-sh/avm-web-provider SDK'
+        )
+      }
+      this.logger.info('@agoralabs-sh/avm-web-provider SDK initialized')
+    }
+
+    return this.avmWebProviderSDK
+  }
+
+  protected async _initializeAVMWebClient(): Promise<AVMWebProviderSDK.AVMWebClient> {
+    const avmWebProviderSDK = await this._initializeAVMWebProviderSDK()
+
+    if (!avmWebProviderSDK.AVMWebClient) {
+      throw new Error('Failed to initialize, AVMWebClient not found')
+    }
+
+    if (!this.avmWebClient) {
+      this.logger.info('Initializing new AVM Web Client...')
+      this.avmWebClient = avmWebProviderSDK.AVMWebClient.init()
+      this.logger.info('AVM Web Client initialized')
+    }
+
+    return this.avmWebClient
+  }
+
+  protected async _getGenesisHash(): Promise<string> {
+    const algodClient = this.getAlgodClient()
+    const version = await algodClient.versionsCheck().do()
+    return version.genesis_hash_b64
+  }
+
+  protected _mapAVMWebProviderAccountToWalletAccounts(
+    accounts: AVMWebProviderSDK.IAccount[]
+  ): WalletAccount[] {
+    return accounts.map(({ address, name }, idx) => ({
+      name: name || `[${this.metadata.name}] Account ${idx + 1}`,
+      address
+    }))
+  }
+
+  protected processTxns(
+    txnGroup: algosdk.Transaction[],
+    indexesToSign?: number[]
+  ): AVMWebProviderSDK.IARC0001Transaction[] {
+    const txnsToSign: AVMWebProviderSDK.IARC0001Transaction[] = []
+
+    txnGroup.forEach((txn, index) => {
+      const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
+      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const canSignTxn = this.addresses.includes(signer)
+
+      const txnString = byteArrayToBase64(txn.toByte())
+
+      if (isIndexMatch && canSignTxn) {
+        txnsToSign.push({ txn: txnString })
+      } else {
+        txnsToSign.push({ txn: txnString, signers: [] })
+      }
+    })
+
+    return txnsToSign
+  }
+
+  protected processEncodedTxns(
+    txnGroup: Uint8Array[],
+    indexesToSign?: number[]
+  ): AVMWebProviderSDK.IARC0001Transaction[] {
+    const txnsToSign: AVMWebProviderSDK.IARC0001Transaction[] = []
+
+    txnGroup.forEach((txnBuffer, index) => {
+      const txnDecodeObj = algosdk.decodeObj(txnBuffer) as
+        | algosdk.EncodedTransaction
+        | algosdk.EncodedSignedTransaction
+
+      const isSigned = isSignedTxn(txnDecodeObj)
+
+      const txn: algosdk.Transaction = isSigned
+        ? algosdk.decodeSignedTransaction(txnBuffer).txn
+        : algosdk.decodeUnsignedTransaction(txnBuffer)
+
+      const isIndexMatch = !indexesToSign || indexesToSign.includes(index)
+      const signer = algosdk.encodeAddress(txn.from.publicKey)
+      const canSignTxn = !isSigned && this.addresses.includes(signer)
+
+      const txnString = byteArrayToBase64(txn.toByte())
+
+      if (isIndexMatch && canSignTxn) {
+        txnsToSign.push({ txn: txnString })
+      } else {
+        txnsToSign.push({ txn: txnString, signers: [] })
+      }
+    })
+
+    return txnsToSign
+  }
+
+  /**
+   * Abstract methods
+   * These methods must be implemented by specific wallet providers
+   */
+  protected abstract _enable(): Promise<AVMWebProviderSDK.IEnableResult>
+  protected abstract _disable(): Promise<AVMWebProviderSDK.IDisableResult>
+  protected abstract _signTransactions(
+    txns: AVMWebProviderSDK.IARC0001Transaction[]
+  ): Promise<AVMWebProviderSDK.ISignTransactionsResult>
+
+  /**
+   * Common methods
+   * These methods can be overridden by specific wallet providers if needed
+   */
+  public async connect(): Promise<WalletAccount[]> {
+    try {
+      this.logger.info('Connecting...')
+      const result = await this._enable()
+      this.logger.info(`Successfully connected on network "${result.genesisId}"`)
+
+      const walletAccounts = this._mapAVMWebProviderAccountToWalletAccounts(result.accounts)
+
+      const walletState: WalletState = {
+        accounts: walletAccounts,
+        activeAccount: walletAccounts[0]
+      }
+
+      addWallet(this.store, {
+        walletId: this.id,
+        wallet: walletState
+      })
+
+      this.logger.info('✅ Connected.', walletState)
+      return walletAccounts
+    } catch (error: any) {
+      this.logger.error(
+        'Error connecting: ',
+        isAVMWebProviderSDKError(error) ? `${error.message} (code: ${error.code})` : error.message
+      )
+      throw error
+    }
+  }
+
+  public async disconnect(): Promise<void> {
+    try {
+      this.logger.info('Disconnecting...')
+      this.onDisconnect()
+
+      const result = await this._disable()
+
+      this.logger.info(
+        `Successfully disconnected${result.sessionIds && result.sessionIds.length ? ` sessions [${result.sessionIds.join(',')}]` : ''} on network "${result.genesisId}"`
+      )
+    } catch (error: any) {
+      this.logger.error(
+        'Error disconnecting: ',
+        isAVMWebProviderSDKError(error) ? `${error.message} (code: ${error.code})` : error.message
+      )
+      throw error
+    }
+  }
+
+  public async resumeSession(): Promise<void> {
+    const state = this.store.state
+    const walletState = state.wallets[this.id]
+
+    if (!walletState) {
+      this.logger.info('No session to resume')
+      return
+    }
+
+    try {
+      this.logger.info('Resuming session...')
+
+      const result = await this._enable()
+
+      if (result.accounts.length === 0) {
+        throw new Error('No accounts found!')
+      }
+
+      const walletAccounts = this._mapAVMWebProviderAccountToWalletAccounts(result.accounts)
+      const match = compareAccounts(walletAccounts, walletState.accounts)
+
+      if (!match) {
+        this.logger.warn('Session accounts mismatch, updating accounts', {
+          prev: walletState.accounts,
+          current: walletAccounts
+        })
+
+        setAccounts(this.store, {
+          walletId: this.id,
+          accounts: walletAccounts
+        })
+      }
+      this.logger.info('Session resumed successfully')
+    } catch (error: any) {
+      this.logger.error(
+        'Error resuming session: ',
+        isAVMWebProviderSDKError(error) ? `${error.message} (code: ${error.code})` : error.message
+      )
+      this.onDisconnect()
+      throw error
+    }
+  }
+
+  public async signTransactions<T extends algosdk.Transaction[] | Uint8Array[]>(
+    txnGroup: T | T[],
+    indexesToSign?: number[]
+  ): Promise<(Uint8Array | null)[]> {
+    try {
+      this.logger.debug('Signing transactions...', { txnGroup, indexesToSign })
+      let txnsToSign: AVMWebProviderSDK.IARC0001Transaction[] = []
+
+      // Determine type and process transactions for signing
+      if (isTransactionArray(txnGroup)) {
+        const flatTxns: algosdk.Transaction[] = flattenTxnGroup(txnGroup)
+        txnsToSign = this.processTxns(flatTxns, indexesToSign)
+      } else {
+        const flatTxns: Uint8Array[] = flattenTxnGroup(txnGroup as Uint8Array[])
+        txnsToSign = this.processEncodedTxns(flatTxns, indexesToSign)
+      }
+
+      this.logger.debug('Sending processed transactions to wallet...', txnsToSign)
+
+      // Sign transactions
+      const signTxnsResult = await this._signTransactions(txnsToSign)
+      this.logger.debug('Received signed transactions from wallet', signTxnsResult)
+
+      // Convert base64 to Uint8Array
+      const result = signTxnsResult.stxns.map((value) => {
+        if (value === null) {
+          return null
+        }
+        return base64ToByteArray(value)
+      })
+
+      this.logger.debug('Transactions signed successfully', result)
+      return result
+    } catch (error: any) {
+      this.logger.error(
+        'Error signing transactions: ',
+        isAVMWebProviderSDKError(error) ? `${error.message} (code: ${error.code})` : error.message
+      )
+      throw error
+    }
+  }
+}

--- a/packages/use-wallet/src/wallets/defly-web.ts
+++ b/packages/use-wallet/src/wallets/defly-web.ts
@@ -18,7 +18,8 @@ export class DeflyWebWallet extends AVMProvider {
     store,
     subscribe,
     getAlgodClient,
-    metadata = {}
+    metadata = {},
+    networks
   }: WalletConstructor<WalletId.DEFLY_WEB>) {
     super({
       id,
@@ -26,6 +27,7 @@ export class DeflyWebWallet extends AVMProvider {
       getAlgodClient,
       store,
       subscribe,
+      networks,
       providerId: DEFLY_WEB_PROVIDER_ID
     })
   }

--- a/packages/use-wallet/src/wallets/defly-web.ts
+++ b/packages/use-wallet/src/wallets/defly-web.ts
@@ -2,38 +2,36 @@ import { AVMProvider } from 'src/wallets/avm-web-provider'
 import { WalletId, type WalletConstructor } from 'src/wallets/types'
 import type AVMWebProviderSDK from '@agoralabs-sh/avm-web-provider'
 
-export const KIBISIS_AVM_WEB_PROVIDER_ID = 'f6d1c86b-4493-42fb-b88d-a62407b4cdf6'
+export const DEFLY_WEB_PROVIDER_ID = '95426e60-5f2e-49e9-b912-c488577be962'
 
-export const ICON = `data:image/svg+xml;base64,${btoa(`
-<svg viewBox="0 0 480 480" xmlns="http://www.w3.org/2000/svg">
-  <rect fill="#801C96" width="480" height="480" />
-  <path fill="#FFFFFF" d="M393.5,223.2c0-7.3-0.6-14.6-1.6-21.6c-0.9-6.5-2.3-12.8-4-18.9c-18-64.9-77.4-112.5-148-112.5c-70.6,0-130,47.6-148,112.5c-1.7,6.2-3,12.5-4,19c-1,7.1-1.6,14.3-1.6,21.6h0v85.5h19.7v-85.5c0-7.2,0.6-14.4,1.8-21.4c14,1.1,27.6,4.3,40.5,9.5c15.9,6.4,30.3,15.6,42.6,27.3c12.3,11.7,22,25.4,28.7,40.6c6.9,15.6,10.5,32.2,10.5,49.2v81.4h0.1h19.6h0.1v-81.5c0.1-17.1,3.6-33.7,10.5-49.2c6.7-15.2,16.4-28.8,28.7-40.6c4.2-4,8.6-7.7,13.2-11.1v132.2h19.7V223.2h0c0-2.5-0.1-5-0.4-7.4c3.3-1.6,6.6-3.1,10-4.5c12.9-5.2,26.4-8.4,40.4-9.5c1.2,7,1.7,14.2,1.8,21.4v85.5h19.7L393.5,223.2L393.5,223.2z M240.1,277.3c-11.6-29.3-32.7-54.1-59.8-71c2.9-10,8.2-19.1,15.8-26.6c11.8-11.8,27.4-18.2,44-18.2s32.3,6.5,44,18.2c4.1,4.1,7.5,8.7,10.3,13.6c5.6-3.4,11.4-6.4,17.4-9.2c-14-25.2-40.9-42.3-71.8-42.3c-35.9,0-66.3,23-77.5,55.1c-15.5-7.1-32.5-11.8-50.4-13.5c1.3-4,2.7-7.9,4.3-11.8c6.7-15.9,16.4-30.3,28.7-42.6s26.6-22,42.6-28.7c16.5-7,34-10.5,52.1-10.5s35.6,3.5,52.1,10.5c15.9,6.7,30.3,16.4,42.6,28.7s22,26.6,28.7,42.6c1.6,3.9,3.1,7.8,4.3,11.8C309,189.2,260.1,226.5,240.1,277.3z" />
-  <path fill="#FFFFFF" d="M158.1,359.8h19.7V245.5c-6.1-5.4-12.7-10-19.7-14V359.8z" />
+const ICON = `data:image/svg+xml;base64,${btoa(`
+<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1024" height="1024" />
+  <path fill="#FFFFFF" d="M779.9,684.4L512,230L244.1,684.4L512,529.5L779.9,684.4z" />
+  <path fill="#FFFFFF" d="M733.1,730L512,613.5L290.9,730L512,658L733.1,730z" />
 </svg>
 `)}`
 
-export class KibisisWallet extends AVMProvider {
+export class DeflyWebWallet extends AVMProvider {
   constructor({
     id,
     store,
     subscribe,
     getAlgodClient,
-    metadata = {},
-    networks
-  }: WalletConstructor<WalletId.KIBISIS>) {
+    metadata = {}
+  }: WalletConstructor<WalletId.DEFLY_WEB>) {
     super({
       id,
       metadata,
       getAlgodClient,
       store,
       subscribe,
-      networks,
-      providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+      providerId: DEFLY_WEB_PROVIDER_ID
     })
   }
 
   static defaultMetadata = {
-    name: 'Kibisis',
+    name: 'Defly Web Wallet',
     icon: ICON
   }
 
@@ -65,7 +63,7 @@ export class KibisisWallet extends AVMProvider {
           new ARC0027MethodTimedOutError({
             method: ARC0027MethodEnum.Enable,
             message: `no response from provider "${this.metadata.name}"`,
-            providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+            providerId: DEFLY_WEB_PROVIDER_ID
           })
         )
       }, DEFAULT_REQUEST_TIMEOUT)
@@ -84,7 +82,7 @@ export class KibisisWallet extends AVMProvider {
           return reject(
             new ARC0027UnknownError({
               message: `received response, but "${method}" request details were empty for provider "${this.metadata.name}"`,
-              providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+              providerId: DEFLY_WEB_PROVIDER_ID
             })
           )
         }
@@ -95,7 +93,7 @@ export class KibisisWallet extends AVMProvider {
       // send the request
       avmWebClient.enable({
         genesisHash,
-        providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+        providerId: DEFLY_WEB_PROVIDER_ID
       })
     })
   }
@@ -127,7 +125,7 @@ export class KibisisWallet extends AVMProvider {
           new ARC0027MethodTimedOutError({
             method: ARC0027MethodEnum.Disable,
             message: `no response from provider "${this.metadata.name}"`,
-            providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+            providerId: DEFLY_WEB_PROVIDER_ID
           })
         )
       }, LOWER_REQUEST_TIMEOUT)
@@ -146,7 +144,7 @@ export class KibisisWallet extends AVMProvider {
           return reject(
             new ARC0027UnknownError({
               message: `received response, but "${method}" request details were empty for provider "${this.metadata.name}"`,
-              providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+              providerId: DEFLY_WEB_PROVIDER_ID
             })
           )
         }
@@ -158,7 +156,7 @@ export class KibisisWallet extends AVMProvider {
       this.logger.debug('Sending disable request...', { genesisHash })
       avmWebClient.disable({
         genesisHash,
-        providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+        providerId: DEFLY_WEB_PROVIDER_ID
       })
     })
   }
@@ -196,7 +194,7 @@ export class KibisisWallet extends AVMProvider {
           new ARC0027MethodTimedOutError({
             method: ARC0027MethodEnum.SignTransactions,
             message: `no response from provider "${this.metadata.name}"`,
-            providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+            providerId: DEFLY_WEB_PROVIDER_ID
           })
         )
       }, DEFAULT_REQUEST_TIMEOUT)
@@ -215,7 +213,7 @@ export class KibisisWallet extends AVMProvider {
           return reject(
             new ARC0027UnknownError({
               message: `received response, but "${method}" request details were empty for provider "${this.metadata.name}"`,
-              providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+              providerId: DEFLY_WEB_PROVIDER_ID
             })
           )
         }
@@ -227,7 +225,7 @@ export class KibisisWallet extends AVMProvider {
       this.logger.debug('Sending sign transactions request...', { txns })
       avmWebClient.signTransactions({
         txns,
-        providerId: KIBISIS_AVM_WEB_PROVIDER_ID
+        providerId: DEFLY_WEB_PROVIDER_ID
       })
     })
   }

--- a/packages/use-wallet/src/wallets/types.ts
+++ b/packages/use-wallet/src/wallets/types.ts
@@ -1,5 +1,6 @@
 import { CustomWallet, CustomWalletOptions } from './custom'
 import { DeflyWallet, type DeflyWalletConnectOptions } from './defly'
+import { DeflyWebWallet } from './defly-web'
 import { ExodusWallet, type ExodusOptions } from './exodus'
 import { KibisisWallet } from './kibisis'
 import { KmdWallet, type KmdOptions } from './kmd'
@@ -22,6 +23,7 @@ import type { State } from 'src/store'
 export enum WalletId {
   BIATEC = 'biatec',
   DEFLY = 'defly',
+  DEFLY_WEB = 'defly-web',
   CUSTOM = 'custom',
   EXODUS = 'exodus',
   KIBISIS = 'kibisis',
@@ -39,6 +41,7 @@ export type WalletMap = {
   [WalletId.BIATEC]: typeof BiatecWallet
   [WalletId.CUSTOM]: typeof CustomWallet
   [WalletId.DEFLY]: typeof DeflyWallet
+  [WalletId.DEFLY_WEB]: typeof DeflyWebWallet
   [WalletId.EXODUS]: typeof ExodusWallet
   [WalletId.KIBISIS]: typeof KibisisWallet
   [WalletId.KMD]: typeof KmdWallet
@@ -55,6 +58,7 @@ export type WalletOptionsMap = {
   [WalletId.BIATEC]: WalletConnectOptions
   [WalletId.CUSTOM]: CustomWalletOptions
   [WalletId.DEFLY]: DeflyWalletConnectOptions
+  [WalletId.DEFLY_WEB]: Record<string, never>
   [WalletId.EXODUS]: ExodusOptions
   [WalletId.KIBISIS]: Record<string, never>
   [WalletId.KMD]: KmdOptions


### PR DESCRIPTION
## Description

This PR migrates the Defly Web provider implementation from #256 to the v4 architecture, adapting it to work with the new network configuration system and `algosdk` v3. See the [original PR](https://github.com/TxnLab/use-wallet/pull/256) for details about the initial Defly Web provider implementation, which will be closed in favor of this v4-compatible version.

It also improves type safety across AVM provider tests by removing `@ts-nocheck` comments and introducing proper TypeScript patterns.

## Details
- Update Defly Web provider to use new network configuration builder
- Adapt transaction signing to use `algosdk` v3 API
- Fix genesis hash handling with network config fallback
- Remove `@ts-nocheck` comments from AVM provider tests
- Add type-safe utility types for testing protected methods
- Update test spies to use proper TypeScript type assertions
- Maintain consistent type checking across wallet provider tests