### PR TITLE
feat(*): replace isReconnecting with unified isReady state

### DIFF
--- a/docs/guides/react-quick-start.md
+++ b/docs/guides/react-quick-start.md
@@ -49,10 +49,10 @@ Now, in any component, you can use the `useWallet` hook to access the wallet man
 import { useWallet } from '@txnlab/use-wallet-react'
 
 function WalletMenu() {
-  const { wallets, activeWallet, activeAccount, isReconnecting } = useWallet()
+  const { wallets, activeWallet, activeAccount, isReady } = useWallet()
 
-  if (isReconnecting) {
-    return <div>Reconnecting to wallet...</div>
+  if (!isReady) {
+    return <div>Initializing wallet manager...</div>
   }
 
   return (
@@ -80,7 +80,7 @@ function WalletMenu() {
 }
 ```
 
-The `isReconnecting` state is a boolean that helps manage wallet reconnection flows. It starts as `true` during both SSR and initial client-side mounting. During the first mount, the `WalletProvider` automatically attempts to restore any previously connected wallet sessions. Once this reconnection process completes - whether successful or not - `isReconnecting` switches to `false`.
+The `isReady` state indicates whether the wallet manager has completed initialization. It starts as `false` during both SSR and initial client-side mounting. During the first mount, the `WalletProvider` automatically attempts to restore any previously connected wallet sessions. Once this process completes, `isReady` switches to `true`.
 
 ## Signing Transactions
 

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -7,7 +7,6 @@ export * from '@txnlab/use-wallet'
 
 interface IWalletContext {
   manager: WalletManager
-  isReconnecting: boolean
   algodClient: algosdk.Algodv2
   setAlgodClient: React.Dispatch<React.SetStateAction<algosdk.Algodv2>>
 }
@@ -34,7 +33,10 @@ export const useWallet = () => {
     throw new Error('useWallet must be used within the WalletProvider')
   }
 
-  const { manager, isReconnecting, algodClient, setAlgodClient } = context
+  const { manager, algodClient, setAlgodClient } = context
+
+  const managerStatus = useStore(manager.store, (state) => state.managerStatus)
+  const isReady = managerStatus === 'ready'
 
   const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
 
@@ -109,7 +111,7 @@ export const useWallet = () => {
 
   return {
     wallets,
-    isReconnecting,
+    isReady,
     algodClient,
     activeNetwork,
     activeWallet,
@@ -131,7 +133,6 @@ interface WalletProviderProps {
 
 export const WalletProvider = ({ manager, children }: WalletProviderProps): JSX.Element => {
   const [algodClient, setAlgodClient] = React.useState(manager.algodClient)
-  const [isReconnecting, setIsReconnecting] = React.useState(true)
 
   React.useEffect(() => {
     manager.algodClient = algodClient
@@ -140,24 +141,14 @@ export const WalletProvider = ({ manager, children }: WalletProviderProps): JSX.
   const resumedRef = React.useRef(false)
 
   React.useEffect(() => {
-    const resumeSessions = async () => {
-      try {
-        await manager.resumeSessions()
-      } catch (error) {
-        console.error('Error resuming sessions:', error)
-      } finally {
-        setIsReconnecting(false)
-      }
-    }
-
     if (!resumedRef.current) {
-      resumeSessions()
+      manager.resumeSessions()
       resumedRef.current = true
     }
   }, [manager])
 
   return (
-    <WalletContext.Provider value={{ manager, isReconnecting, algodClient, setAlgodClient }}>
+    <WalletContext.Provider value={{ manager, algodClient, setAlgodClient }}>
       {children}
     </WalletContext.Provider>
   )

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -8,7 +8,8 @@ import {
   WalletManager,
   WalletId,
   type State,
-  type WalletAccount
+  type WalletAccount,
+  type ManagerStatus
 } from '@txnlab/use-wallet'
 import { For, Show, createSignal } from 'solid-js'
 import { Wallet, WalletProvider, useWallet, useWalletManager } from '../index'
@@ -69,7 +70,8 @@ const TestComponent = () => {
     isWalletConnected,
     walletStore,
     wallets,
-    algodClient
+    algodClient,
+    isReady
   } = useWallet()
 
   const [magicEmail, setMagicEmail] = createSignal('')
@@ -83,6 +85,7 @@ const TestComponent = () => {
 
   return (
     <div>
+      <div data-testid="is-ready">{JSON.stringify(isReady())}</div>
       <div data-testid="active-account">{JSON.stringify(activeAccount())}</div>
       <div data-testid="active-address">{JSON.stringify(activeAddress())}</div>
       <div data-testid="active-network">{activeNetwork()}</div>
@@ -191,7 +194,8 @@ describe('useWallet', () => {
       wallets: {},
       activeWallet: null,
       activeNetwork: NetworkId.TESTNET,
-      algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/')
+      algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/'),
+      managerStatus: 'initializing' as ManagerStatus
     }
 
     mockStore = new Store<State>(defaultState)
@@ -531,6 +535,58 @@ describe('useWallet', () => {
     }))
 
     expect(screen.getByTestId('active-network')).toHaveTextContent(NetworkId.MAINNET)
+  })
+
+  it('initializes with isReady false and updates after resumeSessions', async () => {
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    // Initially should not be ready
+    expect(screen.getByTestId('is-ready')).toHaveTextContent('false')
+
+    // Simulate manager status change
+    mockStore.setState((state) => ({
+      ...state,
+      managerStatus: 'ready'
+    }))
+
+    // Should be ready after status change
+    await waitFor(() => {
+      expect(screen.getByTestId('is-ready')).toHaveTextContent('true')
+    })
+  })
+
+  it('updates isReady when manager status changes', async () => {
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    expect(screen.getByTestId('is-ready')).toHaveTextContent('false')
+
+    // Simulate manager status change
+    mockStore.setState((state) => ({
+      ...state,
+      managerStatus: 'ready'
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-ready')).toHaveTextContent('true')
+    })
+
+    // Simulate manager status change back to initializing (though this shouldn't happen in practice)
+    mockStore.setState((state) => ({
+      ...state,
+      managerStatus: 'initializing'
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-ready')).toHaveTextContent('false')
+    })
   })
 })
 

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -57,27 +57,22 @@ export interface Wallet {
 export function useWallet() {
   const manager = createMemo(() => useWalletManager())
 
+  const managerStatus = useStore(manager().store, (state) => state.managerStatus)
+  const isReady = createMemo(() => managerStatus() === 'ready')
+
   const algodClient = useStore(manager().store, (state) => state.algodClient)
-
   const walletStore = useStore(manager().store, (state) => state.wallets)
-
   const walletState = (walletId: WalletId): WalletState | null => walletStore()[walletId] || null
-
   const activeWalletId = useStore(manager().store, (state) => state.activeWallet)
-
   const activeWallet = () => manager().getWallet(activeWalletId() as WalletId) || null
-
   const activeWalletState = () => walletState(activeWalletId() as WalletId)
-
   const activeWalletAccounts = () => activeWalletState()?.accounts ?? null
 
   const activeWalletAddresses = () =>
     activeWalletAccounts()?.map((account) => account.address) ?? null
 
   const activeAccount = () => activeWalletState()?.activeAccount ?? null
-
   const activeAddress = () => activeAccount()?.address ?? null
-
   const isWalletActive = (walletId: WalletId) => walletId === activeWalletId()
   const isWalletConnected = (walletId: WalletId) =>
     !!walletState(walletId)?.accounts.length || false
@@ -141,6 +136,7 @@ export function useWallet() {
     setActiveNetwork,
     signTransactions,
     transactionSigner,
-    wallets: manager().wallets
+    wallets: manager().wallets,
+    isReady
   }
 }

--- a/packages/use-wallet-vue/src/useWallet.ts
+++ b/packages/use-wallet-vue/src/useWallet.ts
@@ -35,6 +35,9 @@ export function useWallet() {
     throw new Error('Algod client or setter not properly installed')
   }
 
+  const managerStatus = useStore(manager.store, (state) => state.managerStatus)
+  const isReady = computed(() => managerStatus.value === 'ready')
+
   const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
   const setActiveNetwork = async (networkId: NetworkId): Promise<void> => {
     if (networkId === activeNetwork.value) {
@@ -124,6 +127,7 @@ export function useWallet() {
 
   return {
     wallets,
+    isReady,
     algodClient: computed(() => {
       if (!algodClient.value) {
         throw new Error('Algod client is undefined')

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -2,7 +2,7 @@ import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
 import { NetworkId } from 'src/network'
-import { LOCAL_STORAGE_KEY, State, defaultState } from 'src/store'
+import { LOCAL_STORAGE_KEY, PersistedState, State, defaultState } from 'src/store'
 import { WalletManager } from 'src/manager'
 import { StorageAdapter } from 'src/storage'
 import { BaseWallet } from 'src/wallets/base'
@@ -293,7 +293,8 @@ describe('WalletManager', () => {
         },
         activeWallet: WalletId.KIBISIS,
         activeNetwork: NetworkId.BETANET,
-        algodClient: new algosdk.Algodv2('', 'https://betanet-api.4160.nodely.dev/')
+        algodClient: new algosdk.Algodv2('', 'https://betanet-api.4160.nodely.dev/'),
+        managerStatus: 'ready'
       }
     })
 
@@ -338,7 +339,7 @@ describe('WalletManager', () => {
 
   describe('savePersistedState', () => {
     it('saves state to local storage', async () => {
-      const stateToSave: Omit<State, 'algodClient'> = {
+      const stateToSave: PersistedState = {
         wallets: {},
         activeWallet: null,
         activeNetwork: NetworkId.MAINNET
@@ -379,7 +380,8 @@ describe('WalletManager', () => {
         },
         activeWallet: WalletId.KIBISIS,
         activeNetwork: NetworkId.BETANET,
-        algodClient: new algosdk.Algodv2('', 'https://betanet-api.4160.nodely.dev/')
+        algodClient: new algosdk.Algodv2('', 'https://betanet-api.4160.nodely.dev/'),
+        managerStatus: 'ready'
       }
     })
 
@@ -431,8 +433,16 @@ describe('WalletManager', () => {
     // @todo: Tests for successful signing
   })
 
-  describe('resumeSessions', () => {
-    it('resumes sessions for all wallets', async () => {
+  describe('status', () => {
+    it('returns initializing by default', () => {
+      const manager = new WalletManager({
+        wallets: [WalletId.DEFLY, WalletId.KIBISIS]
+      })
+      expect(manager.status).toBe('initializing')
+      expect(manager.isReady).toBe(false)
+    })
+
+    it('changes to ready after resumeSessions', async () => {
       const manager = new WalletManager({
         wallets: [WalletId.DEFLY, WalletId.KIBISIS]
       })
@@ -440,6 +450,45 @@ describe('WalletManager', () => {
         [WalletId.DEFLY, mockDeflyWallet],
         [WalletId.KIBISIS, mockKibisisWallet]
       ])
+
+      expect(manager.status).toBe('initializing')
+      await manager.resumeSessions()
+      expect(manager.status).toBe('ready')
+      expect(manager.isReady).toBe(true)
+    })
+
+    it('changes to ready after resumeSessions even if it fails', async () => {
+      const manager = new WalletManager({
+        wallets: [WalletId.DEFLY, WalletId.KIBISIS]
+      })
+      manager._clients = new Map<WalletId, BaseWallet>([
+        [WalletId.DEFLY, mockDeflyWallet],
+        [WalletId.KIBISIS, mockKibisisWallet]
+      ])
+
+      // Mock one of the wallets to throw an error
+      vi.mocked(mockDeflyWallet.resumeSession).mockRejectedValueOnce(
+        new Error('Failed to resume session')
+      )
+
+      expect(manager.status).toBe('initializing')
+      await expect(manager.resumeSessions()).rejects.toThrow('Failed to resume session')
+      expect(manager.status).toBe('ready')
+      expect(manager.isReady).toBe(true)
+    })
+  })
+
+  describe('resumeSessions', () => {
+    it('resumes sessions for all wallets and updates status', async () => {
+      const manager = new WalletManager({
+        wallets: [WalletId.DEFLY, WalletId.KIBISIS]
+      })
+      manager._clients = new Map<WalletId, BaseWallet>([
+        [WalletId.DEFLY, mockDeflyWallet],
+        [WalletId.KIBISIS, mockKibisisWallet]
+      ])
+
+      expect(manager.status).toBe('initializing')
       await manager.resumeSessions()
 
       const deflyResumeSessionMock = mockDeflyWallet.resumeSession as Mock
@@ -447,6 +496,7 @@ describe('WalletManager', () => {
 
       expect(deflyResumeSessionMock).toHaveBeenCalled()
       expect(kibisisResumeSessionMock).toHaveBeenCalled()
+      expect(manager.status).toBe('ready')
 
       const calls = [
         deflyResumeSessionMock.mock.calls.length,
@@ -525,7 +575,8 @@ describe('WalletManager', () => {
           wallets: {},
           activeWallet: null,
           activeNetwork: NetworkId.MAINNET,
-          algodClient: new algosdk.Algodv2('', 'https://mainnet-api.algonode.cloud')
+          algodClient: new algosdk.Algodv2('', 'https://mainnet-api.algonode.cloud'),
+          managerStatus: 'ready'
         }
 
         const manager = new WalletManager({
@@ -542,7 +593,8 @@ describe('WalletManager', () => {
           wallets: {},
           activeWallet: null,
           activeNetwork: NetworkId.MAINNET,
-          algodClient: new algosdk.Algodv2('', 'https://mainnet-api.algonode.cloud')
+          algodClient: new algosdk.Algodv2('', 'https://mainnet-api.algonode.cloud'),
+          managerStatus: 'ready'
         }
 
         const manager = new WalletManager({
@@ -574,7 +626,8 @@ describe('WalletManager', () => {
           },
           activeWallet: WalletId.PERA,
           activeNetwork: NetworkId.MAINNET,
-          algodClient: new algosdk.Algodv2('', 'https://mainnet-api.algonode.cloud')
+          algodClient: new algosdk.Algodv2('', 'https://mainnet-api.algonode.cloud'),
+          managerStatus: 'ready'
         }
 
         const manager = new WalletManager({

--- a/packages/use-wallet/src/__tests__/store.test.ts
+++ b/packages/use-wallet/src/__tests__/store.test.ts
@@ -3,6 +3,7 @@ import { Algodv2 } from 'algosdk'
 import { NetworkId } from 'src/network'
 import {
   State,
+  PersistedState,
   addWallet,
   defaultState,
   removeWallet,
@@ -10,7 +11,7 @@ import {
   setActiveAccount,
   setActiveNetwork,
   setActiveWallet,
-  isValidState,
+  isValidPersistedState,
   isValidWalletAccount,
   isValidWalletId,
   isValidWalletState
@@ -560,17 +561,16 @@ describe('Type Guards', () => {
     })
   })
 
-  describe('isValidState', () => {
+  describe('isValidPersistedState', () => {
     it('returns true for a valid state', () => {
-      const defaultState: State = {
+      const defaultState: PersistedState = {
         wallets: {},
         activeWallet: null,
-        activeNetwork: NetworkId.TESTNET,
-        algodClient: new Algodv2('', 'https://testnet-api.4160.nodely.dev/')
+        activeNetwork: NetworkId.TESTNET
       }
-      expect(isValidState(defaultState)).toBe(true)
+      expect(isValidPersistedState(defaultState)).toBe(true)
 
-      const state: State = {
+      const state: PersistedState = {
         wallets: {
           [WalletId.DEFLY]: {
             accounts: [
@@ -602,32 +602,31 @@ describe('Type Guards', () => {
           }
         },
         activeWallet: WalletId.DEFLY,
-        activeNetwork: NetworkId.TESTNET,
-        algodClient: new Algodv2('', 'https://testnet-api.4160.nodely.dev/')
+        activeNetwork: NetworkId.TESTNET
       }
-      expect(isValidState(state)).toBe(true)
+      expect(isValidPersistedState(state)).toBe(true)
     })
 
     it('returns false for an invalid state', () => {
-      expect(isValidState('foo')).toBe(false)
-      expect(isValidState(null)).toBe(false)
+      expect(isValidPersistedState('foo')).toBe(false)
+      expect(isValidPersistedState(null)).toBe(false)
 
       expect(
-        isValidState({
+        isValidPersistedState({
           activeWallet: WalletId.DEFLY,
           activeNetwork: NetworkId.TESTNET
         })
       ).toBe(false)
 
       expect(
-        isValidState({
+        isValidPersistedState({
           wallets: {},
           activeNetwork: NetworkId.TESTNET
         })
       ).toBe(false)
 
       expect(
-        isValidState({
+        isValidPersistedState({
           wallets: {},
           activeWallet: WalletId.DEFLY
         })

--- a/packages/use-wallet/src/index.ts
+++ b/packages/use-wallet/src/index.ts
@@ -1,7 +1,7 @@
 export { LogLevel } from './logger'
 export { WalletManager, WalletManagerConfig, WalletManagerOptions } from './manager'
 export { NetworkId } from './network'
-export { State, WalletState, defaultState } from './store'
+export { State, WalletState, ManagerStatus, defaultState } from './store'
 export { StorageAdapter } from './storage'
 export { webpackFallback } from './webpack'
 export * from './wallets'

--- a/packages/use-wallet/src/manager.ts
+++ b/packages/use-wallet/src/manager.ts
@@ -11,12 +11,14 @@ import {
 import { StorageAdapter } from 'src/storage'
 import {
   defaultState,
-  isValidState,
+  isValidPersistedState,
   LOCAL_STORAGE_KEY,
   removeWallet,
   setActiveNetwork,
   setActiveWallet,
-  type State
+  type State,
+  type ManagerStatus,
+  type PersistedState
 } from 'src/store'
 import { createWalletMap, deepMerge } from 'src/utils'
 import type { BaseWallet } from 'src/wallets/base'
@@ -42,8 +44,6 @@ export interface WalletManagerConfig {
   algod?: NetworkConfig
   options?: WalletManagerOptions
 }
-
-export type PersistedState = Omit<State, 'algodClient'>
 
 export class WalletManager {
   public _clients: Map<WalletId, BaseWallet> = new Map()
@@ -153,11 +153,11 @@ export class WalletManager {
         return null
       }
       const parsedState = JSON.parse(serializedState)
-      if (!isValidState(parsedState)) {
+      if (!isValidPersistedState(parsedState)) {
         this.logger.warn('Parsed state:', parsedState)
         throw new Error('Persisted state is invalid')
       }
-      return parsedState as PersistedState
+      return parsedState
     } catch (error: any) {
       this.logger.error(`Could not load state from local storage: ${error.message}`)
       return null
@@ -173,6 +173,16 @@ export class WalletManager {
     } catch (error) {
       this.logger.error('Could not save state to local storage:', error)
     }
+  }
+
+  // ---------- Status ------------------------------------------------ //
+
+  public get status(): ManagerStatus {
+    return this.store.state.managerStatus
+  }
+
+  public get isReady(): boolean {
+    return this.store.state.managerStatus === 'ready'
   }
 
   // ---------- Wallets ----------------------------------------------- //
@@ -246,8 +256,15 @@ export class WalletManager {
   }
 
   public async resumeSessions(): Promise<void> {
-    const promises = this.wallets.map((wallet) => wallet?.resumeSession())
-    await Promise.all(promises)
+    try {
+      const promises = this.wallets.map((wallet) => wallet?.resumeSession())
+      await Promise.all(promises)
+    } finally {
+      this.store.setState((state) => ({
+        ...state,
+        managerStatus: 'ready'
+      }))
+    }
   }
 
   public async disconnect(): Promise<void> {

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -11,19 +11,25 @@ export type WalletState = {
 
 export type WalletStateMap = Partial<Record<WalletId, WalletState>>
 
+export type ManagerStatus = 'initializing' | 'ready'
+
 export interface State {
   wallets: WalletStateMap
   activeWallet: WalletId | null
   activeNetwork: NetworkId
   algodClient: algosdk.Algodv2
+  managerStatus: ManagerStatus
 }
 
 export const defaultState: State = {
   wallets: {},
   activeWallet: null,
   activeNetwork: NetworkId.TESTNET,
-  algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/')
+  algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/'),
+  managerStatus: 'initializing'
 }
+
+export type PersistedState = Omit<State, 'algodClient' | 'managerStatus'>
 
 export const LOCAL_STORAGE_KEY = '@txnlab/use-wallet:v3'
 
@@ -180,7 +186,7 @@ export function isValidWalletState(wallet: any): wallet is WalletState {
   )
 }
 
-export function isValidState(state: any): state is State {
+export function isValidPersistedState(state: any): state is PersistedState {
   if (!state || typeof state !== 'object') return false
   if (typeof state.wallets !== 'object') return false
   for (const [walletId, wallet] of Object.entries(state.wallets)) {


### PR DESCRIPTION
## Description

This PR replaces the React-specific `isReconnecting` state with a unified `isReady` state that works consistently across all framework implementations. The new state tracks the wallet manager's initialization status and is available in React, Vue, and Solid implementations.

## Details
- Add `managerStatus` to core state management
- Add `isReady` getter to WalletManager class
- Remove React-specific `isReconnecting` state
- Add `isReady` to all framework implementations
- Update documentation to reflect new approach
- Add comprehensive tests across all implementations
- Make persisted state validation more accurate