### PR TITLE
fix(kmd): handle empty password correctly in getPassword

### DIFF
--- a/packages/use-wallet/src/wallets/kmd.ts
+++ b/packages/use-wallet/src/wallets/kmd.ts
@@ -60,7 +60,7 @@ export class KmdWallet extends BaseWallet {
   private options: KmdConstructor
   private walletName: string
   private walletId: string = ''
-  private password: string = ''
+  private password: string | null = null
 
   protected store: Store<State>
 
@@ -302,7 +302,7 @@ export class KmdWallet extends BaseWallet {
   }
 
   private getPassword(): string {
-    if (this.password) {
+    if (this.password !== null) {
       return this.password
     }
     const password = prompt('KMD password') || ''


### PR DESCRIPTION
fix(kmd): prompt for password twice when the password is an empty string

When using KMD wallet for localnet, it's common that the password is set to an empty string. In this case, the memoised logic failed to detect the existing password.

To fix this:
- the password field is initialised to null
- the memoised logic returns the password if it is not null