### PR TITLE
fix(wallets): prevent WalletConnect v1 session data collision

### DIFF
--- a/packages/use-wallet/src/__tests__/wallets/defly.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/defly.test.ts
@@ -449,6 +449,29 @@ describe('DeflyWallet', () => {
       expect(store.state.wallets[WalletId.DEFLY]).toBeUndefined()
       expect(wallet.isConnected).toBe(false)
     })
+
+    it('should skip reconnectSession if Pera is active', async () => {
+      const walletState: WalletState = {
+        accounts: [account1],
+        activeAccount: account1
+      }
+
+      store = new Store<State>({
+        ...defaultState,
+        activeWallet: WalletId.PERA,
+        wallets: {
+          [WalletId.DEFLY]: walletState
+        }
+      })
+
+      wallet = createWalletWithStore(store)
+
+      await wallet.resumeSession()
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Skipping reconnectSession for Defly (inactive)')
+      expect(mockDeflyWallet.reconnectSession).not.toHaveBeenCalled()
+      expect(store.state.wallets[WalletId.DEFLY]).toEqual(walletState)
+    })
   })
 
   describe('setActive', () => {

--- a/packages/use-wallet/src/__tests__/wallets/pera.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera.test.ts
@@ -449,6 +449,29 @@ describe('PeraWallet', () => {
       expect(store.state.wallets[WalletId.PERA]).toBeUndefined()
       expect(wallet.isConnected).toBe(false)
     })
+
+    it('should skip reconnectSession if Defly is active', async () => {
+      const walletState: WalletState = {
+        accounts: [account1],
+        activeAccount: account1
+      }
+
+      store = new Store<State>({
+        ...defaultState,
+        activeWallet: WalletId.DEFLY,
+        wallets: {
+          [WalletId.PERA]: walletState
+        }
+      })
+
+      wallet = createWalletWithStore(store)
+
+      await wallet.resumeSession()
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Skipping reconnectSession for Pera (inactive)')
+      expect(mockPeraWallet.reconnectSession).not.toHaveBeenCalled()
+      expect(store.state.wallets[WalletId.PERA]).toEqual(walletState)
+    })
   })
 
   describe('setActive', () => {

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -137,6 +137,12 @@ export class DeflyWallet extends BaseWallet {
         return
       }
 
+      // If Pera is active, skip reconnectSession for Defly
+      if (state.activeWallet === WalletId.PERA) {
+        this.logger.info('Skipping reconnectSession for Defly (inactive)')
+        return
+      }
+
       this.logger.info('Resuming session...')
 
       const client = this.client || (await this.initializeClient())

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -142,6 +142,12 @@ export class PeraWallet extends BaseWallet {
         return
       }
 
+      // If Defly is active, skip reconnectSession for Pera
+      if (state.activeWallet === WalletId.DEFLY) {
+        this.logger.info('Skipping reconnectSession for Pera (inactive)')
+        return
+      }
+
       this.logger.info('Resuming session...')
 
       const client = this.client || (await this.initializeClient())


### PR DESCRIPTION
## Description
This PR fixes an issue where inactive WalletConnect v1 wallets (Pera/Defly) would overwrite the active wallet's connected accounts during session resume. The fix skips the `reconnectSession` call for inactive wallets since the library already handles wallet state persistence.

## Details
- Skip `reconnectSession` for inactive Pera/Defly wallets
- Prevent WalletConnect v1 storage key collision between Pera and Defly wallets
- Add test coverage to verify fix