### PR TITLE
feat(*): add custom password prompt for KMD and Mnemonic

### DIFF
--- a/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
@@ -428,13 +428,38 @@ describe('KmdWallet', () => {
 
     it('should handle null from cancelled prompt', async () => {
       // Mock prompt to return null (user cancelled)
-      global.prompt = vi.fn().mockReturnValue(null)
+      global.prompt = vi.fn().mockReturnValue(null) 
 
       mockKmd.listKeys.mockResolvedValueOnce({ addresses: [account1.address] })
       await wallet.connect()
 
       expect(global.prompt).toHaveBeenCalledTimes(1)
       expect(mockKmd.initWalletHandle).toHaveBeenCalledWith(mockWallet.id, '')
+    })
+  })
+
+  describe('custom prompt for password', () => {
+    const customPassword = 'customPassword'
+
+    beforeEach(() => {
+      wallet = new KmdWallet({
+        id: WalletId.KMD,
+        metadata: {},
+        getAlgodClient: {} as any,
+        store,
+        subscribe: vi.fn(),
+        options: {
+          promptForPassword: () => Promise.resolve(customPassword)
+        }
+      })
+    })
+
+    it('should return password from custom prompt', async () => {
+      mockKmd.listKeys.mockResolvedValueOnce({ addresses: [account1.address] })
+      await wallet.connect()
+
+      expect(global.prompt).toHaveBeenCalledTimes(0)
+      expect(mockKmd.initWalletHandle).toHaveBeenCalledWith(mockWallet.id, customPassword)
     })
   })
 })

--- a/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
@@ -428,7 +428,7 @@ describe('KmdWallet', () => {
 
     it('should handle null from cancelled prompt', async () => {
       // Mock prompt to return null (user cancelled)
-      global.prompt = vi.fn().mockReturnValue(null) 
+      global.prompt = vi.fn().mockReturnValue(null)
 
       mockKmd.listKeys.mockResolvedValueOnce({ addresses: [account1.address] })
       await wallet.connect()

--- a/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
@@ -361,4 +361,30 @@ describe('MnemonicWallet', () => {
       })
     })
   })
+
+  describe('custom prompt for mnemonic', () => {
+    const MOCK_ACCOUNT_MNEMONIC = 'just aim reveal time update elegant column reunion lazy ritual room unusual notice camera forward couple quantum gym laundry absurd drill pyramid tip able outdoor'
+
+    beforeEach(() => {
+      wallet = new MnemonicWallet({
+        id: WalletId.MNEMONIC,
+        options: { promptForMnemonic: () => Promise.resolve(MOCK_ACCOUNT_MNEMONIC), persistToStorage: true },
+        metadata: {},
+        getAlgodClient: {} as any,
+        store,
+        subscribe: vi.fn()
+      })
+    })
+
+    it('should save mnemonic into storage', async () => {
+      const storageSetItemSpy = vi.spyOn(StorageAdapter, 'setItem')
+      // Simulate no mnemonic in storage
+      vi.mocked(StorageAdapter.getItem).mockImplementation(() => null)
+
+      await wallet.connect()
+
+      expect(global.prompt).toHaveBeenCalledTimes(0)
+      expect(storageSetItemSpy).toHaveBeenCalledWith(LOCAL_STORAGE_MNEMONIC_KEY, MOCK_ACCOUNT_MNEMONIC)
+    })
+  })
 })

