### PR TITLE
refactor(network): remove name property and improve network ID types

### DIFF
--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@tanstack/react-store'
-import { WalletAccount, WalletManager, WalletMetadata } from '@txnlab/use-wallet'
+import { NetworkId, WalletAccount, WalletManager, WalletMetadata } from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
 import * as React from 'react'
 
@@ -40,7 +40,7 @@ export const useWallet = () => {
 
   const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
 
-  const setActiveNetwork = async (networkId: string): Promise<void> => {
+  const setActiveNetwork = async (networkId: NetworkId | string): Promise<void> => {
     if (networkId === activeNetwork) {
       return
     }

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@tanstack/solid-store'
 import algosdk from 'algosdk'
 import { JSX, createContext, createMemo, onMount, useContext } from 'solid-js'
 import type {
+  NetworkId,
   WalletAccount,
   WalletId,
   WalletManager,
@@ -78,7 +79,7 @@ export function useWallet() {
 
   const activeNetwork = useStore(manager().store, (state) => state.activeNetwork)
 
-  const setActiveNetwork = async (networkId: string): Promise<void> => {
+  const setActiveNetwork = async (networkId: NetworkId | string): Promise<void> => {
     if (networkId === activeNetwork()) {
       return
     }

--- a/packages/use-wallet-vue/src/useWallet.ts
+++ b/packages/use-wallet-vue/src/useWallet.ts
@@ -1,5 +1,10 @@
 import { useStore } from '@tanstack/vue-store'
-import { WalletManager, type WalletAccount, type WalletMetadata } from '@txnlab/use-wallet'
+import {
+  NetworkId,
+  WalletManager,
+  type WalletAccount,
+  type WalletMetadata
+} from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
 import { computed, inject, ref } from 'vue'
 
@@ -34,7 +39,7 @@ export function useWallet() {
   const isReady = computed(() => managerStatus.value === 'ready')
 
   const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
-  const setActiveNetwork = async (networkId: string): Promise<void> => {
+  const setActiveNetwork = async (networkId: NetworkId | string): Promise<void> => {
     if (networkId === activeNetwork.value) {
       return
     }

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -177,7 +177,6 @@ describe('WalletManager', () => {
     it('initializes with custom network', () => {
       const networks = new NetworkConfigBuilder()
         .addNetwork('custom', {
-          name: 'Custom Network',
           algod: {
             token: 'token',
             baseServer: 'https://custom-network.com',

--- a/packages/use-wallet/src/__tests__/network.test.ts
+++ b/packages/use-wallet/src/__tests__/network.test.ts
@@ -16,7 +16,6 @@ describe('Network Configuration', () => {
       const networks = createNetworkConfig()
 
       expect(networks.mainnet).toEqual({
-        name: 'MainNet',
         algod: {
           token: '',
           baseServer: 'https://mainnet-api.4160.nodely.dev',
@@ -48,13 +47,11 @@ describe('Network Configuration', () => {
         headers: { 'X-API-Key': 'key' }
       })
       // Other properties should remain unchanged
-      expect(networks.mainnet.name).toBe('MainNet')
       expect(networks.mainnet.isTestnet).toBe(false)
     })
 
     it('allows adding custom networks', () => {
       const customNetwork = {
-        name: 'Custom Network',
         algod: {
           token: 'token',
           baseServer: 'server',
@@ -75,7 +72,6 @@ describe('Network Configuration', () => {
 
       expect(() =>
         builder.addNetwork('mainnet', {
-          name: 'Custom MainNet',
           algod: {
             token: '',
             baseServer: ''
@@ -104,7 +100,6 @@ describe('Network Configuration', () => {
   describe('isNetworkConfig', () => {
     it('validates correct network configs', () => {
       const validConfig = {
-        name: 'Test Network',
         algod: {
           token: 'token',
           baseServer: 'server'
@@ -115,7 +110,6 @@ describe('Network Configuration', () => {
 
     it('validates network configs with optional properties', () => {
       const validConfig = {
-        name: 'Test Network',
         algod: {
           token: 'token',
           baseServer: 'server'
@@ -130,10 +124,8 @@ describe('Network Configuration', () => {
     it('rejects invalid network configs', () => {
       expect(isNetworkConfig(null)).toBe(false)
       expect(isNetworkConfig({})).toBe(false)
-      expect(isNetworkConfig({ name: 'Test' })).toBe(false)
       expect(
         isNetworkConfig({
-          name: 'Test',
           algod: { baseServer: 'server' }
         })
       ).toBe(false)

--- a/packages/use-wallet/src/manager.ts
+++ b/packages/use-wallet/src/manager.ts
@@ -1,7 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { Logger, LogLevel, logger } from 'src/logger'
-import { createNetworkConfig, isNetworkConfig, type NetworkConfig } from 'src/network'
+import { createNetworkConfig, isNetworkConfig, NetworkId, type NetworkConfig } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import {
   DEFAULT_STATE,
@@ -313,7 +313,7 @@ export class WalletManager {
     return this.algodClient
   }
 
-  public setActiveNetwork = async (networkId: string): Promise<void> => {
+  public setActiveNetwork = async (networkId: NetworkId | string): Promise<void> => {
     if (this.activeNetwork === networkId) {
       return
     }

--- a/packages/use-wallet/src/network.ts
+++ b/packages/use-wallet/src/network.ts
@@ -8,7 +8,6 @@ export interface AlgodConfig {
 }
 
 export interface NetworkConfig {
-  name: string
   algod: AlgodConfig
   genesisHash?: string
   genesisId?: string
@@ -19,7 +18,6 @@ export interface NetworkConfig {
 // Default configurations
 export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
   mainnet: {
-    name: 'MainNet',
     algod: {
       token: '',
       baseServer: 'https://mainnet-api.4160.nodely.dev',
@@ -31,7 +29,6 @@ export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
     caipChainId: 'algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k'
   },
   testnet: {
-    name: 'TestNet',
     algod: {
       token: '',
       baseServer: 'https://testnet-api.4160.nodely.dev',
@@ -43,7 +40,6 @@ export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
     caipChainId: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe'
   },
   betanet: {
-    name: 'BetaNet',
     algod: {
       token: '',
       baseServer: 'https://betanet-api.4160.nodely.dev',
@@ -55,7 +51,6 @@ export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
     caipChainId: 'algorand:mFgazF-2uRS1tMiL9dsj01hJGySEmPN2'
   },
   fnet: {
-    name: 'FNet',
     algod: {
       token: '',
       baseServer: 'https://fnet-api.4160.nodely.dev',
@@ -67,7 +62,6 @@ export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
     caipChainId: 'algorand:kUt08LxeVAAGHnh4JoAoAMM9ql_hBwSo'
   },
   localnet: {
-    name: 'LocalNet',
     algod: {
       token: 'a'.repeat(64),
       baseServer: 'http://localhost',
@@ -204,7 +198,7 @@ function isValidToken(
 export function isNetworkConfig(config: unknown): config is NetworkConfig {
   if (typeof config !== 'object' || config === null) return false
 
-  const { name, algod, isTestnet, genesisHash, genesisId, caipChainId } = config as NetworkConfig
+  const { algod, isTestnet, genesisHash, genesisId, caipChainId } = config as NetworkConfig
 
   const isValidAlgod =
     typeof algod === 'object' &&
@@ -213,7 +207,6 @@ export function isNetworkConfig(config: unknown): config is NetworkConfig {
     typeof algod.baseServer === 'string'
 
   return (
-    typeof name === 'string' &&
     isValidAlgod &&
     (isTestnet === undefined || typeof isTestnet === 'boolean') &&
     (genesisHash === undefined || typeof genesisHash === 'string') &&

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -1,5 +1,6 @@
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
+import { NetworkId } from 'src/network'
 import { WalletId, type WalletAccount } from 'src/wallets/types'
 import type { Store } from '@tanstack/store'
 
@@ -151,7 +152,7 @@ export function setAccounts(
 
 export function setActiveNetwork(
   store: Store<State>,
-  { networkId, algodClient }: { networkId: string; algodClient: algosdk.Algodv2 }
+  { networkId, algodClient }: { networkId: NetworkId | string; algodClient: algosdk.Algodv2 }
 ) {
   store.setState((state) => ({
     ...state,


### PR DESCRIPTION
## Description

This PR removes the unused `name` property from network configurations and updates the type signature of `setActiveNetwork` to properly support both built-in and custom network IDs.

⚠️ **BREAKING CHANGE**: The `name` property has been removed from the `NetworkConfig` interface. If you're using custom network configurations, you'll need to remove any `name` properties from your configs.

## Details
- Remove unused `name` property from `NetworkConfig` interface
- Remove `name` field from all default network configurations
- Update `setActiveNetwork` to accept both `NetworkId` enum and custom string IDs
- Update type signatures in React, Solid, and Vue adapters
- Update tests to remove name-related assertions