### PR TITLE
test(kmd): add tests for empty and null password handling

### DIFF
--- a/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
@@ -407,4 +407,34 @@ describe('KmdWallet', () => {
       })
     })
   })
+
+  describe('getPassword', () => {
+    it('should return empty string password when set', async () => {
+      // Mock prompt to return empty string
+      global.prompt = vi.fn().mockReturnValue('')
+
+      // First call to connect will set the empty password
+      mockKmd.listKeys.mockResolvedValueOnce({ addresses: [account1.address] })
+      await wallet.connect()
+
+      // Second call to connect should reuse the empty password
+      mockKmd.listKeys.mockResolvedValueOnce({ addresses: [account1.address] })
+      await wallet.connect()
+
+      // Prompt should only be called once
+      expect(global.prompt).toHaveBeenCalledTimes(1)
+      expect(mockKmd.initWalletHandle).toHaveBeenCalledWith(mockWallet.id, '')
+    })
+
+    it('should handle null from cancelled prompt', async () => {
+      // Mock prompt to return null (user cancelled)
+      global.prompt = vi.fn().mockReturnValue(null)
+
+      mockKmd.listKeys.mockResolvedValueOnce({ addresses: [account1.address] })
+      await wallet.connect()
+
+      expect(global.prompt).toHaveBeenCalledTimes(1)
+      expect(mockKmd.initWalletHandle).toHaveBeenCalledWith(mockWallet.id, '')
+    })
+  })
 })


### PR DESCRIPTION
## Description

This PR adds test coverage for the `KmdWallet` client's password handling functionality, specifically for the empty string and null password handling changes introduced in PR #318.

## Details
- Add test to verify empty string passwords are properly cached and reused
- Add test to verify cancelled password prompts (null) fall back to empty string
- Verify password prompt is only shown once when password is cached