--- a/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
@@ -363,12 +363,16 @@ describe('MnemonicWallet', () => {
   })
 
   describe('custom prompt for mnemonic', () => {
-    const MOCK_ACCOUNT_MNEMONIC = 'just aim reveal time update elegant column reunion lazy ritual room unusual notice camera forward couple quantum gym laundry absurd drill pyramid tip able outdoor'
+    const MOCK_ACCOUNT_MNEMONIC =
+      'just aim reveal time update elegant column reunion lazy ritual room unusual notice camera forward couple quantum gym laundry absurd drill pyramid tip able outdoor'
 
     beforeEach(() => {
       wallet = new MnemonicWallet({
         id: WalletId.MNEMONIC,
-        options: { promptForMnemonic: () => Promise.resolve(MOCK_ACCOUNT_MNEMONIC), persistToStorage: true },
+        options: {
+          promptForMnemonic: () => Promise.resolve(MOCK_ACCOUNT_MNEMONIC),
+          persistToStorage: true
+        },
         metadata: {},
         getAlgodClient: {} as any,
         store,
@@ -384,7 +388,10 @@ describe('MnemonicWallet', () => {
       await wallet.connect()
 
       expect(global.prompt).toHaveBeenCalledTimes(0)
-      expect(storageSetItemSpy).toHaveBeenCalledWith(LOCAL_STORAGE_MNEMONIC_KEY, MOCK_ACCOUNT_MNEMONIC)
+      expect(storageSetItemSpy).toHaveBeenCalledWith(
+        LOCAL_STORAGE_MNEMONIC_KEY,
+        MOCK_ACCOUNT_MNEMONIC
+      )
     })
   })
 })

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -15,7 +15,6 @@ interface MnemonicConstructor {
 export type MnemonicOptions = Partial<Pick<MnemonicConstructor, 'promptForMnemonic'>> &
   Omit<MnemonicConstructor, 'promptForMnemonic'>
 
-
 export const LOCAL_STORAGE_MNEMONIC_KEY = `${LOCAL_STORAGE_KEY}_mnemonic`
 
 const ICON = `data:image/svg+xml;base64,${btoa(`
@@ -41,7 +40,10 @@ export class MnemonicWallet extends BaseWallet {
   }: WalletConstructor<WalletId.MNEMONIC>) {
     super({ id, metadata, getAlgodClient, store, subscribe })
 
-    const { persistToStorage = false, promptForMnemonic = () => Promise.resolve(prompt('Enter 25-word mnemonic passphrase:')) } = options || {}
+    const {
+      persistToStorage = false,
+      promptForMnemonic = () => Promise.resolve(prompt('Enter 25-word mnemonic passphrase:'))
+    } = options || {}
     this.options = { persistToStorage, promptForMnemonic }
 
     this.store = store

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -7,9 +7,14 @@ import { BaseWallet } from 'src/wallets/base'
 import type { Store } from '@tanstack/store'
 import type { WalletAccount, WalletConstructor, WalletId } from 'src/wallets/types'
 
-export type MnemonicOptions = {
+interface MnemonicConstructor {
   persistToStorage?: boolean
+  promptForMnemonic: () => Promise<string | null>
 }
+
+export type MnemonicOptions = Partial<Pick<MnemonicConstructor, 'promptForMnemonic'>> &
+  Omit<MnemonicConstructor, 'promptForMnemonic'>
+
 
 export const LOCAL_STORAGE_MNEMONIC_KEY = `${LOCAL_STORAGE_KEY}_mnemonic`
 
@@ -22,7 +27,7 @@ const ICON = `data:image/svg+xml;base64,${btoa(`
 
 export class MnemonicWallet extends BaseWallet {
   private account: algosdk.Account | null = null
-  private options: MnemonicOptions
+  private options: MnemonicConstructor
 
   protected store: Store<State>
 
@@ -36,8 +41,8 @@ export class MnemonicWallet extends BaseWallet {
   }: WalletConstructor<WalletId.MNEMONIC>) {
     super({ id, metadata, getAlgodClient, store, subscribe })
 
-    const { persistToStorage = false } = options || {}
-    this.options = { persistToStorage }
+    const { persistToStorage = false, promptForMnemonic = () => Promise.resolve(prompt('Enter 25-word mnemonic passphrase:')) } = options || {}
+    this.options = { persistToStorage, promptForMnemonic }
 
     this.store = store
 
@@ -80,10 +85,10 @@ export class MnemonicWallet extends BaseWallet {
     }
   }
 
-  private initializeAccount(): algosdk.Account {
+  private async initializeAccount(): Promise<algosdk.Account> {
     let mnemonic = this.loadMnemonicFromStorage()
     if (!mnemonic) {
-      mnemonic = prompt('Enter 25-word mnemonic passphrase:')
+      mnemonic = await this.options.promptForMnemonic()
       if (!mnemonic) {
         this.account = null
         this.logger.error('No mnemonic provided')
@@ -106,7 +111,7 @@ export class MnemonicWallet extends BaseWallet {
     this.checkMainnet()
 
     this.logger.info('Connecting...')
-    const account = this.initializeAccount()
+    const account = await this.initializeAccount()
 
     const walletAccount = {
       name: `${this.metadata.name} Account`,
@@ -153,7 +158,7 @@ export class MnemonicWallet extends BaseWallet {
     // If persisting to storage is enabled, then resume session
     if (this.options.persistToStorage) {
       try {
-        this.initializeAccount()
+        await this.initializeAccount()
         this.logger.info('Session resumed successfully')
       } catch (error: any) {
         this.logger.error('Error resuming session:', error.message)


### PR DESCRIPTION
There are scenarios where customising window.prompt are needed:
- There are environments where window.prompt isn't supported, for example, Tauri app built for macOS
- a better UI to display the message is required

To implement this change:
- add options to customise the prompt to KMD and Mnemonic wallets
- when the option isn't set, fallback to the default window.prompt