### PR TITLE
feat(pera): add auto-connect for Pera Discover browser

### DIFF
--- a/packages/use-wallet/src/__tests__/wallets/pera.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera.test.ts
@@ -541,6 +541,53 @@ describe('PeraWallet', () => {
     })
   })
 
+  describe('autoConnect', () => {
+    let mockUserAgent: string
+
+    beforeEach(() => {
+      mockUserAgent = ''
+      vi.clearAllMocks()
+
+      vi.stubGlobal('window', {
+        navigator: {
+          get userAgent() {
+            return mockUserAgent
+          }
+        }
+      })
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('should attempt auto-connect in Pera browser', () => {
+      mockUserAgent = 'pera/1.0.0'
+
+      // Mock the private method before creating the wallet
+      vi.spyOn(PeraWallet.prototype as any, 'autoConnect')
+        .mockReset()
+        .mockImplementation(() => Promise.resolve())
+
+      createWalletWithStore(store)
+
+      expect(PeraWallet.prototype['autoConnect']).toHaveBeenCalled()
+    })
+
+    it('should not attempt auto-connect in other browsers', () => {
+      mockUserAgent = 'chrome/1.0.0'
+
+      // Mock the private method before creating the wallet
+      vi.spyOn(PeraWallet.prototype as any, 'autoConnect')
+        .mockReset()
+        .mockImplementation(() => Promise.resolve())
+
+      createWalletWithStore(store)
+
+      expect(PeraWallet.prototype['autoConnect']).not.toHaveBeenCalled()
+    })
+  })
+
   describe('signing transactions', () => {
     // Connected accounts
     const connectedAcct1 = '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q'

--- a/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
@@ -332,52 +332,78 @@ describe('PeraWallet', () => {
       expect(store.state.wallets[WalletId.PERA2]).toBeUndefined()
       expect(wallet.isConnected).toBe(false)
     })
-  })
 
-  describe('autoConnect', () => {
-    let mockUserAgent: string
+    describe('auto-connect in Pera browser', () => {
+      let mockUserAgent: string
 
-    beforeEach(() => {
-      mockUserAgent = ''
-      vi.clearAllMocks()
+      beforeEach(() => {
+        mockUserAgent = ''
+        vi.clearAllMocks()
 
-      vi.stubGlobal('window', {
-        navigator: {
-          get userAgent() {
-            return mockUserAgent
+        vi.stubGlobal('window', {
+          navigator: {
+            get userAgent() {
+              return mockUserAgent
+            }
           }
-        }
+        })
       })
-    })
 
-    afterEach(() => {
-      vi.unstubAllGlobals()
-    })
+      afterEach(() => {
+        vi.unstubAllGlobals()
+      })
 
-    it('should attempt auto-connect in Pera browser', () => {
-      mockUserAgent = 'pera/1.0.0'
+      it('should attempt auto-connect in Pera browser when no session exists and no active wallet', async () => {
+        mockUserAgent = 'pera/1.0.0'
+        mockPeraWallet.connect.mockResolvedValueOnce([account1.address])
 
-      // Mock the private method before creating the wallet
-      vi.spyOn(PeraWallet.prototype as any, 'autoConnect')
-        .mockReset()
-        .mockImplementation(() => Promise.resolve())
+        await wallet.resumeSession()
 
-      createWalletWithStore(store)
+        expect(mockPeraWallet.connect).toHaveBeenCalled()
+        expect(store.state.wallets[WalletId.PERA2]).toBeDefined()
+        expect(mockLogger.info).toHaveBeenCalledWith('Auto-connect successful')
+      })
 
-      expect(PeraWallet.prototype['autoConnect']).toHaveBeenCalled()
-    })
+      it('should not attempt auto-connect if another wallet is active', async () => {
+        mockUserAgent = 'pera/1.0.0'
 
-    it('should not attempt auto-connect in other browsers', () => {
-      mockUserAgent = 'chrome/1.0.0'
+        // Set up another active wallet
+        store.setState((state) => ({
+          ...state,
+          activeWallet: WalletId.DEFLY,
+          wallets: {
+            [WalletId.DEFLY]: {
+              accounts: [account2],
+              activeAccount: account2
+            }
+          }
+        }))
 
-      // Mock the private method before creating the wallet
-      vi.spyOn(PeraWallet.prototype as any, 'autoConnect')
-        .mockReset()
-        .mockImplementation(() => Promise.resolve())
+        await wallet.resumeSession()
 
-      createWalletWithStore(store)
+        expect(mockPeraWallet.connect).not.toHaveBeenCalled()
+        expect(mockLogger.info).toHaveBeenCalledWith('No session to resume')
+      })
 
-      expect(PeraWallet.prototype['autoConnect']).not.toHaveBeenCalled()
+      it('should not attempt auto-connect in other browsers', async () => {
+        mockUserAgent = 'chrome/1.0.0'
+
+        await wallet.resumeSession()
+
+        expect(mockPeraWallet.connect).not.toHaveBeenCalled()
+        expect(mockLogger.info).toHaveBeenCalledWith('No session to resume')
+      })
+
+      it('should handle auto-connect failure gracefully', async () => {
+        mockUserAgent = 'pera/1.0.0'
+        mockPeraWallet.connect.mockRejectedValueOnce(new Error('Connect failed'))
+
+        await wallet.resumeSession()
+
+        expect(mockPeraWallet.connect).toHaveBeenCalled()
+        expect(mockLogger.warn).toHaveBeenCalledWith('Auto-connect failed:', 'Connect failed')
+        expect(store.state.wallets[WalletId.PERA2]).toBeUndefined()
+      })
     })
   })
 

--- a/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera2.test.ts
@@ -334,6 +334,53 @@ describe('PeraWallet', () => {
     })
   })
 
+  describe('autoConnect', () => {
+    let mockUserAgent: string
+
+    beforeEach(() => {
+      mockUserAgent = ''
+      vi.clearAllMocks()
+
+      vi.stubGlobal('window', {
+        navigator: {
+          get userAgent() {
+            return mockUserAgent
+          }
+        }
+      })
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('should attempt auto-connect in Pera browser', () => {
+      mockUserAgent = 'pera/1.0.0'
+
+      // Mock the private method before creating the wallet
+      vi.spyOn(PeraWallet.prototype as any, 'autoConnect')
+        .mockReset()
+        .mockImplementation(() => Promise.resolve())
+
+      createWalletWithStore(store)
+
+      expect(PeraWallet.prototype['autoConnect']).toHaveBeenCalled()
+    })
+
+    it('should not attempt auto-connect in other browsers', () => {
+      mockUserAgent = 'chrome/1.0.0'
+
+      // Mock the private method before creating the wallet
+      vi.spyOn(PeraWallet.prototype as any, 'autoConnect')
+        .mockReset()
+        .mockImplementation(() => Promise.resolve())
+
+      createWalletWithStore(store)
+
+      expect(PeraWallet.prototype['autoConnect']).not.toHaveBeenCalled()
+    })
+  })
+
   describe('signing transactions', () => {
     // Connected accounts
     const connectedAcct1 = '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q'

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -47,16 +47,8 @@ export class PeraWallet extends BaseWallet {
 
     if (typeof window !== 'undefined' && window.navigator) {
       const isPeraDiscover = window.navigator.userAgent.includes('pera')
-
       if (isPeraDiscover) {
-        this.logger.info('Pera Discover browser detected, auto connecting...')
-        void this.connect()
-          .then(() => {
-            this.logger.info('Auto-connect successful')
-          })
-          .catch((error) => {
-            this.logger.warn('Auto-connect failed:', error.message)
-          })
+        void this.autoConnect()
       }
     }
   }
@@ -64,6 +56,16 @@ export class PeraWallet extends BaseWallet {
   static defaultMetadata = {
     name: 'Pera',
     icon: ICON
+  }
+
+  private async autoConnect(): Promise<void> {
+    this.logger.info('Pera Discover browser detected, auto connecting...')
+    try {
+      await this.connect()
+      this.logger.info('Auto-connect successful')
+    } catch (error: any) {
+      this.logger.warn('Auto-connect failed:', error.message)
+    }
   }
 
   private async initializeClient(): Promise<PeraWalletConnect> {

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -44,6 +44,19 @@ export class PeraWallet extends BaseWallet {
     super({ id, metadata, getAlgodClient, store, subscribe, networks })
     this.options = options
     this.store = store
+
+    const isPeraDiscover = window.navigator.userAgent.includes('pera')
+
+    if (isPeraDiscover) {
+      this.logger.info('Pera Discover browser detected, auto connecting...')
+      void this.connect()
+        .then(() => {
+          this.logger.info('Auto-connect successful')
+        })
+        .catch((error) => {
+          this.logger.warn('Auto-connect failed:', error.message)
+        })
+    }
   }
 
   static defaultMetadata = {

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -44,13 +44,6 @@ export class PeraWallet extends BaseWallet {
     super({ id, metadata, getAlgodClient, store, subscribe, networks })
     this.options = options
     this.store = store
-
-    if (typeof window !== 'undefined' && window.navigator) {
-      const isPeraDiscover = window.navigator.userAgent.includes('pera')
-      if (isPeraDiscover) {
-        void this.autoConnect()
-      }
-    }
   }
 
   static defaultMetadata = {
@@ -153,6 +146,21 @@ export class PeraWallet extends BaseWallet {
     try {
       const state = this.store.state
       const walletState = state.wallets[this.id]
+
+      // Check for Pera Discover browser and auto-connect if no other wallet is active
+      if (typeof window !== 'undefined' && window.navigator) {
+        const isPeraDiscover = window.navigator.userAgent.includes('pera')
+        if (isPeraDiscover && !walletState && !state.activeWallet) {
+          this.logger.info('Pera Discover browser detected, attempting auto-connect...')
+          try {
+            await this.connect()
+            this.logger.info('Auto-connect successful')
+            return
+          } catch (error: any) {
+            this.logger.warn('Auto-connect failed:', error.message)
+          }
+        }
+      }
 
       // No session to resume
       if (!walletState) {

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -45,17 +45,19 @@ export class PeraWallet extends BaseWallet {
     this.options = options
     this.store = store
 
-    const isPeraDiscover = window.navigator.userAgent.includes('pera')
+    if (typeof window !== 'undefined' && window.navigator) {
+      const isPeraDiscover = window.navigator.userAgent.includes('pera')
 
-    if (isPeraDiscover) {
-      this.logger.info('Pera Discover browser detected, auto connecting...')
-      void this.connect()
-        .then(() => {
-          this.logger.info('Auto-connect successful')
-        })
-        .catch((error) => {
-          this.logger.warn('Auto-connect failed:', error.message)
-        })
+      if (isPeraDiscover) {
+        this.logger.info('Pera Discover browser detected, auto connecting...')
+        void this.connect()
+          .then(() => {
+            this.logger.info('Auto-connect successful')
+          })
+          .catch((error) => {
+            this.logger.warn('Auto-connect failed:', error.message)
+          })
+      }
     }
   }
 

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -51,16 +51,6 @@ export class PeraWallet extends BaseWallet {
     icon: ICON
   }
 
-  private async autoConnect(): Promise<void> {
-    this.logger.info('Pera Discover browser detected, auto connecting...')
-    try {
-      await this.connect()
-      this.logger.info('Auto-connect successful')
-    } catch (error: any) {
-      this.logger.warn('Auto-connect failed:', error.message)
-    }
-  }
-
   private async initializeClient(): Promise<PeraWalletConnect> {
     this.logger.info('Initializing client...')
     const module = await import('@perawallet/connect')

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -54,17 +54,19 @@ export class PeraWallet extends BaseWallet {
     this.options = options
     this.store = store
 
-    const isPeraDiscover = window.navigator.userAgent.includes('pera')
+    if (typeof window !== 'undefined' && window.navigator) {
+      const isPeraDiscover = window.navigator.userAgent.includes('pera')
 
-    if (isPeraDiscover) {
-      this.logger.info('Pera Discover browser detected, auto connecting...')
-      void this.connect()
-        .then(() => {
-          this.logger.info('Auto-connect successful')
-        })
-        .catch((error) => {
-          this.logger.warn('Auto-connect failed:', error.message)
-        })
+      if (isPeraDiscover) {
+        this.logger.info('Pera Discover browser detected, auto connecting...')
+        void this.connect()
+          .then(() => {
+            this.logger.info('Auto-connect successful')
+          })
+          .catch((error) => {
+            this.logger.warn('Auto-connect failed:', error.message)
+          })
+      }
     }
   }
 

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -53,28 +53,11 @@ export class PeraWallet extends BaseWallet {
     }
     this.options = options
     this.store = store
-
-    if (typeof window !== 'undefined' && window.navigator) {
-      const isPeraDiscover = window.navigator.userAgent.includes('pera')
-      if (isPeraDiscover) {
-        void this.autoConnect()
-      }
-    }
   }
 
   static defaultMetadata = {
     name: 'Pera',
     icon: ICON
-  }
-
-  private async autoConnect(): Promise<void> {
-    this.logger.info('Pera Discover browser detected, auto connecting...')
-    try {
-      await this.connect()
-      this.logger.info('Auto-connect successful')
-    } catch (error: any) {
-      this.logger.warn('Auto-connect failed:', error.message)
-    }
   }
 
   private async initializeClient(): Promise<PeraWalletConnect> {
@@ -135,6 +118,21 @@ export class PeraWallet extends BaseWallet {
     try {
       const state = this.store.state
       const walletState = state.wallets[this.id]
+
+      // Check for Pera Discover browser and auto-connect if no other wallet is active
+      if (typeof window !== 'undefined' && window.navigator) {
+        const isPeraDiscover = window.navigator.userAgent.includes('pera')
+        if (isPeraDiscover && !walletState && !state.activeWallet) {
+          this.logger.info('Pera Discover browser detected, attempting auto-connect...')
+          try {
+            await this.connect()
+            this.logger.info('Auto-connect successful')
+            return
+          } catch (error: any) {
+            this.logger.warn('Auto-connect failed:', error.message)
+          }
+        }
+      }
 
       // No session to resume
       if (!walletState) {

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -56,16 +56,8 @@ export class PeraWallet extends BaseWallet {
 
     if (typeof window !== 'undefined' && window.navigator) {
       const isPeraDiscover = window.navigator.userAgent.includes('pera')
-
       if (isPeraDiscover) {
-        this.logger.info('Pera Discover browser detected, auto connecting...')
-        void this.connect()
-          .then(() => {
-            this.logger.info('Auto-connect successful')
-          })
-          .catch((error) => {
-            this.logger.warn('Auto-connect failed:', error.message)
-          })
+        void this.autoConnect()
       }
     }
   }
@@ -73,6 +65,16 @@ export class PeraWallet extends BaseWallet {
   static defaultMetadata = {
     name: 'Pera',
     icon: ICON
+  }
+
+  private async autoConnect(): Promise<void> {
+    this.logger.info('Pera Discover browser detected, auto connecting...')
+    try {
+      await this.connect()
+      this.logger.info('Auto-connect successful')
+    } catch (error: any) {
+      this.logger.warn('Auto-connect failed:', error.message)
+    }
   }
 
   private async initializeClient(): Promise<PeraWalletConnect> {

--- a/packages/use-wallet/src/wallets/pera2.ts
+++ b/packages/use-wallet/src/wallets/pera2.ts
@@ -53,6 +53,19 @@ export class PeraWallet extends BaseWallet {
     }
     this.options = options
     this.store = store
+
+    const isPeraDiscover = window.navigator.userAgent.includes('pera')
+
+    if (isPeraDiscover) {
+      this.logger.info('Pera Discover browser detected, auto connecting...')
+      void this.connect()
+        .then(() => {
+          this.logger.info('Auto-connect successful')
+        })
+        .catch((error) => {
+          this.logger.warn('Auto-connect failed:', error.message)
+        })
+    }
   }
 
   static defaultMetadata = {


### PR DESCRIPTION
## Description

This PR adds automatic connection functionality for Pera wallet when running in the Pera Discover browser environment. The auto-connect happens during session resumption to ensure SSR compatibility and respect existing wallet connections.

## Details
- Added auto-connect detection for Pera Discover browser during session resumption
- Added check to prevent auto-connect when another wallet is already active
- Implemented silent error handling for auto-connect attempts
- Added logging for both successful and failed connection attempts
- Added comprehensive test coverage for auto-connect scenarios