### PR TITLE
feat(network): enable runtime connection to custom Algorand nodes

### DIFF
--- a/examples/nextjs/src/app/Connect.tsx
+++ b/examples/nextjs/src/app/Connect.tsx
@@ -6,8 +6,8 @@ import * as React from 'react'
 import styles from './Connect.module.css'
 
 export function Connect() {
-  const { activeAddress, transactionSigner, wallets } = useWallet()
-  const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
+  const { algodClient, activeAddress, transactionSigner, wallets } = useWallet()
+  const { activeNetwork, setActiveNetwork } = useNetwork()
 
   const [isSending, setIsSending] = React.useState(false)
   const [magicEmail, setMagicEmail] = React.useState('')

--- a/examples/nextjs/src/app/Connect.tsx
+++ b/examples/nextjs/src/app/Connect.tsx
@@ -1,19 +1,13 @@
 'use client'
 
-import { NetworkId, WalletId, useWallet, type Wallet } from '@txnlab/use-wallet-react'
+import { NetworkId, WalletId, useNetwork, useWallet, type Wallet } from '@txnlab/use-wallet-react'
 import algosdk from 'algosdk'
 import * as React from 'react'
 import styles from './Connect.module.css'
 
 export function Connect() {
-  const {
-    algodClient,
-    activeAddress,
-    activeNetwork,
-    setActiveNetwork,
-    transactionSigner,
-    wallets
-  } = useWallet()
+  const { activeAddress, transactionSigner, wallets } = useWallet()
+  const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
 
   const [isSending, setIsSending] = React.useState(false)
   const [magicEmail, setMagicEmail] = React.useState('')

--- a/examples/nuxt/components/Connect.vue
+++ b/examples/nuxt/components/Connect.vue
@@ -1,16 +1,13 @@
 <script setup lang="ts">
-import { NetworkId, WalletId, useWallet, type Wallet } from '@txnlab/use-wallet-vue'
+import { NetworkId, WalletId, useNetwork, useWallet, type Wallet } from '@txnlab/use-wallet-vue'
 import algosdk from 'algosdk'
 import { ref } from 'vue'
 
-const {
-  algodClient,
-  activeNetwork,
-  setActiveNetwork,
-  transactionSigner,
-  wallets: walletsRef
-} = useWallet()
+const { transactionSigner, wallets: walletsRef } = useWallet()
 const wallets = computed(() => walletsRef.value)
+
+const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
+
 const isSending = ref(false)
 const magicEmail = ref('')
 

--- a/examples/nuxt/components/Connect.vue
+++ b/examples/nuxt/components/Connect.vue
@@ -3,10 +3,10 @@ import { NetworkId, WalletId, useNetwork, useWallet, type Wallet } from '@txnlab
 import algosdk from 'algosdk'
 import { ref } from 'vue'
 
-const { transactionSigner, wallets: walletsRef } = useWallet()
+const { algodClient, transactionSigner, wallets: walletsRef } = useWallet()
 const wallets = computed(() => walletsRef.value)
 
-const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
+const { activeNetwork, setActiveNetwork } = useNetwork()
 
 const isSending = ref(false)
 const magicEmail = ref('')

--- a/examples/react-ts/src/App.css
+++ b/examples/react-ts/src/App.css
@@ -103,3 +103,66 @@
     animation: logo-spin infinite 20s linear;
   }
 }
+
+.config-section {
+  width: 100%;
+  max-width: 500px;
+  margin-top: 1em;
+}
+
+.config-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  margin: 1em 0;
+  padding: 1em;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  text-align: left;
+}
+
+.form-group label {
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+.form-group input {
+  padding: 0.5em;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.1);
+  color: inherit;
+}
+
+.current-config {
+  margin-top: 1em;
+  text-align: left;
+}
+
+.current-config h5 {
+  margin: 0 0 0.5em 0;
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+.current-config pre {
+  padding: 1em;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  font-size: 0.9em;
+  overflow-x: auto;
+}
+
+.error-message {
+  margin-top: 1em;
+  padding: 0.5em 1em;
+  color: #ff4444;
+  background: rgba(255, 68, 68, 0.1);
+  border-radius: 4px;
+}

--- a/examples/react-ts/src/App.tsx
+++ b/examples/react-ts/src/App.tsx
@@ -1,5 +1,6 @@
 import { NetworkId, WalletId, WalletManager, WalletProvider } from '@txnlab/use-wallet-react'
 import { Connect } from './Connect'
+import { NetworkControls } from './NetworkControls'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
@@ -45,6 +46,7 @@ function App() {
         </a>
       </div>
       <h1>@txnlab/use-wallet-react</h1>
+      <NetworkControls />
       <Connect />
     </WalletProvider>
   )

--- a/examples/react-ts/src/Connect.tsx
+++ b/examples/react-ts/src/Connect.tsx
@@ -1,10 +1,9 @@
-import { NetworkId, WalletId, useNetwork, useWallet, type Wallet } from '@txnlab/use-wallet-react'
+import { useWallet, WalletId, type Wallet } from '@txnlab/use-wallet-react'
 import algosdk from 'algosdk'
 import * as React from 'react'
 
 export function Connect() {
-  const { activeAddress, transactionSigner, wallets } = useWallet()
-  const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
+  const { algodClient, activeAddress, transactionSigner, wallets } = useWallet()
 
   const [isSending, setIsSending] = React.useState(false)
   const [magicEmail, setMagicEmail] = React.useState('')
@@ -71,35 +70,6 @@ export function Connect() {
 
   return (
     <div>
-      <div className="network-group">
-        <h4>
-          Current Network: <span className="active-network">{activeNetwork}</span>
-        </h4>
-        <div className="network-buttons">
-          <button
-            type="button"
-            onClick={() => setActiveNetwork(NetworkId.BETANET)}
-            disabled={activeNetwork === NetworkId.BETANET}
-          >
-            Set to Betanet
-          </button>
-          <button
-            type="button"
-            onClick={() => setActiveNetwork(NetworkId.TESTNET)}
-            disabled={activeNetwork === NetworkId.TESTNET}
-          >
-            Set to Testnet
-          </button>
-          <button
-            type="button"
-            onClick={() => setActiveNetwork(NetworkId.MAINNET)}
-            disabled={activeNetwork === NetworkId.MAINNET}
-          >
-            Set to Mainnet
-          </button>
-        </div>
-      </div>
-
       {wallets.map((wallet) => (
         <div key={wallet.id} className="wallet-group">
           <h4>

--- a/examples/react-ts/src/Connect.tsx
+++ b/examples/react-ts/src/Connect.tsx
@@ -1,16 +1,10 @@
-import { NetworkId, WalletId, useWallet, type Wallet } from '@txnlab/use-wallet-react'
+import { NetworkId, WalletId, useNetwork, useWallet, type Wallet } from '@txnlab/use-wallet-react'
 import algosdk from 'algosdk'
 import * as React from 'react'
 
 export function Connect() {
-  const {
-    algodClient,
-    activeAddress,
-    activeNetwork,
-    setActiveNetwork,
-    transactionSigner,
-    wallets
-  } = useWallet()
+  const { activeAddress, transactionSigner, wallets } = useWallet()
+  const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
 
   const [isSending, setIsSending] = React.useState(false)
   const [magicEmail, setMagicEmail] = React.useState('')

--- a/examples/react-ts/src/NetworkControls.tsx
+++ b/examples/react-ts/src/NetworkControls.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 export function NetworkControls() {
   const {
     activeNetwork,
-    networks,
+    networkConfig,
     activeNetworkConfig,
     setActiveNetwork,
     updateNetworkAlgod,
@@ -71,7 +71,7 @@ export function NetworkControls() {
       <div className="active-network">Active: {activeNetwork}</div>
 
       <div className="network-buttons">
-        {Object.keys(networks).map((networkId) => (
+        {Object.keys(networkConfig).map((networkId) => (
           <button
             key={networkId}
             onClick={() => handleNetworkSwitch(networkId as NetworkId)}

--- a/examples/react-ts/src/NetworkControls.tsx
+++ b/examples/react-ts/src/NetworkControls.tsx
@@ -1,0 +1,144 @@
+import { AlgodConfig, NetworkId, useNetwork } from '@txnlab/use-wallet-react'
+import * as React from 'react'
+
+export function NetworkControls() {
+  const {
+    activeNetwork,
+    networks,
+    activeNetworkConfig,
+    setActiveNetwork,
+    updateNetworkAlgod,
+    resetNetworkConfig
+  } = useNetwork()
+
+  const [error, setError] = React.useState<string>('')
+  const [showConfig, setShowConfig] = React.useState(false)
+
+  const [configForm, setConfigForm] = React.useState<Partial<AlgodConfig>>({
+    baseServer: activeNetworkConfig.algod.baseServer,
+    port: activeNetworkConfig.algod.port?.toString() || '',
+    token: activeNetworkConfig.algod.token?.toString() || ''
+  })
+
+  React.useEffect(() => {
+    setConfigForm({
+      baseServer: activeNetworkConfig.algod.baseServer,
+      port: activeNetworkConfig.algod.port?.toString() || '',
+      token: activeNetworkConfig.algod.token?.toString() || ''
+    })
+  }, [activeNetworkConfig])
+
+  const handleNetworkSwitch = async (networkId: NetworkId) => {
+    try {
+      setError('')
+      await setActiveNetwork(networkId)
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to switch networks')
+    }
+  }
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target
+    setConfigForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleConfigSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    try {
+      setError('')
+      updateNetworkAlgod(activeNetwork, {
+        baseServer: configForm.baseServer,
+        port: configForm.port || undefined,
+        token: configForm.token
+      })
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to update node configuration')
+    }
+  }
+
+  const handleResetConfig = () => {
+    try {
+      setError('')
+      resetNetworkConfig(activeNetwork)
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to reset node configuration')
+    }
+  }
+
+  return (
+    <div className="network-group">
+      <h4>Network Controls</h4>
+      <div className="active-network">Active: {activeNetwork}</div>
+
+      <div className="network-buttons">
+        {Object.keys(networks).map((networkId) => (
+          <button
+            key={networkId}
+            onClick={() => handleNetworkSwitch(networkId as NetworkId)}
+            disabled={networkId === activeNetwork}
+          >
+            Switch to {networkId}
+          </button>
+        ))}
+      </div>
+
+      <div className="config-section">
+        <button onClick={() => setShowConfig(!showConfig)}>
+          {showConfig ? 'Hide' : 'Show'} Network Config
+        </button>
+
+        {showConfig && (
+          <form onSubmit={handleConfigSubmit} className="config-form">
+            <div className="form-group">
+              <label htmlFor="baseServer">Base Server:</label>
+              <input
+                type="text"
+                id="baseServer"
+                name="baseServer"
+                value={configForm.baseServer}
+                onChange={handleInputChange}
+                placeholder="https://mainnet-api.4160.nodely.dev"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="port">Port:</label>
+              <input
+                type="text"
+                id="port"
+                name="port"
+                value={configForm.port}
+                onChange={handleInputChange}
+                placeholder="443"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="token">Token:</label>
+              <input
+                type="text"
+                id="token"
+                name="token"
+                value={configForm.token?.toString() || ''}
+                onChange={handleInputChange}
+                placeholder="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              />
+            </div>
+
+            <button type="submit">Update Configuration</button>
+            <button type="button" onClick={handleResetConfig}>
+              Reset Configuration
+            </button>
+          </form>
+        )}
+
+        <div className="current-config">
+          <h5>Current Algod Configuration:</h5>
+          <pre>{JSON.stringify(activeNetworkConfig.algod, null, 2)}</pre>
+        </div>
+      </div>
+
+      {error && <div className="error-message">{error}</div>}
+    </div>
+  )
+}

--- a/examples/react-ts/src/NetworkControls.tsx
+++ b/examples/react-ts/src/NetworkControls.tsx
@@ -7,7 +7,7 @@ export function NetworkControls() {
     networkConfig,
     activeNetworkConfig,
     setActiveNetwork,
-    updateNetworkAlgod,
+    updateAlgodConfig,
     resetNetworkConfig
   } = useNetwork()
 
@@ -46,7 +46,7 @@ export function NetworkControls() {
     event.preventDefault()
     try {
       setError('')
-      updateNetworkAlgod(activeNetwork, {
+      updateAlgodConfig(activeNetwork, {
         baseServer: configForm.baseServer,
         port: configForm.port || undefined,
         token: configForm.token

--- a/examples/solid-ts/src/App.css
+++ b/examples/solid-ts/src/App.css
@@ -88,3 +88,69 @@
   opacity: 0.75;
   color: light-dark(rgba(16, 16, 16, 0.3), rgba(255, 255, 255, 0.3));
 }
+
+.config-section {
+  width: 100%;
+  max-width: 500px;
+  margin-top: 1em;
+}
+
+.config-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  margin: 1em 0;
+  padding: 1em;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  text-align: left;
+}
+
+.form-group label {
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+.current-config {
+  margin-top: 1em;
+  text-align: left;
+}
+
+.current-config h5 {
+  margin: 0 0 0.5em 0;
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+.current-config pre {
+  padding: 1em;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  font-size: 0.9em;
+  overflow-x: auto;
+}
+
+.error-message {
+  margin-top: 1em;
+  padding: 0.5em 1em;
+  color: #ff4444;
+  background: rgba(255, 68, 68, 0.1);
+  border-radius: 4px;
+}
+
+@media (prefers-color-scheme: light) {
+  .config-form {
+    border-color: rgba(0, 0, 0, 0.1);
+  }
+
+  .form-group input,
+  .current-config pre {
+    background: rgba(0, 0, 0, 0.05);
+  }
+}

--- a/examples/solid-ts/src/App.tsx
+++ b/examples/solid-ts/src/App.tsx
@@ -1,5 +1,6 @@
 import { NetworkId, WalletId, WalletManager, WalletProvider } from '@txnlab/use-wallet-solid'
 import { Connect } from './Connect'
+import { NetworkControls } from './NetworkControls'
 import solidLogo from './assets/solid.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
@@ -45,6 +46,7 @@ function App() {
         </a>
       </div>
       <h1>@txnlab/use-wallet-solid</h1>
+      <NetworkControls />
       <Connect />
     </WalletProvider>
   )

--- a/examples/solid-ts/src/Connect.tsx
+++ b/examples/solid-ts/src/Connect.tsx
@@ -18,9 +18,11 @@ export function Connect() {
     isWalletActive,
     isWalletConnected,
     transactionSigner,
-    wallets
+    wallets,
+    algodClient
   } = useWallet()
-  const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
+
+  const { activeNetwork, setActiveNetwork } = useNetwork()
 
   const isMagicLink = (wallet: BaseWallet) => wallet.id === WalletId.MAGIC
   const isEmailValid = () => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(magicEmail())

--- a/examples/solid-ts/src/Connect.tsx
+++ b/examples/solid-ts/src/Connect.tsx
@@ -1,10 +1,4 @@
-import {
-  useWallet,
-  WalletId,
-  NetworkId,
-  useNetwork,
-  type BaseWallet
-} from '@txnlab/use-wallet-solid'
+import { useWallet, WalletId, type BaseWallet } from '@txnlab/use-wallet-solid'
 import algosdk from 'algosdk'
 import { For, Show, createSignal } from 'solid-js'
 
@@ -21,8 +15,6 @@ export function Connect() {
     wallets,
     algodClient
   } = useWallet()
-
-  const { activeNetwork, setActiveNetwork } = useNetwork()
 
   const isMagicLink = (wallet: BaseWallet) => wallet.id === WalletId.MAGIC
   const isEmailValid = () => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(magicEmail())
@@ -86,102 +78,71 @@ export function Connect() {
   }
 
   return (
-    <div>
-      <div class="network-group">
-        <h4>
-          Current Network: <span class="active-network">{activeNetwork()}</span>
-        </h4>
-        <div class="network-buttons">
-          <button
-            type="button"
-            onClick={() => setActiveNetwork(NetworkId.BETANET)}
-            disabled={activeNetwork() === NetworkId.BETANET}
-          >
-            Set to Betanet
-          </button>
-          <button
-            type="button"
-            onClick={() => setActiveNetwork(NetworkId.TESTNET)}
-            disabled={activeNetwork() === NetworkId.TESTNET}
-          >
-            Set to Testnet
-          </button>
-          <button
-            type="button"
-            onClick={() => setActiveNetwork(NetworkId.MAINNET)}
-            disabled={activeNetwork() === NetworkId.MAINNET}
-          >
-            Set to Mainnet
-          </button>
-        </div>
-      </div>
-
-      <For each={wallets}>
-        {(wallet) => (
-          <div class="wallet-group">
-            <h4>
-              {wallet.metadata.name}{' '}
-              <Show when={wallet.id === activeWalletId()} fallback="">
-                [active]
-              </Show>
-            </h4>
-            <div class="wallet-buttons">
-              <button
-                type="button"
-                onClick={() => wallet.connect(getConnectArgs(wallet))}
-                disabled={isConnectDisabled(wallet)}
-              >
-                Connect
+    <For each={wallets}>
+      {(wallet) => (
+        <div class="wallet-group">
+          <h4>
+            {wallet.metadata.name}{' '}
+            <Show when={wallet.id === activeWalletId()} fallback="">
+              [active]
+            </Show>
+          </h4>
+          <div class="wallet-buttons">
+            <button
+              type="button"
+              onClick={() => wallet.connect(getConnectArgs(wallet))}
+              disabled={isConnectDisabled(wallet)}
+            >
+              Connect
+            </button>
+            <button
+              type="button"
+              onClick={() => wallet.disconnect()}
+              disabled={!isWalletConnected(wallet.id)}
+            >
+              Disconnect
+            </button>
+            <Show when={isWalletActive(wallet.id)}>
+              <button type="button" onClick={sendTransaction} disabled={isSending()}>
+                {isSending() ? 'Sending Transaction...' : 'Send Transaction'}
               </button>
+            </Show>
+            <Show when={!isWalletActive(wallet.id)}>
               <button
                 type="button"
-                onClick={() => wallet.disconnect()}
+                onClick={() => wallet.setActive()}
                 disabled={!isWalletConnected(wallet.id)}
               >
-                Disconnect
+                Set Active
               </button>
-              <Show when={isWalletActive(wallet.id)}>
-                <button type="button" onClick={sendTransaction} disabled={isSending()}>
-                  {isSending() ? 'Sending Transaction...' : 'Send Transaction'}
-                </button>
-              </Show>
-              <Show when={!isWalletActive(wallet.id)}>
-                <button
-                  type="button"
-                  onClick={() => wallet.setActive()}
-                  disabled={!isWalletConnected(wallet.id)}
-                >
-                  Set Active
-                </button>
-              </Show>
-            </div>
-
-            <Show when={isMagicLink(wallet)}>
-              <div class="input-group">
-                <label for="magic-email">Email:</label>
-                <input
-                  id="magic-email"
-                  type="email"
-                  value={magicEmail()}
-                  onInput={(e) => setMagicEmail(e.target.value)}
-                  placeholder="Enter email to connect..."
-                  disabled={isWalletConnected(wallet.id)}
-                />
-              </div>
-            </Show>
-
-            <Show when={wallet.id === activeWalletId() && wallet.accounts.length}>
-              <div>
-                <select onChange={(event) => setActiveAccount(event, wallet)}>
-                  <For each={wallet.accounts}>
-                    {(account) => <option value={account.address}>{account.address}</option>}
-                  </For>
-                </select>
-              </div>
             </Show>
           </div>
-        )}
-      </For>
-    </div>
+
+          <Show when={isMagicLink(wallet)}>
+            <div class="input-group">
+              <label for="magic-email">Email:</label>
+              <input
+                id="magic-email"
+                type="email"
+                value={magicEmail()}
+                onInput={(e) => setMagicEmail(e.target.value)}
+                placeholder="Enter email to connect..."
+                disabled={isWalletConnected(wallet.id)}
+              />
+            </div>
+          </Show>
+
+          <Show when={wallet.id === activeWalletId() && wallet.accounts.length}>
+            <div>
+              <select onChange={(event) => setActiveAccount(event, wallet)}>
+                <For each={wallet.accounts}>
+                  {(account) => <option value={account.address}>{account.address}</option>}
+                </For>
+              </select>
+            </div>
+          </Show>
+        </div>
+      )}
+    </For>
   )
 }

--- a/examples/solid-ts/src/Connect.tsx
+++ b/examples/solid-ts/src/Connect.tsx
@@ -1,4 +1,10 @@
-import { useWallet, type BaseWallet, WalletId, NetworkId } from '@txnlab/use-wallet-solid'
+import {
+  useWallet,
+  WalletId,
+  NetworkId,
+  useNetwork,
+  type BaseWallet
+} from '@txnlab/use-wallet-solid'
 import algosdk from 'algosdk'
 import { For, Show, createSignal } from 'solid-js'
 
@@ -7,16 +13,14 @@ export function Connect() {
   const [magicEmail, setMagicEmail] = createSignal('')
 
   const {
-    algodClient,
     activeAddress,
-    activeNetwork,
-    setActiveNetwork,
     activeWalletId,
     isWalletActive,
     isWalletConnected,
     transactionSigner,
     wallets
   } = useWallet()
+  const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
 
   const isMagicLink = (wallet: BaseWallet) => wallet.id === WalletId.MAGIC
   const isEmailValid = () => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(magicEmail())

--- a/examples/solid-ts/src/NetworkControls.tsx
+++ b/examples/solid-ts/src/NetworkControls.tsx
@@ -1,0 +1,146 @@
+import { AlgodConfig, NetworkId, useNetwork } from '@txnlab/use-wallet-solid'
+import { createSignal, createEffect } from 'solid-js'
+
+export function NetworkControls() {
+  const {
+    activeNetwork,
+    networkConfig,
+    activeNetworkConfig,
+    setActiveNetwork,
+    updateNetworkAlgod,
+    resetNetworkConfig
+  } = useNetwork()
+
+  const [error, setError] = createSignal('')
+  const [showConfig, setShowConfig] = createSignal(false)
+  const [configForm, setConfigForm] = createSignal<Partial<AlgodConfig>>({
+    baseServer: activeNetworkConfig().algod.baseServer,
+    port: activeNetworkConfig().algod.port?.toString() || '',
+    token: activeNetworkConfig().algod.token?.toString() || ''
+  })
+
+  // Update form when network config changes
+  createEffect(() => {
+    setConfigForm({
+      baseServer: activeNetworkConfig().algod.baseServer,
+      port: activeNetworkConfig().algod.port?.toString() || '',
+      token: activeNetworkConfig().algod.token?.toString() || ''
+    })
+  })
+
+  const handleNetworkSwitch = async (networkId: NetworkId) => {
+    try {
+      setError('')
+      await setActiveNetwork(networkId)
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to switch networks')
+    }
+  }
+
+  const handleInputChange = (event: InputEvent & { currentTarget: HTMLInputElement }) => {
+    const { name, value } = event.currentTarget
+    setConfigForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleConfigSubmit = async (event: Event) => {
+    event.preventDefault()
+    try {
+      setError('')
+      const form = configForm()
+      updateNetworkAlgod(activeNetwork(), {
+        baseServer: form.baseServer,
+        port: form.port || undefined,
+        token: form.token
+      })
+    } catch (error) {
+      console.error('[NetworkControls] Error updating config:', error)
+      setError(error instanceof Error ? error.message : 'Failed to update node configuration')
+    }
+  }
+
+  const handleResetConfig = () => {
+    try {
+      setError('')
+      resetNetworkConfig(activeNetwork())
+    } catch (error) {
+      console.error('[NetworkControls] Error resetting config:', error)
+      setError(error instanceof Error ? error.message : 'Failed to reset node configuration')
+    }
+  }
+
+  return (
+    <div class="network-group">
+      <h4>Network Controls</h4>
+      <div class="active-network">Active: {activeNetwork()}</div>
+
+      <div class="network-buttons">
+        {Object.keys(networkConfig()).map((networkId) => (
+          <button
+            onClick={() => handleNetworkSwitch(networkId as NetworkId)}
+            disabled={networkId === activeNetwork()}
+          >
+            Switch to {networkId}
+          </button>
+        ))}
+      </div>
+
+      <div class="config-section">
+        <button onClick={() => setShowConfig(!showConfig())}>
+          {showConfig() ? 'Hide' : 'Show'} Network Config
+        </button>
+
+        {showConfig() && (
+          <form onSubmit={handleConfigSubmit} class="config-form">
+            <div class="form-group">
+              <label for="baseServer">Base Server:</label>
+              <input
+                type="text"
+                id="baseServer"
+                name="baseServer"
+                value={configForm().baseServer}
+                onInput={handleInputChange}
+                placeholder="https://mainnet-api.4160.nodely.dev"
+              />
+            </div>
+
+            <div class="form-group">
+              <label for="port">Port:</label>
+              <input
+                type="text"
+                id="port"
+                name="port"
+                value={configForm().port}
+                onInput={handleInputChange}
+                placeholder="443"
+              />
+            </div>
+
+            <div class="form-group">
+              <label for="token">Token:</label>
+              <input
+                type="text"
+                id="token"
+                name="token"
+                value={configForm().token?.toString() || ''}
+                onInput={handleInputChange}
+                placeholder="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              />
+            </div>
+
+            <button type="submit">Update Configuration</button>
+            <button type="button" onClick={handleResetConfig}>
+              Reset Configuration
+            </button>
+          </form>
+        )}
+
+        <div class="current-config">
+          <h5>Current Algod Configuration:</h5>
+          <pre>{JSON.stringify(activeNetworkConfig().algod, null, 2)}</pre>
+        </div>
+      </div>
+
+      {error() && <div class="error-message">{error()}</div>}
+    </div>
+  )
+}

--- a/examples/solid-ts/src/NetworkControls.tsx
+++ b/examples/solid-ts/src/NetworkControls.tsx
@@ -7,7 +7,7 @@ export function NetworkControls() {
     networkConfig,
     activeNetworkConfig,
     setActiveNetwork,
-    updateNetworkAlgod,
+    updateAlgodConfig,
     resetNetworkConfig
   } = useNetwork()
 
@@ -47,7 +47,7 @@ export function NetworkControls() {
     try {
       setError('')
       const form = configForm()
-      updateNetworkAlgod(activeNetwork(), {
+      updateAlgodConfig(activeNetwork(), {
         baseServer: form.baseServer,
         port: form.port || undefined,
         token: form.token

--- a/examples/vue-ts/src/App.vue
+++ b/examples/vue-ts/src/App.vue
@@ -31,4 +31,3 @@ import NetworkControls from './components/NetworkControls.vue'
   filter: drop-shadow(0 0 2em #42b883aa);
 }
 </style>
-

--- a/examples/vue-ts/src/App.vue
+++ b/examples/vue-ts/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Connect from './components/Connect.vue'
+import NetworkControls from './components/NetworkControls.vue'
 </script>
 
 <template>
@@ -12,6 +13,7 @@ import Connect from './components/Connect.vue'
     </a>
   </div>
   <h1>@txnlab/use-wallet-vue</h1>
+  <NetworkControls />
   <Connect />
 </template>
 
@@ -29,3 +31,4 @@ import Connect from './components/Connect.vue'
   filter: drop-shadow(0 0 2em #42b883aa);
 }
 </style>
+

--- a/examples/vue-ts/src/components/Connect.vue
+++ b/examples/vue-ts/src/components/Connect.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { NetworkId, WalletId, useNetwork, useWallet, type Wallet } from '@txnlab/use-wallet-vue'
+import { WalletId, useWallet, type Wallet } from '@txnlab/use-wallet-vue'
 import algosdk from 'algosdk'
 import { ref } from 'vue'
 
-const { transactionSigner, wallets } = useWallet()
-const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
+const { algodClient, transactionSigner, wallets } = useWallet()
 
 const isSending = ref(false)
 const magicEmail = ref('')
@@ -65,35 +64,6 @@ const sendTransaction = async (wallet: Wallet) => {
 
 <template>
   <div>
-    <div className="network-group">
-      <h4>
-        Current Network: <span className="active-network">{{ activeNetwork }}</span>
-      </h4>
-      <div className="network-buttons">
-        <button
-          type="button"
-          @click="() => setActiveNetwork(NetworkId.BETANET)"
-          :disabled="activeNetwork === NetworkId.BETANET"
-        >
-          Set to Betanet
-        </button>
-        <button
-          type="button"
-          @click="() => setActiveNetwork(NetworkId.TESTNET)"
-          :disabled="activeNetwork === NetworkId.TESTNET"
-        >
-          Set to Testnet
-        </button>
-        <button
-          type="button"
-          @click="() => setActiveNetwork(NetworkId.MAINNET)"
-          :disabled="activeNetwork === NetworkId.MAINNET"
-        >
-          Set to Mainnet
-        </button>
-      </div>
-    </div>
-
     <div v-for="wallet in wallets" :key="wallet.id" class="wallet-group">
       <h4>{{ wallet.metadata.name }} <span v-if="wallet.isActive">[active]</span></h4>
       <div class="wallet-buttons">
@@ -143,36 +113,6 @@ const sendTransaction = async (wallet: Wallet) => {
 </template>
 
 <style scoped>
-.network-group {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1em;
-  margin: 2em;
-  padding: 2em;
-  background-color: light-dark(rgba(0, 0, 0, 0.025), rgba(255, 255, 255, 0.025));
-  border-color: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 8px;
-}
-
-.network-group h4 {
-  margin: 0;
-}
-
-.network-group .active-network {
-  text-transform: capitalize;
-}
-
-.network-buttons {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.5em;
-}
-
 .wallet-group {
   display: flex;
   flex-direction: column;
@@ -220,3 +160,4 @@ const sendTransaction = async (wallet: Wallet) => {
   }
 }
 </style>
+

--- a/examples/vue-ts/src/components/Connect.vue
+++ b/examples/vue-ts/src/components/Connect.vue
@@ -160,4 +160,3 @@ const sendTransaction = async (wallet: Wallet) => {
   }
 }
 </style>
-

--- a/examples/vue-ts/src/components/Connect.vue
+++ b/examples/vue-ts/src/components/Connect.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { NetworkId, WalletId, useWallet, type Wallet } from '@txnlab/use-wallet-vue'
+import { NetworkId, WalletId, useNetwork, useWallet, type Wallet } from '@txnlab/use-wallet-vue'
 import algosdk from 'algosdk'
 import { ref } from 'vue'
 
-const { algodClient, activeNetwork, setActiveNetwork, transactionSigner, wallets } = useWallet()
+const { transactionSigner, wallets } = useWallet()
+const { algodClient, activeNetwork, setActiveNetwork } = useNetwork()
+
 const isSending = ref(false)
 const magicEmail = ref('')
 

--- a/examples/vue-ts/src/components/NetworkControls.vue
+++ b/examples/vue-ts/src/components/NetworkControls.vue
@@ -154,4 +154,3 @@ const handleResetConfig = () => {
   gap: 0.5em;
 }
 </style>
-

--- a/examples/vue-ts/src/components/NetworkControls.vue
+++ b/examples/vue-ts/src/components/NetworkControls.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { AlgodConfig, NetworkId, useNetwork } from '@txnlab/use-wallet-vue'
+import { ref, reactive, watch } from 'vue'
+
+const {
+  activeNetwork,
+  networks,
+  activeNetworkConfig,
+  setActiveNetwork,
+  updateNetworkAlgod,
+  resetNetworkConfig
+} = useNetwork()
+
+const error = ref('')
+const showConfig = ref(false)
+
+const configForm = reactive<Partial<AlgodConfig>>({
+  baseServer: activeNetworkConfig.value.algod.baseServer,
+  port: activeNetworkConfig.value.algod.port?.toString() || '',
+  token: activeNetworkConfig.value.algod.token?.toString() || ''
+})
+
+watch(
+  () => activeNetworkConfig.value,
+  (newConfig) => {
+    configForm.baseServer = newConfig.algod.baseServer
+    configForm.port = newConfig.algod.port?.toString() || ''
+    configForm.token = newConfig.algod.token?.toString() || ''
+  }
+)
+
+const handleNetworkSwitch = async (networkId: NetworkId) => {
+  try {
+    error.value = ''
+    await setActiveNetwork(networkId)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to switch networks'
+  }
+}
+
+const handleConfigSubmit = async (event: Event) => {
+  event.preventDefault()
+  try {
+    error.value = ''
+    updateNetworkAlgod(activeNetwork.value, {
+      baseServer: configForm.baseServer,
+      port: configForm.port || undefined,
+      token: configForm.token
+    })
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to update node configuration'
+  }
+}
+
+const handleResetConfig = () => {
+  try {
+    error.value = ''
+    resetNetworkConfig(activeNetwork.value)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to reset node configuration'
+  }
+}
+</script>
+
+<template>
+  <div class="network-group">
+    <h4>Network Controls</h4>
+    <div class="active-network">Active: {{ activeNetwork }}</div>
+
+    <div class="network-buttons">
+      <button
+        v-for="networkId in Object.keys(networks)"
+        :key="networkId"
+        @click="() => handleNetworkSwitch(networkId as NetworkId)"
+        :disabled="networkId === activeNetwork"
+      >
+        Switch to {{ networkId }}
+      </button>
+    </div>
+
+    <div class="config-section">
+      <button @click="showConfig = !showConfig">
+        {{ showConfig ? 'Hide' : 'Show' }} Network Config
+      </button>
+
+      <form v-if="showConfig" @submit="handleConfigSubmit" class="config-form">
+        <div class="form-group">
+          <label for="baseServer">Base Server:</label>
+          <input
+            type="text"
+            id="baseServer"
+            v-model="configForm.baseServer"
+            placeholder="https://mainnet-api.4160.nodely.dev"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="port">Port:</label>
+          <input type="text" id="port" v-model="configForm.port" placeholder="443" />
+        </div>
+
+        <div class="form-group">
+          <label for="token">Token:</label>
+          <input
+            type="text"
+            id="token"
+            v-model="configForm.token"
+            placeholder="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          />
+        </div>
+
+        <button type="submit">Update Configuration</button>
+        <button type="button" @click="handleResetConfig">Reset Configuration</button>
+      </form>
+
+      <div class="current-config">
+        <h5>Current Algod Configuration:</h5>
+        <pre>{{ JSON.stringify(activeNetworkConfig.algod, null, 2) }}</pre>
+      </div>
+    </div>
+
+    <div v-if="error" class="error-message">{{ error }}</div>
+  </div>
+</template>
+
+<style scoped>
+.network-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1em;
+  margin: 2em;
+  padding: 2em;
+  background-color: light-dark(rgba(0, 0, 0, 0.025), rgba(255, 255, 255, 0.025));
+  border-color: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1));
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 8px;
+}
+
+.network-group h4 {
+  margin: 0;
+}
+
+.active-network {
+  text-transform: capitalize;
+}
+
+.network-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5em;
+}
+</style>
+

--- a/examples/vue-ts/src/components/NetworkControls.vue
+++ b/examples/vue-ts/src/components/NetworkControls.vue
@@ -7,7 +7,7 @@ const {
   networkConfig,
   activeNetworkConfig,
   setActiveNetwork,
-  updateNetworkAlgod,
+  updateAlgodConfig,
   resetNetworkConfig
 } = useNetwork()
 
@@ -42,7 +42,7 @@ const handleConfigSubmit = async (event: Event) => {
   event.preventDefault()
   try {
     error.value = ''
-    updateNetworkAlgod(activeNetwork.value, {
+    updateAlgodConfig(activeNetwork.value, {
       baseServer: configForm.baseServer,
       port: configForm.port || undefined,
       token: configForm.token

--- a/examples/vue-ts/src/components/NetworkControls.vue
+++ b/examples/vue-ts/src/components/NetworkControls.vue
@@ -4,7 +4,7 @@ import { ref, reactive, watch } from 'vue'
 
 const {
   activeNetwork,
-  networks,
+  networkConfig,
   activeNetworkConfig,
   setActiveNetwork,
   updateNetworkAlgod,
@@ -69,7 +69,7 @@ const handleResetConfig = () => {
 
     <div class="network-buttons">
       <button
-        v-for="networkId in Object.keys(networks)"
+        v-for="networkId in Object.keys(networkConfig)"
         :key="networkId"
         @click="() => handleNetworkSwitch(networkId as NetworkId)"
         :disabled="networkId === activeNetwork"

--- a/examples/vue-ts/src/style.css
+++ b/examples/vue-ts/src/style.css
@@ -119,3 +119,69 @@ select {
     border-color: #f9f9f9;
   }
 }
+
+.config-section {
+  width: 100%;
+  max-width: 500px;
+  margin-top: 1em;
+}
+
+.config-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  margin: 1em 0;
+  padding: 1em;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  text-align: left;
+}
+
+.form-group label {
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+.current-config {
+  margin-top: 1em;
+  text-align: left;
+}
+
+.current-config h5 {
+  margin: 0 0 0.5em 0;
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+.current-config pre {
+  padding: 1em;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  font-size: 0.9em;
+  overflow-x: auto;
+}
+
+.error-message {
+  margin-top: 1em;
+  padding: 0.5em 1em;
+  color: #ff4444;
+  background: rgba(255, 68, 68, 0.1);
+  border-radius: 4px;
+}
+
+@media (prefers-color-scheme: light) {
+  .config-form {
+    border-color: rgba(0, 0, 0, 0.1);
+  }
+
+  .form-group input,
+  .current-config pre {
+    background: rgba(0, 0, 0, 0.05);
+  }
+}

--- a/packages/use-wallet-react/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-react/src/__tests__/index.test.tsx
@@ -7,7 +7,6 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
-  DEFAULT_NETWORKS,
   DEFAULT_STATE,
   type State,
   type WalletAccount
@@ -60,8 +59,7 @@ const mockDeflyWallet = new DeflyWallet({
   metadata: { name: 'Defly', icon: 'icon' },
   getAlgodClient: () => ({}) as any,
   store: mockStore,
-  subscribe: vi.fn(),
-  networks: DEFAULT_NETWORKS
+  subscribe: vi.fn()
 })
 
 const mockMagicAuth = new MagicAuth({
@@ -72,8 +70,7 @@ const mockMagicAuth = new MagicAuth({
   metadata: { name: 'Magic', icon: 'icon' },
   getAlgodClient: () => ({}) as any,
   store: mockStore,
-  subscribe: vi.fn(),
-  networks: DEFAULT_NETWORKS
+  subscribe: vi.fn()
 })
 
 describe('WalletProvider', () => {
@@ -147,8 +144,10 @@ describe('useNetwork', () => {
     const { result } = renderHook(() => useNetwork(), { wrapper })
 
     expect(result.current.activeNetwork).toBe(NetworkId.TESTNET)
-    expect(result.current.networks).toBeDefined()
-    expect(result.current.activeNetworkConfig).toBe(mockWalletManager.networks[NetworkId.TESTNET])
+    expect(result.current.networkConfig).toBeDefined()
+    expect(result.current.activeNetworkConfig).toBe(
+      mockWalletManager.networkConfig[NetworkId.TESTNET]
+    )
     expect(typeof result.current.setActiveNetwork).toBe('function')
     expect(typeof result.current.updateNetworkAlgod).toBe('function')
   })
@@ -224,7 +223,7 @@ describe('useNetwork', () => {
       await result.current.setActiveNetwork(newNetwork)
     })
 
-    expect(result.current.activeNetworkConfig).toBe(mockWalletManager.networks[newNetwork])
+    expect(result.current.activeNetworkConfig).toBe(mockWalletManager.networkConfig[newNetwork])
   })
 
   it('updates activeNetworkConfig when updating network configuration', async () => {
@@ -283,7 +282,8 @@ describe('useNetwork', () => {
     })
 
     // Verify new algod client was created
-    expect(createAlgodClientSpy).toHaveBeenCalledWith(NetworkId.TESTNET)
+    const algodConfig = mockWalletManager.networkConfig[NetworkId.TESTNET].algod
+    expect(createAlgodClientSpy).toHaveBeenCalledWith(algodConfig)
   })
 
   it('updates algodClient when updating active network config', async () => {

--- a/packages/use-wallet-react/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-react/src/__tests__/index.test.tsx
@@ -146,6 +146,7 @@ describe('useNetwork', () => {
 
     expect(result.current.activeNetwork).toBe(NetworkId.TESTNET)
     expect(result.current.networks).toBeDefined()
+    expect(result.current.activeNetworkConfig).toBe(mockWalletManager.networks[NetworkId.TESTNET])
     expect(result.current.algodClient).toBeDefined()
     expect(typeof result.current.setActiveNetwork).toBe('function')
     expect(typeof result.current.updateNetworkAlgod).toBe('function')
@@ -221,6 +222,27 @@ describe('useNetwork', () => {
     })
 
     expect(result.current.algodClient).toBe(newAlgodClient)
+  })
+
+  it('updates activeNetworkConfig when switching networks', async () => {
+    const { result } = renderHook(() => useNetwork(), { wrapper })
+    const newNetwork = NetworkId.MAINNET
+
+    await act(async () => {
+      await result.current.setActiveNetwork(newNetwork)
+    })
+
+    expect(result.current.activeNetworkConfig).toBe(mockWalletManager.networks[newNetwork])
+  })
+
+  it('updates activeNetworkConfig when updating network configuration', async () => {
+    const { result } = renderHook(() => useNetwork(), { wrapper })
+    const networkId = NetworkId.TESTNET
+    const config = { baseServer: 'https://new-server.com' }
+
+    result.current.updateNetworkAlgod(networkId, config)
+
+    expect(mockWalletManager.activeNetworkConfig.algod.baseServer).toBe(config.baseServer)
   })
 
   describe('setActiveNetwork', () => {

--- a/packages/use-wallet-react/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-react/src/__tests__/index.test.tsx
@@ -149,7 +149,7 @@ describe('useNetwork', () => {
       mockWalletManager.networkConfig[NetworkId.TESTNET]
     )
     expect(typeof result.current.setActiveNetwork).toBe('function')
-    expect(typeof result.current.updateNetworkAlgod).toBe('function')
+    expect(typeof result.current.updateAlgodConfig).toBe('function')
   })
 
   it('updates activeNetwork and algodClient when setActiveNetwork is called', async () => {
@@ -169,13 +169,13 @@ describe('useNetwork', () => {
     )
   })
 
-  it('calls updateNetworkAlgod on the manager when updating network config', () => {
+  it('calls updateAlgodConfig on the manager when updating network config', () => {
     const { result } = renderHook(() => useNetwork(), { wrapper })
     const networkId = NetworkId.TESTNET
     const config = { baseServer: 'https://new-server.com' }
 
     act(() => {
-      result.current.updateNetworkAlgod(networkId, config)
+      result.current.updateAlgodConfig(networkId, config)
     })
 
     expect(mockWalletManager.networkConfig[networkId].algod.baseServer).toBe(config.baseServer)
@@ -241,7 +241,7 @@ describe('useNetwork', () => {
     const expectedClient = new algosdk.Algodv2('', 'https://new-server.com', '')
 
     await act(async () => {
-      result.current.network.updateNetworkAlgod(networkId, config)
+      result.current.network.updateAlgodConfig(networkId, config)
     })
 
     expect(mockWalletManager.networkConfig[networkId].algod.baseServer).toBe(config.baseServer)
@@ -267,7 +267,7 @@ describe('useNetwork', () => {
 
     // Modify the config
     act(() => {
-      result.current.updateNetworkAlgod(NetworkId.TESTNET, {
+      result.current.updateAlgodConfig(NetworkId.TESTNET, {
         token: 'custom-token',
         baseServer: 'https://custom-server.com'
       })
@@ -300,7 +300,7 @@ describe('useNetwork', () => {
     const expectedClient = new algosdk.Algodv2('', 'https://new-server.com', '')
 
     await act(async () => {
-      result.current.network.updateNetworkAlgod(networkId, newConfig)
+      result.current.network.updateAlgodConfig(networkId, newConfig)
     })
 
     expect(mockWalletManager.networkConfig[networkId].algod.baseServer).toBe(newConfig.baseServer)
@@ -316,7 +316,7 @@ describe('useNetwork', () => {
     const newConfig = { baseServer: 'https://new-server.com' }
 
     await act(async () => {
-      networkResult.current.updateNetworkAlgod(networkId, newConfig)
+      networkResult.current.updateAlgodConfig(networkId, newConfig)
     })
 
     expect(mockWalletManager.networkConfig[networkId].algod.baseServer).toBe(newConfig.baseServer)
@@ -346,7 +346,7 @@ describe('useNetwork', () => {
 
     // Modify the config
     await act(async () => {
-      networkResult.current.updateNetworkAlgod(networkId, {
+      networkResult.current.updateAlgodConfig(networkId, {
         baseServer: 'https://modified-server.com'
       })
     })
@@ -369,7 +369,7 @@ describe('useNetwork', () => {
 
     // Modify the config
     await act(async () => {
-      networkResult.current.updateNetworkAlgod(networkId, {
+      networkResult.current.updateAlgodConfig(networkId, {
         baseServer: 'https://modified-server.com'
       })
     })

--- a/packages/use-wallet-react/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-react/src/__tests__/index.test.tsx
@@ -245,6 +245,44 @@ describe('useNetwork', () => {
     expect(mockWalletManager.activeNetworkConfig.algod.baseServer).toBe(config.baseServer)
   })
 
+  it('provides resetNetworkConfig functionality', () => {
+    const resetNetworkConfigSpy = vi.spyOn(mockWalletManager, 'resetNetworkConfig')
+    const { result } = renderHook(() => useNetwork(), { wrapper })
+
+    expect(typeof result.current.resetNetworkConfig).toBe('function')
+
+    act(() => {
+      result.current.resetNetworkConfig(NetworkId.TESTNET)
+    })
+
+    expect(resetNetworkConfigSpy).toHaveBeenCalledWith(NetworkId.TESTNET)
+  })
+
+  it('updates algodClient when resetting active network', () => {
+    // Set up mock manager with spy
+    const createAlgodClientSpy = vi.spyOn(mockWalletManager as any, 'createAlgodClient')
+    const { result } = renderHook(() => useNetwork(), { wrapper })
+
+    // First update the network config
+    act(() => {
+      result.current.updateNetworkAlgod(NetworkId.TESTNET, {
+        token: 'custom-token',
+        baseServer: 'https://custom-server.com'
+      })
+    })
+
+    // Clear previous calls
+    createAlgodClientSpy.mockClear()
+
+    // Then reset it
+    act(() => {
+      result.current.resetNetworkConfig(NetworkId.TESTNET)
+    })
+
+    // Verify new algod client was created
+    expect(createAlgodClientSpy).toHaveBeenCalledWith(NetworkId.TESTNET)
+  })
+
   describe('setActiveNetwork', () => {
     it('calls setActiveNetwork correctly and updates algodClient', async () => {
       const { result } = renderHook(() => useNetwork(), { wrapper })

--- a/packages/use-wallet-react/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-react/src/__tests__/index.test.tsx
@@ -189,7 +189,6 @@ describe('useNetwork', () => {
 
   it('allows setting custom network that exists in config', async () => {
     const customNetwork = {
-      name: 'Custom Network',
       algod: {
         token: '',
         baseServer: 'https://custom.network',

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -89,6 +89,7 @@ export const useNetwork = () => {
   return {
     activeNetwork,
     networks: manager.networks,
+    activeNetworkConfig: manager.activeNetworkConfig,
     algodClient,
     setAlgodClient,
     setActiveNetwork,

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -106,7 +106,7 @@ export const useNetwork = () => {
 
   return {
     activeNetwork,
-    networks: manager.networks,
+    networkConfig: manager.networkConfig,
     activeNetworkConfig: manager.activeNetworkConfig,
     setActiveNetwork,
     updateNetworkAlgod,

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -82,8 +82,8 @@ export const useNetwork = () => {
     console.info(`[React] ✅ Active network set to ${networkId}.`)
   }
 
-  const updateNetworkAlgod = (networkId: string, config: Partial<AlgodConfig>): void => {
-    manager.updateNetworkAlgod(networkId, config)
+  const updateAlgodConfig = (networkId: string, config: Partial<AlgodConfig>): void => {
+    manager.updateAlgodConfig(networkId, config)
 
     // If this is the active network, update the algodClient
     if (networkId === activeNetwork) {
@@ -113,7 +113,7 @@ export const useNetwork = () => {
     networkConfig: manager.networkConfig,
     activeNetworkConfig: manager.activeNetworkConfig,
     setActiveNetwork,
-    updateNetworkAlgod,
+    updateAlgodConfig,
     resetNetworkConfig
   }
 }

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -86,6 +86,10 @@ export const useNetwork = () => {
     manager.updateNetworkAlgod(networkId, config)
   }
 
+  const resetNetworkConfig = (networkId: string): void => {
+    manager.resetNetworkConfig(networkId)
+  }
+
   return {
     activeNetwork,
     networks: manager.networks,
@@ -93,7 +97,8 @@ export const useNetwork = () => {
     algodClient,
     setAlgodClient,
     setActiveNetwork,
-    updateNetworkAlgod
+    updateNetworkAlgod,
+    resetNetworkConfig
   }
 }
 

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -67,7 +67,7 @@ export const useNetwork = () => {
       throw new Error(`Network "${networkId}" not found in network configuration`)
     }
 
-    console.info(`[React] Creating Algodv2 client for ${networkId}...`)
+    console.info(`[React] Creating new Algodv2 client...`)
 
     const { algod } = manager.networkConfig[networkId]
     const { token = '', baseServer, port = '', headers = {} } = algod
@@ -85,7 +85,9 @@ export const useNetwork = () => {
   const updateNetworkAlgod = (networkId: string, config: Partial<AlgodConfig>): void => {
     manager.updateNetworkAlgod(networkId, config)
 
+    // If this is the active network, update the algodClient
     if (networkId === activeNetwork) {
+      console.info(`[React] Creating new Algodv2 client...`)
       const { algod } = manager.networkConfig[networkId]
       const { token = '', baseServer, port = '', headers = {} } = algod
       const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
@@ -96,7 +98,9 @@ export const useNetwork = () => {
   const resetNetworkConfig = (networkId: string): void => {
     manager.resetNetworkConfig(networkId)
 
+    // If this is the active network, update the algodClient
     if (networkId === activeNetwork) {
+      console.info(`[React] Creating new Algodv2 client...`)
       const { algod } = manager.networkConfig[networkId]
       const { token = '', baseServer, port = '', headers = {} } = algod
       const newClient = new algosdk.Algodv2(token, baseServer, port, headers)

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -54,7 +54,7 @@ export const useNetwork = () => {
     throw new Error('useNetwork must be used within the WalletProvider')
   }
 
-  const { manager, algodClient, setAlgodClient } = context
+  const { manager, setAlgodClient } = context
 
   const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
 
@@ -108,8 +108,6 @@ export const useNetwork = () => {
     activeNetwork,
     networks: manager.networks,
     activeNetworkConfig: manager.activeNetworkConfig,
-    algodClient,
-    setAlgodClient,
     setActiveNetwork,
     updateNetworkAlgod,
     resetNetworkConfig
@@ -136,7 +134,7 @@ export const useWallet = () => {
     throw new Error('useWallet must be used within the WalletProvider')
   }
 
-  const { manager } = context
+  const { manager, algodClient, setAlgodClient } = context
 
   const managerStatus = useStore(manager.store, (state) => state.managerStatus)
   const isReady = managerStatus === 'ready'
@@ -194,6 +192,8 @@ export const useWallet = () => {
   return {
     wallets,
     isReady,
+    algodClient,
+    setAlgodClient,
     activeWallet,
     activeWalletAccounts,
     activeWalletAddresses,

--- a/packages/use-wallet-react/src/index.tsx
+++ b/packages/use-wallet-react/src/index.tsx
@@ -84,10 +84,24 @@ export const useNetwork = () => {
 
   const updateNetworkAlgod = (networkId: string, config: Partial<AlgodConfig>): void => {
     manager.updateNetworkAlgod(networkId, config)
+
+    if (networkId === activeNetwork) {
+      const { algod } = manager.networkConfig[networkId]
+      const { token = '', baseServer, port = '', headers = {} } = algod
+      const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
+      setAlgodClient(newClient)
+    }
   }
 
   const resetNetworkConfig = (networkId: string): void => {
     manager.resetNetworkConfig(networkId)
+
+    if (networkId === activeNetwork) {
+      const { algod } = manager.networkConfig[networkId]
+      const { token = '', baseServer, port = '', headers = {} } = algod
+      const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
+      setAlgodClient(newClient)
+    }
   }
 
   return {

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -422,6 +422,46 @@ describe('useNetwork', () => {
 
     expect(mockUpdateNetworkAlgod).toHaveBeenCalledWith(networkId, config)
   })
+
+  it('updates algodClient when modifying active network configuration', () => {
+    const newAlgodClient = new algosdk.Algodv2('', 'https://new-server.com', '')
+
+    const TestComponent = () => {
+      const { updateNetworkAlgod, algodClient } = useNetwork()
+      return (
+        <div>
+          <div data-testid="algod-client">{JSON.stringify(algodClient())}</div>
+          <button
+            data-testid="update-btn"
+            onClick={() => {
+              // Mock the manager's updateNetworkAlgod to update the config
+              mockWalletManager.networkConfig[NetworkId.TESTNET].algod.baseServer =
+                'https://new-server.com'
+              // Update the store's algodClient
+              mockSetAlgodClient(newAlgodClient)
+              // Call the function under test
+              updateNetworkAlgod(NetworkId.TESTNET, {
+                baseServer: 'https://new-server.com'
+              })
+            }}
+          >
+            Update
+          </button>
+        </div>
+      )
+    }
+
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    const updateButton = screen.getByTestId('update-btn')
+    fireEvent.click(updateButton)
+
+    expect(screen.getByTestId('algod-client')).toHaveTextContent(JSON.stringify(newAlgodClient))
+  })
 })
 
 describe('useWallet', () => {

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -375,6 +375,53 @@ describe('useNetwork', () => {
       expect(screen.getByTestId('algod-client')).toHaveTextContent(JSON.stringify(newAlgodClient))
     })
   })
+
+  it('provides updateNetworkAlgod function', () => {
+    const TestComponent = () => {
+      const { updateNetworkAlgod } = useNetwork()
+      return <div data-testid="update-network-algod-type">{typeof updateNetworkAlgod}</div>
+    }
+
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    expect(screen.getByTestId('update-network-algod-type')).toHaveTextContent('function')
+  })
+
+  it('calls updateNetworkAlgod on the manager when updating network config', () => {
+    const networkId = NetworkId.TESTNET
+    const config = {
+      token: 'new-token',
+      baseServer: 'https://new-server.com',
+      port: '443'
+    }
+
+    const TestComponent = () => {
+      const { updateNetworkAlgod } = useNetwork()
+      return (
+        <button data-testid="update-btn" onClick={() => updateNetworkAlgod(networkId, config)}>
+          Update
+        </button>
+      )
+    }
+
+    const mockUpdateNetworkAlgod = vi.fn()
+    mockWalletManager.updateNetworkAlgod = mockUpdateNetworkAlgod
+
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    const updateButton = screen.getByTestId('update-btn')
+    fireEvent.click(updateButton)
+
+    expect(mockUpdateNetworkAlgod).toHaveBeenCalledWith(networkId, config)
+  })
 })
 
 describe('useWallet', () => {

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -22,7 +22,8 @@ const mockStore = new Store<State>({
   activeWallet: null,
   algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
   managerStatus: 'ready',
-  wallets: {}
+  wallets: {},
+  customNetworkConfigs: {}
 })
 
 // Create mock wallet manager
@@ -42,7 +43,8 @@ beforeEach(() => {
     activeWallet: null,
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
-    wallets: {}
+    wallets: {},
+    customNetworkConfigs: {}
   }))
 })
 
@@ -538,7 +540,8 @@ describe('useWallet', () => {
       activeWallet: null,
       activeNetwork: NetworkId.TESTNET,
       algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/'),
-      managerStatus: 'initializing' as ManagerStatus
+      managerStatus: 'initializing' as ManagerStatus,
+      customNetworkConfigs: {}
     }
 
     mockStore = new Store<State>(defaultState)

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -465,6 +465,69 @@ describe('useNetwork', () => {
     expect(screen.getByTestId('algod-client')).toHaveTextContent(JSON.stringify(newAlgodClient))
   })
 
+  it('provides resetNetworkConfig functionality', () => {
+    const mockResetNetworkConfig = vi.fn()
+    mockWalletManager.resetNetworkConfig = mockResetNetworkConfig
+
+    const TestComponent = () => {
+      const { resetNetworkConfig } = useNetwork()
+      return (
+        <button data-testid="reset-btn" onClick={() => resetNetworkConfig(NetworkId.TESTNET)}>
+          Reset Network
+        </button>
+      )
+    }
+
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    const resetButton = screen.getByTestId('reset-btn')
+    fireEvent.click(resetButton)
+
+    expect(mockResetNetworkConfig).toHaveBeenCalledWith(NetworkId.TESTNET)
+  })
+
+  it('updates algodClient when resetting active network', () => {
+    const newAlgodClient = new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/', '')
+
+    const TestComponent = () => {
+      const { resetNetworkConfig, algodClient } = useNetwork()
+      return (
+        <div>
+          <div data-testid="algod-client">{JSON.stringify(algodClient())}</div>
+          <button
+            data-testid="reset-btn"
+            onClick={() => {
+              // Mock the manager's resetNetworkConfig to update the config
+              mockWalletManager.networkConfig[NetworkId.TESTNET] =
+                DEFAULT_NETWORKS[NetworkId.TESTNET]
+              // Update the store's algodClient
+              mockSetAlgodClient(newAlgodClient)
+              // Call the function under test
+              resetNetworkConfig(NetworkId.TESTNET)
+            }}
+          >
+            Reset
+          </button>
+        </div>
+      )
+    }
+
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    const resetButton = screen.getByTestId('reset-btn')
+    fireEvent.click(resetButton)
+
+    expect(screen.getByTestId('algod-client')).toHaveTextContent(JSON.stringify(newAlgodClient))
+  })
+
   it('provides activeNetworkConfig through useNetwork', () => {
     const TestComponent = () => {
       const { activeNetworkConfig } = useNetwork()

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -7,7 +7,7 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
-  DEFAULT_NETWORKS,
+  DEFAULT_NETWORK_CONFIG,
   type State,
   type WalletAccount,
   ManagerStatus
@@ -24,7 +24,7 @@ const mockStore = new Store<State>({
   managerStatus: 'ready',
   wallets: {},
   customNetworkConfigs: {},
-  networkConfig: DEFAULT_NETWORKS
+  networkConfig: DEFAULT_NETWORK_CONFIG
 })
 
 // Create mock wallet manager
@@ -45,7 +45,7 @@ beforeEach(() => {
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
     wallets: {},
-    networkConfig: { ...DEFAULT_NETWORKS },
+    networkConfig: { ...DEFAULT_NETWORK_CONFIG },
     customNetworkConfigs: {}
   }))
 })
@@ -622,7 +622,7 @@ describe('useWallet', () => {
       algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/'),
       managerStatus: 'initializing' as ManagerStatus,
       customNetworkConfigs: {},
-      networkConfig: { ...DEFAULT_NETWORKS }
+      networkConfig: { ...DEFAULT_NETWORK_CONFIG }
     }
 
     mockStore = new Store<State>(defaultState)

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -101,10 +101,11 @@ const TestComponent = () => {
     isWalletConnected,
     walletStore,
     wallets,
-    isReady
+    isReady,
+    algodClient
   } = useWallet()
 
-  const { activeNetwork, algodClient, setActiveNetwork } = useNetwork()
+  const { activeNetwork, setActiveNetwork } = useNetwork()
 
   const [magicEmail, setMagicEmail] = createSignal('')
 
@@ -340,7 +341,8 @@ describe('useNetwork', () => {
 
   it('updates algodClient when setActiveNetwork is called', async () => {
     const TestComponent = () => {
-      const { setActiveNetwork, algodClient } = useNetwork()
+      const { setActiveNetwork } = useNetwork()
+      const { algodClient } = useWallet()
       return (
         <div>
           <div data-testid="algod-client">{JSON.stringify(algodClient())}</div>
@@ -429,19 +431,17 @@ describe('useNetwork', () => {
     const newAlgodClient = new algosdk.Algodv2('', 'https://new-server.com', '')
 
     const TestComponent = () => {
-      const { updateNetworkAlgod, algodClient } = useNetwork()
+      const { updateNetworkAlgod } = useNetwork()
+      const { algodClient } = useWallet()
       return (
         <div>
           <div data-testid="algod-client">{JSON.stringify(algodClient())}</div>
           <button
             data-testid="update-btn"
             onClick={() => {
-              // Mock the manager's updateNetworkAlgod to update the config
               mockWalletManager.networkConfig[NetworkId.TESTNET].algod.baseServer =
                 'https://new-server.com'
-              // Update the store's algodClient
               mockSetAlgodClient(newAlgodClient)
-              // Call the function under test
               updateNetworkAlgod(NetworkId.TESTNET, {
                 baseServer: 'https://new-server.com'
               })
@@ -494,7 +494,8 @@ describe('useNetwork', () => {
     const newAlgodClient = new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/', '')
 
     const TestComponent = () => {
-      const { resetNetworkConfig, algodClient } = useNetwork()
+      const { resetNetworkConfig } = useNetwork()
+      const { algodClient } = useWallet()
       return (
         <div>
           <div data-testid="algod-client">{JSON.stringify(algodClient())}</div>

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -462,6 +462,61 @@ describe('useNetwork', () => {
 
     expect(screen.getByTestId('algod-client')).toHaveTextContent(JSON.stringify(newAlgodClient))
   })
+
+  it('provides activeNetworkConfig through useNetwork', () => {
+    const TestComponent = () => {
+      const { activeNetworkConfig } = useNetwork()
+      return <div data-testid="active-network-config">{JSON.stringify(activeNetworkConfig())}</div>
+    }
+
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    expect(screen.getByTestId('active-network-config')).toHaveTextContent(
+      JSON.stringify(mockWalletManager.networkConfig[NetworkId.TESTNET])
+    )
+  })
+
+  it('updates activeNetworkConfig when switching networks', async () => {
+    const TestComponent = () => {
+      const { activeNetworkConfig, setActiveNetwork } = useNetwork()
+      return (
+        <div>
+          <div data-testid="active-network-config">{JSON.stringify(activeNetworkConfig())}</div>
+          <button
+            data-testid="set-active-network-btn"
+            onClick={() => setActiveNetwork(NetworkId.MAINNET)}
+          >
+            Set Active Network to Mainnet
+          </button>
+        </div>
+      )
+    }
+
+    render(() => (
+      <WalletProvider manager={mockWalletManager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    const button = screen.getByTestId('set-active-network-btn')
+    fireEvent.click(button)
+
+    mockStore.setState((state) => ({
+      ...state,
+      activeNetwork: NetworkId.MAINNET,
+      algodClient: new algosdk.Algodv2('', 'https://mainnet-api.4160.nodely.dev/', '')
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-network-config')).toHaveTextContent(
+        JSON.stringify(mockWalletManager.networkConfig[NetworkId.MAINNET])
+      )
+    })
+  })
 })
 
 describe('useWallet', () => {

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -308,7 +308,6 @@ describe('useNetwork', () => {
 
   it('allows setting custom network that exists in config', async () => {
     const customNetwork = {
-      name: 'Custom Network',
       algod: {
         token: '',
         baseServer: 'https://custom.network',

--- a/packages/use-wallet-solid/src/__tests__/index.test.tsx
+++ b/packages/use-wallet-solid/src/__tests__/index.test.tsx
@@ -382,10 +382,10 @@ describe('useNetwork', () => {
     })
   })
 
-  it('provides updateNetworkAlgod function', () => {
+  it('provides updateAlgodConfig function', () => {
     const TestComponent = () => {
-      const { updateNetworkAlgod } = useNetwork()
-      return <div data-testid="update-network-algod-type">{typeof updateNetworkAlgod}</div>
+      const { updateAlgodConfig } = useNetwork()
+      return <div data-testid="update-network-algod-type">{typeof updateAlgodConfig}</div>
     }
 
     render(() => (
@@ -397,7 +397,7 @@ describe('useNetwork', () => {
     expect(screen.getByTestId('update-network-algod-type')).toHaveTextContent('function')
   })
 
-  it('calls updateNetworkAlgod on the manager when updating network config', () => {
+  it('calls updateAlgodConfig on the manager when updating network config', () => {
     const networkId = NetworkId.TESTNET
     const config = {
       token: 'new-token',
@@ -406,16 +406,16 @@ describe('useNetwork', () => {
     }
 
     const TestComponent = () => {
-      const { updateNetworkAlgod } = useNetwork()
+      const { updateAlgodConfig } = useNetwork()
       return (
-        <button data-testid="update-btn" onClick={() => updateNetworkAlgod(networkId, config)}>
+        <button data-testid="update-btn" onClick={() => updateAlgodConfig(networkId, config)}>
           Update
         </button>
       )
     }
 
-    const mockUpdateNetworkAlgod = vi.fn()
-    mockWalletManager.updateNetworkAlgod = mockUpdateNetworkAlgod
+    const mockUpdateAlgodConfig = vi.fn()
+    mockWalletManager.updateAlgodConfig = mockUpdateAlgodConfig
 
     render(() => (
       <WalletProvider manager={mockWalletManager}>
@@ -426,14 +426,14 @@ describe('useNetwork', () => {
     const updateButton = screen.getByTestId('update-btn')
     fireEvent.click(updateButton)
 
-    expect(mockUpdateNetworkAlgod).toHaveBeenCalledWith(networkId, config)
+    expect(mockUpdateAlgodConfig).toHaveBeenCalledWith(networkId, config)
   })
 
   it('updates algodClient when modifying active network configuration', () => {
     const newAlgodClient = new algosdk.Algodv2('', 'https://new-server.com', '')
 
     const TestComponent = () => {
-      const { updateNetworkAlgod } = useNetwork()
+      const { updateAlgodConfig } = useNetwork()
       const { algodClient } = useWallet()
       return (
         <div>
@@ -444,7 +444,7 @@ describe('useNetwork', () => {
               mockWalletManager.networkConfig[NetworkId.TESTNET].algod.baseServer =
                 'https://new-server.com'
               mockSetAlgodClient(newAlgodClient)
-              updateNetworkAlgod(NetworkId.TESTNET, {
+              updateAlgodConfig(NetworkId.TESTNET, {
                 baseServer: 'https://new-server.com'
               })
             }}

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -73,6 +73,18 @@ export const useNetwork = () => {
 
   const updateNetworkAlgod = (networkId: string, config: Partial<AlgodConfig>): void => {
     manager().updateNetworkAlgod(networkId, config)
+
+    // If this is the active network, update the algodClient
+    if (networkId === activeNetwork()) {
+      const { algod } = manager().networkConfig[networkId]
+      const { token = '', baseServer, port = '', headers = {} } = algod
+      const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
+
+      manager().store.setState((state) => ({
+        ...state,
+        algodClient: newClient
+      }))
+    }
   }
 
   return {

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -44,7 +44,6 @@ export const useWalletManager = (): WalletManager => {
 
 export const useNetwork = () => {
   const manager = createMemo(() => useWalletManager())
-  const algodClient = useStore(manager().store, (state) => state.algodClient)
   const activeNetwork = useStore(manager().store, (state) => state.activeNetwork)
   const activeNetworkConfig = createMemo(() => manager().networkConfig[activeNetwork()])
 
@@ -110,7 +109,6 @@ export const useNetwork = () => {
     activeNetwork,
     networks: manager().networks,
     activeNetworkConfig,
-    algodClient,
     setActiveNetwork,
     updateNetworkAlgod,
     resetNetworkConfig
@@ -135,6 +133,7 @@ export const useWallet = () => {
 
   const managerStatus = useStore(manager().store, (state) => state.managerStatus)
   const isReady = createMemo(() => managerStatus() === 'ready')
+  const algodClient = useStore(manager().store, (state) => state.algodClient)
 
   const walletStore = useStore(manager().store, (state) => state.wallets)
   const walletState = (walletId: WalletId): WalletState | null => walletStore()[walletId] || null
@@ -175,6 +174,7 @@ export const useWallet = () => {
   return {
     wallets: manager().wallets,
     isReady,
+    algodClient,
     activeWallet,
     activeWalletAccounts,
     activeWalletAddresses,

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -46,6 +46,7 @@ export const useNetwork = () => {
   const manager = createMemo(() => useWalletManager())
   const algodClient = useStore(manager().store, (state) => state.algodClient)
   const activeNetwork = useStore(manager().store, (state) => state.activeNetwork)
+  const activeNetworkConfig = createMemo(() => manager().networkConfig[activeNetwork()])
 
   const setActiveNetwork = async (networkId: NetworkId | string): Promise<void> => {
     if (networkId === activeNetwork()) {
@@ -61,6 +62,8 @@ export const useNetwork = () => {
     const { algod } = manager().networkConfig[networkId]
     const { token = '', baseServer, port = '', headers = {} } = algod
     const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
+
+    await manager().setActiveNetwork(networkId)
 
     manager().store.setState((state) => ({
       ...state,
@@ -90,6 +93,7 @@ export const useNetwork = () => {
   return {
     activeNetwork,
     networks: manager().networks,
+    activeNetworkConfig,
     algodClient,
     setActiveNetwork,
     updateNetworkAlgod

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -90,13 +90,30 @@ export const useNetwork = () => {
     }
   }
 
+  const resetNetworkConfig = (networkId: string): void => {
+    manager().resetNetworkConfig(networkId)
+
+    // If this is the active network, update the algodClient in store
+    if (networkId === activeNetwork()) {
+      const { algod } = manager().networkConfig[networkId]
+      const { token = '', baseServer, port = '', headers = {} } = algod
+      const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
+
+      manager().store.setState((state) => ({
+        ...state,
+        algodClient: newClient
+      }))
+    }
+  }
+
   return {
     activeNetwork,
     networks: manager().networks,
     activeNetworkConfig,
     algodClient,
     setActiveNetwork,
-    updateNetworkAlgod
+    updateNetworkAlgod,
+    resetNetworkConfig
   }
 }
 

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -59,7 +59,7 @@ export const useNetwork = () => {
       throw new Error(`Network "${networkId}" not found in network configuration`)
     }
 
-    console.info(`[Solid] Creating Algodv2 client for ${networkId}...`)
+    console.info(`[Solid] Creating new Algodv2 client...`)
 
     const { algod } = manager().networkConfig[networkId]
     const { token = '', baseServer, port = '', headers = {} } = algod
@@ -81,6 +81,7 @@ export const useNetwork = () => {
 
     // If this is the active network, update the algodClient
     if (networkId === activeNetwork()) {
+      console.info(`[Solid] Creating new Algodv2 client...`)
       const { algod } = manager().networkConfig[networkId]
       const { token = '', baseServer, port = '', headers = {} } = algod
       const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
@@ -95,8 +96,9 @@ export const useNetwork = () => {
   const resetNetworkConfig = (networkId: string): void => {
     manager().resetNetworkConfig(networkId)
 
-    // If this is the active network, update the algodClient in store
+    // If this is the active network, update the algodClient
     if (networkId === activeNetwork()) {
+      console.info(`[Solid] Creating new Algodv2 client...`)
       const { algod } = manager().networkConfig[networkId]
       const { token = '', baseServer, port = '', headers = {} } = algod
       const newClient = new algosdk.Algodv2(token, baseServer, port, headers)

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -45,7 +45,10 @@ export const useWalletManager = (): WalletManager => {
 export const useNetwork = () => {
   const manager = createMemo(() => useWalletManager())
   const activeNetwork = useStore(manager().store, (state) => state.activeNetwork)
-  const activeNetworkConfig = createMemo(() => manager().networkConfig[activeNetwork()])
+  const activeNetworkConfig = () => {
+    const store = useStore(manager().store)
+    return store().networkConfig[activeNetwork()]
+  }
 
   const setActiveNetwork = async (networkId: NetworkId | string): Promise<void> => {
     if (networkId === activeNetwork()) {
@@ -107,7 +110,7 @@ export const useNetwork = () => {
 
   return {
     activeNetwork,
-    networks: manager().networks,
+    networkConfig: () => manager().networkConfig,
     activeNetworkConfig,
     setActiveNetwork,
     updateNetworkAlgod,

--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -76,8 +76,8 @@ export const useNetwork = () => {
     console.info(`[Solid] ✅ Active network set to ${networkId}.`)
   }
 
-  const updateNetworkAlgod = (networkId: string, config: Partial<AlgodConfig>): void => {
-    manager().updateNetworkAlgod(networkId, config)
+  const updateAlgodConfig = (networkId: string, config: Partial<AlgodConfig>): void => {
+    manager().updateAlgodConfig(networkId, config)
 
     // If this is the active network, update the algodClient
     if (networkId === activeNetwork()) {
@@ -115,7 +115,7 @@ export const useNetwork = () => {
     networkConfig: () => manager().networkConfig,
     activeNetworkConfig,
     setActiveNetwork,
-    updateNetworkAlgod,
+    updateAlgodConfig,
     resetNetworkConfig
   }
 }

--- a/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
@@ -1,0 +1,141 @@
+import { Store } from '@tanstack/vue-store'
+import { NetworkId, WalletManager, WalletId, type State } from '@txnlab/use-wallet'
+import { mount } from '@vue/test-utils'
+import algosdk from 'algosdk'
+import { inject, nextTick, ref, type InjectionKey } from 'vue'
+import { useNetwork } from '../useNetwork'
+import type { Mock } from 'vitest'
+
+// Mock Vue's inject function
+vi.mock('vue', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('vue')>()
+  return {
+    ...mod,
+    inject: vi.fn()
+  }
+})
+
+// Share the same mock setup
+let mockStore: Store<State>
+let mockWalletManager: WalletManager
+const mockAlgodClient = ref(new algosdk.Algodv2('token', 'https://server', ''))
+const mockSetAlgodClient = (client: algosdk.Algodv2) => {
+  mockAlgodClient.value = client
+}
+
+const setupMocks = () => {
+  mockStore = new Store<State>({
+    activeNetwork: NetworkId.TESTNET,
+    activeWallet: null,
+    algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
+    managerStatus: 'ready',
+    wallets: {}
+  })
+
+  mockWalletManager = new WalletManager({
+    wallets: [WalletId.DEFLY]
+  })
+
+  vi.spyOn(mockWalletManager, 'store', 'get').mockReturnValue(mockStore)
+}
+
+beforeEach(() => {
+  setupMocks()
+  vi.clearAllMocks()
+  mockStore.setState((state) => ({
+    ...state,
+    activeNetwork: NetworkId.TESTNET,
+    activeWallet: null,
+    algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
+    managerStatus: 'ready',
+    wallets: {}
+  }))
+  ;(inject as Mock).mockImplementation((token: string | InjectionKey<unknown>) => {
+    if (token === 'walletManager') return mockWalletManager
+    if (token === 'setAlgodClient') return mockSetAlgodClient
+    if (token === 'algodClient') return mockAlgodClient
+    return null
+  })
+})
+
+describe('useNetwork', () => {
+  it('throws error for invalid network', async () => {
+    const { setActiveNetwork } = useNetwork()
+
+    await expect(setActiveNetwork('invalid-network')).rejects.toThrow(
+      'Network "invalid-network" not found in network configuration'
+    )
+  })
+
+  it('allows setting custom network that exists in config', async () => {
+    const customNetwork = {
+      name: 'Custom Network',
+      algod: {
+        token: '',
+        baseServer: 'https://custom.network',
+        headers: {}
+      }
+    }
+
+    mockWalletManager.networkConfig['custom-net'] = customNetwork
+    const { setActiveNetwork, activeNetwork } = useNetwork()
+
+    await setActiveNetwork('custom-net')
+    expect(activeNetwork.value).toBe('custom-net')
+  })
+
+  it('updates algodClient when setActiveNetwork is called', async () => {
+    const { setActiveNetwork, algodClient } = useNetwork()
+    const newClient = new algosdk.Algodv2('', 'https://mainnet-api.4160.nodely.dev', '')
+
+    mockWalletManager.setActiveNetwork = async (networkId: string) => {
+      mockSetAlgodClient(newClient)
+      mockWalletManager.store.setState((state) => ({
+        ...state,
+        activeNetwork: networkId,
+        algodClient: newClient
+      }))
+    }
+
+    await setActiveNetwork(NetworkId.MAINNET)
+    await nextTick()
+
+    expect(algodClient.value).toStrictEqual(newClient)
+  })
+
+  it('integrates correctly with Vue component', async () => {
+    const TestComponent = {
+      template: `
+        <div>
+          <div data-testid="activeNetwork">{{ activeNetwork }}</div>
+          <div data-testid="algodClient">{{ algodClient }}</div>
+        </div>
+      `,
+      setup() {
+        const { activeNetwork, algodClient } = useNetwork()
+        return { activeNetwork, algodClient }
+      }
+    }
+
+    const wrapper = mount(TestComponent)
+
+    expect(wrapper.get('[data-testid="activeNetwork"]').text()).toBe(NetworkId.TESTNET)
+
+    // Test network change
+    const newClient = new algosdk.Algodv2('', 'https://mainnet-api.algonode.cloud', '')
+    mockWalletManager.setActiveNetwork = async (networkId: string) => {
+      mockSetAlgodClient(newClient)
+      mockWalletManager.store.setState((state) => ({
+        ...state,
+        activeNetwork: networkId,
+        algodClient: newClient
+      }))
+    }
+
+    const { setActiveNetwork } = useNetwork()
+    await setActiveNetwork(NetworkId.MAINNET)
+    await nextTick()
+
+    expect(wrapper.get('[data-testid="activeNetwork"]').text()).toBe(NetworkId.MAINNET)
+  })
+})

--- a/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
@@ -35,7 +35,8 @@ const setupMocks = () => {
     activeWallet: null,
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
-    wallets: {}
+    wallets: {},
+    customNetworkConfigs: {}
   })
 
   mockWalletManager = new WalletManager({

--- a/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
@@ -137,4 +137,26 @@ describe('useNetwork', () => {
 
     expect(wrapper.get('[data-testid="activeNetwork"]').text()).toBe(NetworkId.MAINNET)
   })
+
+  it('provides updateNetworkAlgod function', () => {
+    const { updateNetworkAlgod } = useNetwork()
+    expect(typeof updateNetworkAlgod).toBe('function')
+  })
+
+  it('calls updateNetworkAlgod on the manager when updating network config', () => {
+    const networkId = NetworkId.TESTNET
+    const config = {
+      token: 'new-token',
+      baseServer: 'https://new-server.com',
+      port: '443'
+    }
+
+    const mockUpdateNetworkAlgod = vi.fn()
+    mockWalletManager.updateNetworkAlgod = mockUpdateNetworkAlgod
+
+    const { updateNetworkAlgod } = useNetwork()
+    updateNetworkAlgod(networkId, config)
+
+    expect(mockUpdateNetworkAlgod).toHaveBeenCalledWith(networkId, config)
+  })
 })

--- a/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
@@ -164,12 +164,12 @@ describe('useNetwork', () => {
     expect(wrapper.get('[data-testid="activeNetwork"]').text()).toBe(NetworkId.MAINNET)
   })
 
-  it('provides updateNetworkAlgod function', () => {
-    const { updateNetworkAlgod } = useNetwork()
-    expect(typeof updateNetworkAlgod).toBe('function')
+  it('provides updateAlgodConfig function', () => {
+    const { updateAlgodConfig } = useNetwork()
+    expect(typeof updateAlgodConfig).toBe('function')
   })
 
-  it('calls updateNetworkAlgod on the manager when updating network config', () => {
+  it('calls updateAlgodConfig on the manager when updating network config', () => {
     const networkId = NetworkId.TESTNET
     const config = {
       token: 'new-token',
@@ -177,13 +177,13 @@ describe('useNetwork', () => {
       port: '443'
     }
 
-    const mockUpdateNetworkAlgod = vi.fn()
-    mockWalletManager.updateNetworkAlgod = mockUpdateNetworkAlgod
+    const mockUpdateAlgodConfig = vi.fn()
+    mockWalletManager.updateAlgodConfig = mockUpdateAlgodConfig
 
-    const { updateNetworkAlgod } = useNetwork()
-    updateNetworkAlgod(networkId, config)
+    const { updateAlgodConfig } = useNetwork()
+    updateAlgodConfig(networkId, config)
 
-    expect(mockUpdateNetworkAlgod).toHaveBeenCalledWith(networkId, config)
+    expect(mockUpdateAlgodConfig).toHaveBeenCalledWith(networkId, config)
   })
 
   it('provides activeNetworkConfig through useNetwork', async () => {
@@ -249,9 +249,9 @@ describe('useNetwork', () => {
         <div data-testid="active-network-config">{{ stringifiedConfig }}</div>
       `,
       setup() {
-        const { activeNetworkConfig, updateNetworkAlgod } = useNetwork()
+        const { activeNetworkConfig, updateAlgodConfig } = useNetwork()
         const stringifiedConfig = computed(() => JSON.stringify(activeNetworkConfig.value))
-        return { stringifiedConfig, updateNetworkAlgod }
+        return { stringifiedConfig, updateAlgodConfig }
       }
     }
 
@@ -259,7 +259,7 @@ describe('useNetwork', () => {
     const networkId = NetworkId.TESTNET
     const newConfig = { baseServer: 'https://new-server.com' }
 
-    mockWalletManager.updateNetworkAlgod = (id: string, config: Partial<AlgodConfig>) => {
+    mockWalletManager.updateAlgodConfig = (id: string, config: Partial<AlgodConfig>) => {
       mockWalletManager.networkConfig[id] = {
         ...mockWalletManager.networkConfig[id],
         algod: {
@@ -270,8 +270,8 @@ describe('useNetwork', () => {
       mockStore.setState((state) => ({ ...state }))
     }
 
-    const { updateNetworkAlgod } = useNetwork()
-    updateNetworkAlgod(networkId, newConfig)
+    const { updateAlgodConfig } = useNetwork()
+    updateAlgodConfig(networkId, newConfig)
     await nextTick()
 
     const actual = JSON.parse(wrapper.get('[data-testid="active-network-config"]').text())

--- a/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
@@ -69,7 +69,6 @@ describe('useNetwork', () => {
 
   it('allows setting custom network that exists in config', async () => {
     const customNetwork = {
-      name: 'Custom Network',
       algod: {
         token: '',
         baseServer: 'https://custom.network',

--- a/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
@@ -1,9 +1,9 @@
 import { Store } from '@tanstack/vue-store'
 import {
-  DEFAULT_NETWORKS,
   NetworkId,
   WalletManager,
   WalletId,
+  DEFAULT_NETWORK_CONFIG,
   type AlgodConfig,
   type State
 } from '@txnlab/use-wallet'
@@ -37,7 +37,7 @@ const setupMocks = () => {
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
     wallets: {},
-    networkConfig: DEFAULT_NETWORKS,
+    networkConfig: DEFAULT_NETWORK_CONFIG,
     customNetworkConfigs: {}
   })
 
@@ -63,7 +63,7 @@ beforeEach(() => {
     activeWallet: null,
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
-    networkConfig: { ...DEFAULT_NETWORKS },
+    networkConfig: { ...DEFAULT_NETWORK_CONFIG },
     customNetworkConfigs: {},
     wallets: {}
   }))
@@ -325,9 +325,9 @@ describe('useNetwork', () => {
       ...state,
       networkConfig: {
         [NetworkId.TESTNET]: {
-          ...DEFAULT_NETWORKS[NetworkId.TESTNET],
+          ...DEFAULT_NETWORK_CONFIG[NetworkId.TESTNET],
           algod: {
-            ...DEFAULT_NETWORKS[NetworkId.TESTNET].algod,
+            ...DEFAULT_NETWORK_CONFIG[NetworkId.TESTNET].algod,
             baseServer: 'https://custom-server.com'
           }
         }
@@ -349,7 +349,7 @@ describe('useNetwork', () => {
 
     // Mock the resetNetworkConfig behavior
     mockWalletManager.resetNetworkConfig = () => {
-      mockWalletManager.networkConfig[NetworkId.TESTNET] = DEFAULT_NETWORKS[NetworkId.TESTNET]
+      mockWalletManager.networkConfig[NetworkId.TESTNET] = DEFAULT_NETWORK_CONFIG[NetworkId.TESTNET]
       mockStore.setState((state) => ({ ...state }))
     }
 
@@ -358,6 +358,6 @@ describe('useNetwork', () => {
     await nextTick()
 
     const actual = JSON.parse(wrapper.get('[data-testid="active-network-config"]').text())
-    expect(actual).toEqual(DEFAULT_NETWORKS[NetworkId.TESTNET])
+    expect(actual).toEqual(DEFAULT_NETWORK_CONFIG[NetworkId.TESTNET])
   })
 })

--- a/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useNetwork.test.ts
@@ -1,5 +1,6 @@
 import { Store } from '@tanstack/vue-store'
 import {
+  DEFAULT_NETWORKS,
   NetworkId,
   WalletManager,
   WalletId,
@@ -36,6 +37,7 @@ const setupMocks = () => {
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
     wallets: {},
+    networkConfig: DEFAULT_NETWORKS,
     customNetworkConfigs: {}
   })
 
@@ -61,6 +63,8 @@ beforeEach(() => {
     activeWallet: null,
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
+    networkConfig: { ...DEFAULT_NETWORKS },
+    customNetworkConfigs: {},
     wallets: {}
   }))
 })
@@ -203,24 +207,6 @@ describe('useNetwork', () => {
   })
 
   it('updates activeNetworkConfig when switching networks', async () => {
-    // Set up initial network configs
-    mockWalletManager.networkConfig = {
-      [NetworkId.TESTNET]: {
-        algod: { baseServer: 'https://testnet-api.algonode.cloud', token: '' },
-        isTestnet: true,
-        genesisId: 'testnet-v1.0',
-        genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
-        caipChainId: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe'
-      },
-      [NetworkId.MAINNET]: {
-        algod: { baseServer: 'https://mainnet-api.algonode.cloud', token: '' },
-        isTestnet: false,
-        genesisId: 'mainnet-v1.0',
-        genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-        caipChainId: 'algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k'
-      }
-    }
-
     const TestComponent = {
       template: `
         <div data-testid="active-network-config">{{ stringifiedConfig }}</div>
@@ -258,16 +244,6 @@ describe('useNetwork', () => {
   })
 
   it('updates activeNetworkConfig when updating network configuration', async () => {
-    mockWalletManager.networkConfig = {
-      [NetworkId.TESTNET]: {
-        algod: { baseServer: 'https://testnet-api.algonode.cloud', token: '' },
-        isTestnet: true,
-        genesisId: 'testnet-v1.0',
-        genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
-        caipChainId: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe'
-      }
-    }
-
     const TestComponent = {
       template: `
         <div data-testid="active-network-config">{{ stringifiedConfig }}</div>
@@ -345,26 +321,18 @@ describe('useNetwork', () => {
   })
 
   it('updates activeNetworkConfig when resetting network configuration', async () => {
-    const defaultConfig = {
-      algod: {
-        baseServer: 'https://testnet-api.algonode.cloud',
-        token: ''
-      },
-      isTestnet: true,
-      genesisId: 'testnet-v1.0',
-      genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
-      caipChainId: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe'
-    }
-
-    mockWalletManager.networkConfig = {
-      [NetworkId.TESTNET]: {
-        ...defaultConfig,
-        algod: {
-          ...defaultConfig.algod,
-          baseServer: 'https://custom-server.com'
+    mockStore.setState((state) => ({
+      ...state,
+      networkConfig: {
+        [NetworkId.TESTNET]: {
+          ...DEFAULT_NETWORKS[NetworkId.TESTNET],
+          algod: {
+            ...DEFAULT_NETWORKS[NetworkId.TESTNET].algod,
+            baseServer: 'https://custom-server.com'
+          }
         }
       }
-    }
+    }))
 
     const TestComponent = {
       template: `
@@ -381,7 +349,7 @@ describe('useNetwork', () => {
 
     // Mock the resetNetworkConfig behavior
     mockWalletManager.resetNetworkConfig = () => {
-      mockWalletManager.networkConfig[NetworkId.TESTNET] = defaultConfig
+      mockWalletManager.networkConfig[NetworkId.TESTNET] = DEFAULT_NETWORKS[NetworkId.TESTNET]
       mockStore.setState((state) => ({ ...state }))
     }
 
@@ -390,6 +358,6 @@ describe('useNetwork', () => {
     await nextTick()
 
     const actual = JSON.parse(wrapper.get('[data-testid="active-network-config"]').text())
-    expect(actual).toEqual(defaultConfig)
+    expect(actual).toEqual(DEFAULT_NETWORKS[NetworkId.TESTNET])
   })
 })

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -77,7 +77,8 @@ const setupMocks = () => {
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
     wallets: {},
-    customNetworkConfigs: {}
+    customNetworkConfigs: {},
+    networkConfig: DEFAULT_NETWORKS
   })
 
   mockWalletManager = new WalletManager({
@@ -92,8 +93,7 @@ const setupMocks = () => {
     metadata: { name: 'Defly', icon: 'icon' },
     getAlgodClient: () => ({}) as any,
     store: mockStore,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 
   mockMagicAuth = new MagicAuth({
@@ -104,8 +104,7 @@ const setupMocks = () => {
     metadata: { name: 'Magic', icon: 'icon' },
     getAlgodClient: () => ({}) as any,
     store: mockStore,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
   ;(inject as Mock).mockImplementation((token: string | InjectionKey<unknown>) => {
     if (token === 'walletManager') return mockWalletManager

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -14,7 +14,7 @@ import {
 } from '@txnlab/use-wallet'
 import { mount } from '@vue/test-utils'
 import algosdk from 'algosdk'
-import { inject, nextTick, type InjectionKey } from 'vue'
+import { inject, nextTick, ref, type InjectionKey } from 'vue'
 import { useWallet, type Wallet } from '../useWallet'
 import type { Mock } from 'vitest'
 
@@ -68,6 +68,7 @@ let mockStore: Store<State>
 let mockWalletManager: WalletManager
 let mockDeflyWallet: DeflyWallet
 let mockMagicAuth: MagicAuth
+const mockAlgodClient = ref(new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''))
 
 const setupMocks = () => {
   mockStore = new Store<State>({
@@ -106,6 +107,11 @@ const setupMocks = () => {
     subscribe: vi.fn(),
     networks: DEFAULT_NETWORKS
   })
+  ;(inject as Mock).mockImplementation((token: string | InjectionKey<unknown>) => {
+    if (token === 'walletManager') return mockWalletManager
+    if (token === 'algodClient') return mockAlgodClient
+    return null
+  })
 }
 
 beforeEach(() => {
@@ -124,15 +130,8 @@ beforeEach(() => {
 describe('useWallet', () => {
   let mockWallets: Wallet[]
 
-  const mockInjectImplementation = (token: string | InjectionKey<unknown>) => {
-    if (token === 'walletManager') return mockWalletManager
-    return null
-  }
-
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(inject as Mock).mockImplementation(mockInjectImplementation)
-
     mockStore.setState(() => DEFAULT_STATE)
 
     mockWalletManager = new WalletManager()

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -75,7 +75,8 @@ const setupMocks = () => {
     activeWallet: null,
     algodClient: new algosdk.Algodv2('', 'https://testnet-api.algonode.cloud', ''),
     managerStatus: 'ready',
-    wallets: {}
+    wallets: {},
+    customNetworkConfigs: {}
   })
 
   mockWalletManager = new WalletManager({

--- a/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
+++ b/packages/use-wallet-vue/src/__tests__/useWallet.test.ts
@@ -7,7 +7,7 @@ import {
   NetworkId,
   WalletManager,
   WalletId,
-  DEFAULT_NETWORKS,
+  DEFAULT_NETWORK_CONFIG,
   DEFAULT_STATE,
   type State,
   type WalletAccount
@@ -78,7 +78,7 @@ const setupMocks = () => {
     managerStatus: 'ready',
     wallets: {},
     customNetworkConfigs: {},
-    networkConfig: DEFAULT_NETWORKS
+    networkConfig: DEFAULT_NETWORK_CONFIG
   })
 
   mockWalletManager = new WalletManager({

--- a/packages/use-wallet-vue/src/index.ts
+++ b/packages/use-wallet-vue/src/index.ts
@@ -1,3 +1,4 @@
 export * from '@txnlab/use-wallet'
 export { WalletManagerPlugin } from './walletManagerPlugin'
 export { useWallet, type Wallet } from './useWallet'
+export { useNetwork } from './useNetwork'

--- a/packages/use-wallet-vue/src/useNetwork.ts
+++ b/packages/use-wallet-vue/src/useNetwork.ts
@@ -37,7 +37,7 @@ export function useNetwork() {
       throw new Error(`Network "${networkId}" not found in network configuration`)
     }
 
-    console.info(`[Vue] Creating Algodv2 client for ${networkId}...`)
+    console.info(`[Vue] Creating new Algodv2 client...`)
 
     const { algod } = manager.networkConfig[networkId]
     const { token = '', baseServer, port = '', headers = {} } = algod
@@ -53,7 +53,9 @@ export function useNetwork() {
     manager.updateNetworkAlgod(networkId, config)
     manager.store.setState((state) => ({ ...state }))
 
+    // If this is the active network, update the algodClient
     if (networkId === activeNetwork.value) {
+      console.info(`[Vue] Creating new Algodv2 client...`)
       const { algod } = manager.networkConfig[networkId]
       const { token = '', baseServer, port = '', headers = {} } = algod
       const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
@@ -67,6 +69,7 @@ export function useNetwork() {
 
     // If this is the active network, update the algodClient
     if (networkId === activeNetwork.value) {
+      console.info(`[Vue] Creating new Algodv2 client...`)
       const { algod } = manager.networkConfig[networkId]
       const { token = '', baseServer, port = '', headers = {} } = algod
       const newClient = new algosdk.Algodv2(token, baseServer, port, headers)

--- a/packages/use-wallet-vue/src/useNetwork.ts
+++ b/packages/use-wallet-vue/src/useNetwork.ts
@@ -1,0 +1,56 @@
+import { useStore } from '@tanstack/vue-store'
+import { WalletManager } from '@txnlab/use-wallet'
+import algosdk from 'algosdk'
+import { computed, inject, ref } from 'vue'
+import type { SetAlgodClient } from './useWallet'
+
+export function useNetwork() {
+  const manager = inject<WalletManager>('walletManager')
+  const algodClient = inject<ReturnType<typeof ref<algosdk.Algodv2>>>('algodClient')
+  const setAlgodClient = inject<SetAlgodClient>('setAlgodClient')
+
+  if (!manager) {
+    throw new Error('WalletManager plugin is not properly installed')
+  }
+  if (!algodClient || !setAlgodClient) {
+    throw new Error('Algod client or setter not properly installed')
+  }
+
+  const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
+
+  const setActiveNetwork = async (networkId: string): Promise<void> => {
+    if (networkId === activeNetwork.value) {
+      return
+    }
+
+    if (!manager.networkConfig[networkId]) {
+      throw new Error(`Network "${networkId}" not found in network configuration`)
+    }
+
+    console.info(`[Vue] Creating Algodv2 client for ${networkId}...`)
+
+    const { algod } = manager.networkConfig[networkId]
+    const { token = '', baseServer, port = '', headers = {} } = algod
+    const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
+    setAlgodClient(newClient)
+
+    manager.store.setState((state) => ({
+      ...state,
+      activeNetwork: networkId
+    }))
+
+    console.info(`[Vue] ✅ Active network set to ${networkId}.`)
+  }
+
+  return {
+    activeNetwork,
+    networks: manager.networks,
+    algodClient: computed(() => {
+      if (!algodClient.value) {
+        throw new Error('Algod client is undefined')
+      }
+      return algodClient.value
+    }),
+    setActiveNetwork
+  }
+}

--- a/packages/use-wallet-vue/src/useNetwork.ts
+++ b/packages/use-wallet-vue/src/useNetwork.ts
@@ -1,5 +1,5 @@
 import { useStore } from '@tanstack/vue-store'
-import { WalletManager } from '@txnlab/use-wallet'
+import { WalletManager, type AlgodConfig } from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
 import { computed, inject, ref } from 'vue'
 import type { SetAlgodClient } from './useWallet'
@@ -42,6 +42,10 @@ export function useNetwork() {
     console.info(`[Vue] ✅ Active network set to ${networkId}.`)
   }
 
+  const updateNetworkAlgod = (networkId: string, config: Partial<AlgodConfig>) => {
+    manager.updateNetworkAlgod(networkId, config)
+  }
+
   return {
     activeNetwork,
     networks: manager.networks,
@@ -51,6 +55,7 @@ export function useNetwork() {
       }
       return algodClient.value
     }),
-    setActiveNetwork
+    setActiveNetwork,
+    updateNetworkAlgod
   }
 }

--- a/packages/use-wallet-vue/src/useNetwork.ts
+++ b/packages/use-wallet-vue/src/useNetwork.ts
@@ -76,7 +76,7 @@ export function useNetwork() {
 
   return {
     activeNetwork,
-    networks: manager.networks,
+    networkConfig: manager.networkConfig,
     activeNetworkConfig,
     setActiveNetwork,
     updateNetworkAlgod,

--- a/packages/use-wallet-vue/src/useNetwork.ts
+++ b/packages/use-wallet-vue/src/useNetwork.ts
@@ -49,8 +49,8 @@ export function useNetwork() {
     console.info(`[Vue] ✅ Active network set to ${networkId}.`)
   }
 
-  const updateNetworkAlgod = (networkId: string, config: Partial<AlgodConfig>): void => {
-    manager.updateNetworkAlgod(networkId, config)
+  const updateAlgodConfig = (networkId: string, config: Partial<AlgodConfig>): void => {
+    manager.updateAlgodConfig(networkId, config)
     manager.store.setState((state) => ({ ...state }))
 
     // If this is the active network, update the algodClient
@@ -82,7 +82,7 @@ export function useNetwork() {
     networkConfig: manager.networkConfig,
     activeNetworkConfig,
     setActiveNetwork,
-    updateNetworkAlgod,
+    updateAlgodConfig,
     resetNetworkConfig
   }
 }

--- a/packages/use-wallet-vue/src/useNetwork.ts
+++ b/packages/use-wallet-vue/src/useNetwork.ts
@@ -78,12 +78,6 @@ export function useNetwork() {
     activeNetwork,
     networks: manager.networks,
     activeNetworkConfig,
-    algodClient: computed(() => {
-      if (!algodClient.value) {
-        throw new Error('Algod client is undefined')
-      }
-      return algodClient.value
-    }),
     setActiveNetwork,
     updateNetworkAlgod,
     resetNetworkConfig

--- a/packages/use-wallet-vue/src/useNetwork.ts
+++ b/packages/use-wallet-vue/src/useNetwork.ts
@@ -61,6 +61,19 @@ export function useNetwork() {
     }
   }
 
+  const resetNetworkConfig = (networkId: string): void => {
+    manager.resetNetworkConfig(networkId)
+    manager.store.setState((state) => ({ ...state }))
+
+    // If this is the active network, update the algodClient
+    if (networkId === activeNetwork.value) {
+      const { algod } = manager.networkConfig[networkId]
+      const { token = '', baseServer, port = '', headers = {} } = algod
+      const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
+      setAlgodClient(newClient)
+    }
+  }
+
   return {
     activeNetwork,
     networks: manager.networks,
@@ -72,6 +85,7 @@ export function useNetwork() {
       return algodClient.value
     }),
     setActiveNetwork,
-    updateNetworkAlgod
+    updateNetworkAlgod,
+    resetNetworkConfig
   }
 }

--- a/packages/use-wallet-vue/src/useWallet.ts
+++ b/packages/use-wallet-vue/src/useWallet.ts
@@ -1,7 +1,7 @@
 import { useStore } from '@tanstack/vue-store'
 import { WalletManager, type WalletAccount, type WalletMetadata } from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
-import { computed, inject } from 'vue'
+import { computed, inject, ref } from 'vue'
 
 export interface Wallet {
   id: string
@@ -20,9 +20,13 @@ export type SetAlgodClient = (client: algosdk.Algodv2) => void
 
 export function useWallet() {
   const manager = inject<WalletManager>('walletManager')
+  const algodClient = inject<ReturnType<typeof ref<algosdk.Algodv2>>>('algodClient')
 
   if (!manager) {
     throw new Error('WalletManager plugin is not properly installed')
+  }
+  if (!algodClient) {
+    throw new Error('Algod client not properly installed')
   }
 
   const managerStatus = useStore(manager.store, (state) => state.managerStatus)
@@ -98,6 +102,12 @@ export function useWallet() {
   return {
     wallets,
     isReady,
+    algodClient: computed(() => {
+      if (!algodClient.value) {
+        throw new Error('Algod client is undefined')
+      }
+      return algodClient.value
+    }),
     activeWallet,
     activeWalletAccounts,
     activeWalletAddresses,

--- a/packages/use-wallet-vue/src/useWallet.ts
+++ b/packages/use-wallet-vue/src/useWallet.ts
@@ -1,7 +1,7 @@
 import { useStore } from '@tanstack/vue-store'
 import { WalletManager, type WalletAccount, type WalletMetadata } from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
-import { computed, inject, ref } from 'vue'
+import { computed, inject } from 'vue'
 
 export interface Wallet {
   id: string
@@ -20,43 +20,13 @@ export type SetAlgodClient = (client: algosdk.Algodv2) => void
 
 export function useWallet() {
   const manager = inject<WalletManager>('walletManager')
-  const algodClient = inject<ReturnType<typeof ref<algosdk.Algodv2>>>('algodClient')
-  const setAlgodClient = inject<SetAlgodClient>('setAlgodClient') as SetAlgodClient
 
   if (!manager) {
     throw new Error('WalletManager plugin is not properly installed')
   }
-  if (!algodClient || !setAlgodClient) {
-    throw new Error('Algod client or setter not properly installed')
-  }
 
   const managerStatus = useStore(manager.store, (state) => state.managerStatus)
   const isReady = computed(() => managerStatus.value === 'ready')
-
-  const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
-  const setActiveNetwork = async (networkId: string): Promise<void> => {
-    if (networkId === activeNetwork.value) {
-      return
-    }
-
-    if (!manager.networkConfig[networkId]) {
-      throw new Error(`Network "${networkId}" not found in network configuration`)
-    }
-
-    console.info(`[Vue] Creating Algodv2 client for ${networkId}...`)
-
-    const { algod } = manager.networkConfig[networkId]
-    const { token, baseServer, port, headers } = algod
-    const newClient = new algosdk.Algodv2(token, baseServer, port, headers)
-    setAlgodClient(newClient)
-
-    manager.store.setState((state) => ({
-      ...state,
-      activeNetwork: networkId
-    }))
-
-    console.info(`[Vue] ✅ Active network set to ${networkId}.`)
-  }
 
   const walletStateMap = useStore(manager.store, (state) => state.wallets)
   const activeWalletId = useStore(manager.store, (state) => state.activeWallet)
@@ -128,20 +98,11 @@ export function useWallet() {
   return {
     wallets,
     isReady,
-    algodClient: computed(() => {
-      if (!algodClient.value) {
-        throw new Error('Algod client is undefined')
-      }
-      return algodClient.value
-    }),
-    activeNetwork,
     activeWallet,
     activeWalletAccounts,
     activeWalletAddresses,
     activeAccount,
     activeAddress,
-    setActiveNetwork,
-    setAlgodClient,
     signTransactions,
     transactionSigner
   }

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -1,7 +1,7 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { createNetworkConfig, DEFAULT_NETWORKS, NetworkConfigBuilder } from 'src/network'
+import { createNetworkConfig, DEFAULT_NETWORK_CONFIG, NetworkConfigBuilder } from 'src/network'
 import { LOCAL_STORAGE_KEY, PersistedState, State, DEFAULT_STATE } from 'src/store'
 import { WalletManager } from 'src/manager'
 import { StorageAdapter } from 'src/storage'
@@ -385,7 +385,7 @@ describe('WalletManager', () => {
         activeNetwork: 'testnet',
         algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev'),
         managerStatus: 'ready',
-        networkConfig: DEFAULT_NETWORKS,
+        networkConfig: DEFAULT_NETWORK_CONFIG,
         customNetworkConfigs: {
           mainnet: {
             algod: {
@@ -397,7 +397,7 @@ describe('WalletManager', () => {
       }
 
       const manager = new WalletManager({
-        networks: DEFAULT_NETWORKS
+        networks: DEFAULT_NETWORK_CONFIG
       })
 
       // Verify custom config is loaded
@@ -408,7 +408,7 @@ describe('WalletManager', () => {
       manager.resetNetworkConfig('mainnet')
 
       // Verify config is reset to base values
-      expect(manager.networkConfig.mainnet).toEqual(DEFAULT_NETWORKS.mainnet)
+      expect(manager.networkConfig.mainnet).toEqual(DEFAULT_NETWORK_CONFIG.mainnet)
 
       // Verify persisted state is updated
       const lastCall = vi.mocked(StorageAdapter.setItem).mock.lastCall
@@ -431,7 +431,7 @@ describe('WalletManager', () => {
         activeNetwork: 'mainnet',
         algodClient: new algosdk.Algodv2('', 'https://custom-server.com'),
         managerStatus: 'ready',
-        networkConfig: DEFAULT_NETWORKS,
+        networkConfig: DEFAULT_NETWORK_CONFIG,
         customNetworkConfigs: {
           mainnet: {
             algod: {
@@ -447,7 +447,7 @@ describe('WalletManager', () => {
 
       manager.resetNetworkConfig('mainnet')
 
-      expect(createAlgodClientSpy).toHaveBeenCalledWith(DEFAULT_NETWORKS.mainnet.algod)
+      expect(createAlgodClientSpy).toHaveBeenCalledWith(DEFAULT_NETWORK_CONFIG.mainnet.algod)
       expect(manager.algodClient).toBeDefined()
     })
   })
@@ -533,7 +533,7 @@ describe('WalletManager', () => {
         activeNetwork: 'betanet',
         algodClient: new algosdk.Algodv2('', 'https://betanet-api.4160.nodely.dev/'),
         managerStatus: 'ready',
-        networkConfig: DEFAULT_NETWORKS,
+        networkConfig: DEFAULT_NETWORK_CONFIG,
         customNetworkConfigs: {}
       }
     })
@@ -702,7 +702,7 @@ describe('WalletManager', () => {
         activeNetwork: 'testnet',
         algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev'),
         managerStatus: 'ready',
-        networkConfig: DEFAULT_NETWORKS,
+        networkConfig: DEFAULT_NETWORK_CONFIG,
         customNetworkConfigs: {
           mainnet: {
             algod: {
@@ -736,7 +736,7 @@ describe('WalletManager', () => {
         activeNetwork: 'testnet',
         algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/'),
         managerStatus: 'ready',
-        networkConfig: DEFAULT_NETWORKS,
+        networkConfig: DEFAULT_NETWORK_CONFIG,
         customNetworkConfigs: {
           mainnet: {
             algod: {
@@ -756,16 +756,16 @@ describe('WalletManager', () => {
       // Provide configuration in constructor with different baseServer
       const providedNetworks = {
         mainnet: {
-          ...DEFAULT_NETWORKS.mainnet,
+          ...DEFAULT_NETWORK_CONFIG.mainnet,
           algod: {
-            ...DEFAULT_NETWORKS.mainnet.algod,
+            ...DEFAULT_NETWORK_CONFIG.mainnet.algod,
             baseServer: 'https://provided-server.com'
           }
         },
-        testnet: DEFAULT_NETWORKS.testnet,
-        betanet: DEFAULT_NETWORKS.betanet,
-        fnet: DEFAULT_NETWORKS.fnet,
-        localnet: DEFAULT_NETWORKS.localnet
+        testnet: DEFAULT_NETWORK_CONFIG.testnet,
+        betanet: DEFAULT_NETWORK_CONFIG.betanet,
+        fnet: DEFAULT_NETWORK_CONFIG.fnet,
+        localnet: DEFAULT_NETWORK_CONFIG.localnet
       }
 
       const manager = new WalletManager({
@@ -787,7 +787,7 @@ describe('WalletManager', () => {
       const providedNetworks = {
         mainnet: {
           algod: {
-            ...DEFAULT_NETWORKS.mainnet.algod,
+            ...DEFAULT_NETWORK_CONFIG.mainnet.algod,
             baseServer: 'https://custom-server.com'
           }
         }
@@ -844,7 +844,7 @@ describe('WalletManager', () => {
         activeNetwork: 'betanet',
         algodClient: new algosdk.Algodv2('', 'https://betanet-api.4160.nodely.dev/'),
         managerStatus: 'ready',
-        networkConfig: DEFAULT_NETWORKS,
+        networkConfig: DEFAULT_NETWORK_CONFIG,
         customNetworkConfigs: {}
       }
     })
@@ -1040,7 +1040,7 @@ describe('WalletManager', () => {
           activeNetwork: 'mainnet',
           algodClient: new algosdk.Algodv2('', 'https://mainnet-api.4160.nodely.dev'),
           managerStatus: 'ready',
-          networkConfig: DEFAULT_NETWORKS,
+          networkConfig: DEFAULT_NETWORK_CONFIG,
           customNetworkConfigs: {}
         }
 
@@ -1060,7 +1060,7 @@ describe('WalletManager', () => {
           activeNetwork: 'mainnet',
           algodClient: new algosdk.Algodv2('', 'https://mainnet-api.4160.nodely.dev'),
           managerStatus: 'ready',
-          networkConfig: DEFAULT_NETWORKS,
+          networkConfig: DEFAULT_NETWORK_CONFIG,
           customNetworkConfigs: {}
         }
 
@@ -1095,7 +1095,7 @@ describe('WalletManager', () => {
           activeNetwork: 'mainnet',
           algodClient: new algosdk.Algodv2('', 'https://mainnet-api.4160.nodely.dev'),
           managerStatus: 'ready',
-          networkConfig: DEFAULT_NETWORKS,
+          networkConfig: DEFAULT_NETWORK_CONFIG,
           customNetworkConfigs: {}
         }
 

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -276,7 +276,7 @@ describe('WalletManager', () => {
     })
   })
 
-  describe('updateNetworkAlgod', () => {
+  describe('updateAlgodConfig', () => {
     it('updates algod configuration for a network', () => {
       const manager = new WalletManager({
         wallets: [WalletId.DEFLY, WalletId.KIBISIS]
@@ -289,7 +289,7 @@ describe('WalletManager', () => {
         headers: { 'X-API-Key': 'new-key' }
       }
 
-      manager.updateNetworkAlgod('mainnet', newConfig)
+      manager.updateAlgodConfig('mainnet', newConfig)
 
       expect(manager.networkConfig.mainnet.algod).toEqual(newConfig)
     })
@@ -306,7 +306,7 @@ describe('WalletManager', () => {
         baseServer: 'https://new-server.com'
       }
 
-      manager.updateNetworkAlgod('mainnet', newConfig)
+      manager.updateAlgodConfig('mainnet', newConfig)
 
       expect(manager.algodClient).not.toBe(initialClient)
       expect(manager.networkConfig.mainnet.algod.token).toBe('new-token')
@@ -325,7 +325,7 @@ describe('WalletManager', () => {
         baseServer: 'https://new-server.com'
       }
 
-      manager.updateNetworkAlgod('testnet', newConfig)
+      manager.updateAlgodConfig('testnet', newConfig)
 
       expect(manager.algodClient).toBe(initialClient)
       expect(manager.networkConfig.testnet.algod.token).toBe('new-token')
@@ -338,7 +338,7 @@ describe('WalletManager', () => {
       })
 
       expect(() =>
-        manager.updateNetworkAlgod('invalid-network', {
+        manager.updateAlgodConfig('invalid-network', {
           token: 'new-token',
           baseServer: 'https://new-server.com'
         })
@@ -351,7 +351,7 @@ describe('WalletManager', () => {
       })
 
       expect(() =>
-        manager.updateNetworkAlgod('mainnet', {
+        manager.updateAlgodConfig('mainnet', {
           token: 'new-token',
           // @ts-expect-error Testing invalid config
           baseServer: 123 // Invalid type for baseServer
@@ -365,7 +365,7 @@ describe('WalletManager', () => {
       })
 
       const initialConfig = { ...manager.networkConfig.mainnet.algod }
-      manager.updateNetworkAlgod('mainnet', {
+      manager.updateAlgodConfig('mainnet', {
         token: 'new-token'
       })
 
@@ -486,7 +486,7 @@ describe('WalletManager', () => {
         baseServer: 'https://new-server.com'
       }
 
-      manager.updateNetworkAlgod('mainnet', newConfig)
+      manager.updateAlgodConfig('mainnet', newConfig)
       expect(manager.activeNetworkConfig.algod).toMatchObject(newConfig)
     })
   })
@@ -609,7 +609,7 @@ describe('WalletManager', () => {
         port: '443'
       }
 
-      manager.updateNetworkAlgod('mainnet', customAlgod)
+      manager.updateAlgodConfig('mainnet', customAlgod)
 
       // Verify the persisted state includes the custom network config
       const expectedState: PersistedState = {
@@ -638,7 +638,7 @@ describe('WalletManager', () => {
       const defaultConfig = createNetworkConfig()
 
       // Update only one property
-      manager.updateNetworkAlgod('mainnet', {
+      manager.updateAlgodConfig('mainnet', {
         token: 'custom-token'
       })
 
@@ -672,12 +672,12 @@ describe('WalletManager', () => {
       const defaultConfig = createNetworkConfig()
 
       // First modify the network
-      manager.updateNetworkAlgod('mainnet', {
+      manager.updateAlgodConfig('mainnet', {
         token: 'custom-token'
       })
 
       // Then reset it back to default
-      manager.updateNetworkAlgod('mainnet', defaultConfig.mainnet.algod)
+      manager.updateAlgodConfig('mainnet', defaultConfig.mainnet.algod)
 
       // The persisted state should not include mainnet in customNetworkConfigs
       const expectedState: PersistedState = {
@@ -806,7 +806,7 @@ describe('WalletManager', () => {
       expect(persistedState.customNetworkConfigs).toEqual({})
 
       // Now update the network config through the manager
-      manager.updateNetworkAlgod('mainnet', {
+      manager.updateAlgodConfig('mainnet', {
         baseServer: 'https://user-server.com'
       })
 

--- a/packages/use-wallet/src/__tests__/manager.test.ts
+++ b/packages/use-wallet/src/__tests__/manager.test.ts
@@ -378,6 +378,45 @@ describe('WalletManager', () => {
     })
   })
 
+  describe('activeNetworkConfig', () => {
+    it('returns the configuration for the active network', () => {
+      const manager = new WalletManager({
+        wallets: [WalletId.DEFLY],
+        defaultNetwork: 'mainnet'
+      })
+
+      expect(manager.activeNetworkConfig).toBe(manager.networks.mainnet)
+    })
+
+    it('updates when active network changes', async () => {
+      const manager = new WalletManager({
+        wallets: [WalletId.DEFLY],
+        defaultNetwork: 'mainnet'
+      })
+
+      const mainnetConfig = manager.activeNetworkConfig
+      await manager.setActiveNetwork('testnet')
+
+      expect(manager.activeNetworkConfig).toBe(manager.networks.testnet)
+      expect(manager.activeNetworkConfig).not.toBe(mainnetConfig)
+    })
+
+    it('updates when network configuration changes', () => {
+      const manager = new WalletManager({
+        wallets: [WalletId.DEFLY],
+        defaultNetwork: 'mainnet'
+      })
+
+      const newConfig = {
+        token: 'new-token',
+        baseServer: 'https://new-server.com'
+      }
+
+      manager.updateNetworkAlgod('mainnet', newConfig)
+      expect(manager.activeNetworkConfig.algod).toMatchObject(newConfig)
+    })
+  })
+
   describe('subscribe', () => {
     it('adds and removes a subscriber', async () => {
       const manager = new WalletManager({

--- a/packages/use-wallet/src/__tests__/store.test.ts
+++ b/packages/use-wallet/src/__tests__/store.test.ts
@@ -565,7 +565,8 @@ describe('Type Guards', () => {
       const defaultState: PersistedState = {
         wallets: {},
         activeWallet: null,
-        activeNetwork: 'testnet'
+        activeNetwork: 'testnet',
+        customNetworkConfigs: {}
       }
       expect(isValidPersistedState(defaultState)).toBe(true)
 
@@ -601,7 +602,8 @@ describe('Type Guards', () => {
           }
         },
         activeWallet: WalletId.DEFLY,
-        activeNetwork: 'testnet'
+        activeNetwork: 'testnet',
+        customNetworkConfigs: {}
       }
       expect(isValidPersistedState(state)).toBe(true)
     })

--- a/packages/use-wallet/src/__tests__/wallets/custom.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/custom.test.ts
@@ -1,7 +1,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, DEFAULT_STATE } from 'src/store'
 import { CustomProvider, CustomWallet, WalletId } from 'src/wallets'
@@ -52,8 +51,7 @@ function createWalletWithStore(store: Store<State>): CustomWallet {
     },
     getAlgodClient: {} as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 
@@ -198,8 +196,7 @@ describe('CustomWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn(),
-        networks: DEFAULT_NETWORKS
+        subscribe: vi.fn()
       })
 
       vi.mocked(mockProvider.connect).mockResolvedValueOnce([account1])
@@ -285,8 +282,7 @@ describe('CustomWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn(),
-        networks: DEFAULT_NETWORKS
+        subscribe: vi.fn()
       })
 
       await wallet.resumeSession()
@@ -335,8 +331,7 @@ describe('CustomWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn(),
-        networks: DEFAULT_NETWORKS
+        subscribe: vi.fn()
       })
 
       await expect(wallet.signTransactions(txnGroup, indexesToSign)).rejects.toThrowError(
@@ -384,8 +379,7 @@ describe('CustomWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn(),
-        networks: DEFAULT_NETWORKS
+        subscribe: vi.fn()
       })
 
       await expect(wallet.transactionSigner(txnGroup, indexesToSign)).rejects.toThrowError(

--- a/packages/use-wallet/src/__tests__/wallets/defly-web.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/defly-web.test.ts
@@ -9,7 +9,6 @@ import {
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { DEFAULT_STATE, LOCAL_STORAGE_KEY, State } from 'src/store'
 import { WalletId } from 'src/wallets'
@@ -67,8 +66,7 @@ function createWalletWithStore(store: Store<State>): DeflyWebWallet {
         })
       }) as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/defly.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/defly.test.ts
@@ -1,7 +1,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { DeflyWallet } from 'src/wallets/defly'
@@ -52,8 +51,7 @@ function createWalletWithStore(store: Store<State>): DeflyWallet {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 
   // @ts-expect-error - Mocking the private client property

--- a/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/exodus.test.ts
@@ -1,7 +1,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
@@ -53,8 +52,7 @@ function createWalletWithStore(store: Store<State>): ExodusWallet {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kibisis.test.ts
@@ -9,7 +9,6 @@ import {
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { DEFAULT_STATE, LOCAL_STORAGE_KEY, State } from 'src/store'
 import { WalletId } from 'src/wallets'
@@ -67,8 +66,7 @@ function createWalletWithStore(store: Store<State>): KibisisWallet {
         })
       }) as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/kmd.test.ts
@@ -1,7 +1,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { KmdWallet } from 'src/wallets/kmd'
@@ -54,8 +53,7 @@ function createWalletWithStore(store: Store<State>): KmdWallet {
     metadata: {},
     getAlgodClient: {} as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 
@@ -441,7 +439,6 @@ describe('KmdWallet', () => {
         getAlgodClient: {} as any,
         store,
         subscribe: vi.fn(),
-        networks: DEFAULT_NETWORKS,
         options: {
           promptForPassword: () => Promise.resolve(customPassword)
         }

--- a/packages/use-wallet/src/__tests__/wallets/lute.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/lute.test.ts
@@ -1,7 +1,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { byteArrayToBase64 } from 'src/utils'
@@ -61,8 +60,7 @@ function createWalletWithStore(store: Store<State>): LuteWallet {
         })
       }) as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/magic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/magic.test.ts
@@ -1,7 +1,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
@@ -59,8 +58,7 @@ function createWalletWithStore(store: Store<State>): MagicAuth {
     metadata: {},
     getAlgodClient: {} as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 

--- a/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/mnemonic.test.ts
@@ -2,7 +2,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { LOCAL_STORAGE_MNEMONIC_KEY, MnemonicWallet } from 'src/wallets/mnemonic'
@@ -41,8 +40,7 @@ function createWalletWithStore(store: Store<State>, persistToStorage = false): M
     metadata: {},
     getAlgodClient: {} as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 
@@ -380,8 +378,7 @@ describe('MnemonicWallet', () => {
         metadata: {},
         getAlgodClient: {} as any,
         store,
-        subscribe: vi.fn(),
-        networks: DEFAULT_NETWORKS
+        subscribe: vi.fn()
       })
     })
 

--- a/packages/use-wallet/src/__tests__/wallets/pera.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/pera.test.ts
@@ -1,7 +1,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { PeraWallet } from 'src/wallets/pera'
@@ -52,8 +51,7 @@ function createWalletWithStore(store: Store<State>): PeraWallet {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 
   // @ts-expect-error - Mocking the private client property

--- a/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/walletconnect.test.ts
@@ -2,7 +2,7 @@ import { Store } from '@tanstack/store'
 import { ModalCtrl } from '@walletconnect/modal-core'
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS, NetworkConfig } from 'src/network'
+import { NetworkConfig } from 'src/network'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
 import { base64ToByteArray, byteArrayToBase64 } from 'src/utils'
@@ -116,8 +116,7 @@ function createWalletWithStore(store: Store<State>): WalletConnect {
     metadata: {},
     getAlgodClient: () => ({}) as any,
     store,
-    subscribe: vi.fn(),
-    networks: DEFAULT_NETWORKS
+    subscribe: vi.fn()
   })
 }
 
@@ -178,7 +177,7 @@ describe('WalletConnect', () => {
     it('should initialize client, return accounts, and update store', async () => {
       const mockSession = createMockSession(
         [account1.address, account2.address],
-        wallet.networkConfig
+        store.state.networkConfig
       )
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
@@ -196,7 +195,7 @@ describe('WalletConnect', () => {
     })
 
     it('should throw an error if no URI is returned', async () => {
-      const mockSession = createMockSession([], wallet.networkConfig)
+      const mockSession = createMockSession([], store.state.networkConfig)
       mockSignClient.connect.mockResolvedValueOnce({
         approval: vi.fn().mockResolvedValue(mockSession)
       })
@@ -208,7 +207,7 @@ describe('WalletConnect', () => {
     })
 
     it('should throw an error if an empty array is returned', async () => {
-      const mockSession = createMockSession([], wallet.networkConfig)
+      const mockSession = createMockSession([], store.state.networkConfig)
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
         approval: vi.fn().mockResolvedValue(mockSession)
@@ -222,7 +221,7 @@ describe('WalletConnect', () => {
 
     it('should use the active chain when connecting', async () => {
       store.setState((state) => ({ ...state, activeNetwork: 'testnet' }))
-      const mockSession = createMockSession([account1.address], wallet.networkConfig)
+      const mockSession = createMockSession([account1.address], store.state.networkConfig)
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
         approval: vi.fn().mockResolvedValue(mockSession)
@@ -246,7 +245,7 @@ describe('WalletConnect', () => {
     it('should disconnect client and remove wallet from store', async () => {
       const mockSession = createMockSession(
         [account1.address, account2.address],
-        wallet.networkConfig
+        store.state.networkConfig
       )
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
@@ -284,7 +283,7 @@ describe('WalletConnect', () => {
 
       wallet = createWalletWithStore(store)
 
-      const mockSession = createMockSession([account1.address], wallet.networkConfig)
+      const mockSession = createMockSession([account1.address], store.state.networkConfig)
       mockSignClient.session.get.mockImplementationOnce(() => mockSession)
 
       const mockSessionKey = 'mockSessionKey'
@@ -341,7 +340,7 @@ describe('WalletConnect', () => {
       }
 
       // Client only returns 'GD64YI' on reconnect
-      const mockSession = createMockSession(newAccounts, wallet.networkConfig)
+      const mockSession = createMockSession(newAccounts, store.state.networkConfig)
       mockSignClient.session.get.mockImplementationOnce(() => mockSession)
 
       await wallet.resumeSession()
@@ -399,7 +398,7 @@ describe('WalletConnect', () => {
       // Mock two connected accounts
       const mockSession = createMockSession(
         [account1.address, account2.address],
-        wallet.networkConfig
+        store.state.networkConfig
       )
       mockSignClient.connect.mockResolvedValueOnce({
         uri: 'mock-uri',
@@ -592,7 +591,7 @@ describe('WalletConnect', () => {
 
       it('should use the active chain when signing transactions', async () => {
         store.setState((state) => ({ ...state, activeNetwork: 'mainnet' }))
-        const mockSession = createMockSession([account1.address], wallet.networkConfig)
+        const mockSession = createMockSession([account1.address], store.state.networkConfig)
         mockSignClient.connect.mockResolvedValueOnce({
           uri: 'mock-uri',
           approval: vi.fn().mockResolvedValue(mockSession)
@@ -627,13 +626,13 @@ describe('WalletConnect', () => {
   describe('activeChainId', () => {
     it('should return the correct CAIP-2 chain ID for the active network', () => {
       store.setState((state) => ({ ...state, activeNetwork: 'mainnet' }))
-      expect(wallet.activeChainId).toBe(wallet.networkConfig.mainnet.caipChainId)
+      expect(wallet.activeChainId).toBe(store.state.networkConfig.mainnet.caipChainId)
 
       store.setState((state) => ({ ...state, activeNetwork: 'testnet' }))
-      expect(wallet.activeChainId).toBe(wallet.networkConfig.testnet.caipChainId)
+      expect(wallet.activeChainId).toBe(store.state.networkConfig.testnet.caipChainId)
 
       store.setState((state) => ({ ...state, activeNetwork: 'betanet' }))
-      expect(wallet.activeChainId).toBe(wallet.networkConfig.betanet.caipChainId)
+      expect(wallet.activeChainId).toBe(store.state.networkConfig.betanet.caipChainId)
     })
 
     it('should log a warning and return an empty string if no CAIP-2 chain ID is found', () => {

--- a/packages/use-wallet/src/index.ts
+++ b/packages/use-wallet/src/index.ts
@@ -1,6 +1,6 @@
 export { LogLevel } from './logger'
 export { WalletManager, WalletManagerConfig, WalletManagerOptions } from './manager'
-export { NetworkId, DEFAULT_NETWORKS } from './network'
+export { AlgodConfig, NetworkConfig, NetworkId, DEFAULT_NETWORKS } from './network'
 export { State, WalletState, ManagerStatus, DEFAULT_STATE } from './store'
 export { StorageAdapter } from './storage'
 export { webpackFallback } from './webpack'

--- a/packages/use-wallet/src/index.ts
+++ b/packages/use-wallet/src/index.ts
@@ -1,6 +1,6 @@
 export { LogLevel } from './logger'
 export { WalletManager, WalletManagerConfig, WalletManagerOptions } from './manager'
-export { AlgodConfig, NetworkConfig, NetworkId, DEFAULT_NETWORKS } from './network'
+export { AlgodConfig, NetworkConfig, NetworkId, DEFAULT_NETWORK_CONFIG } from './network'
 export { State, WalletState, ManagerStatus, DEFAULT_STATE } from './store'
 export { StorageAdapter } from './storage'
 export { webpackFallback } from './webpack'

--- a/packages/use-wallet/src/manager.ts
+++ b/packages/use-wallet/src/manager.ts
@@ -373,6 +373,10 @@ export class WalletManager {
     return { ...this.networkConfig }
   }
 
+  public get activeNetworkConfig(): NetworkConfig {
+    return this.networkConfig[this.activeNetwork]
+  }
+
   // ---------- Active Wallet ----------------------------------------- //
 
   public get activeWallet(): BaseWallet | null {

--- a/packages/use-wallet/src/manager.ts
+++ b/packages/use-wallet/src/manager.ts
@@ -377,7 +377,7 @@ export class WalletManager {
     this.logger.info(`✅ Active network set to ${networkId}`)
   }
 
-  public updateNetworkAlgod(networkId: string, algodConfig: Partial<AlgodConfig>): void {
+  public updateAlgodConfig(networkId: string, algodConfig: Partial<AlgodConfig>): void {
     // Verify network exists
     if (!this.networkConfig[networkId]) {
       throw new Error(`Network "${networkId}" not found in network configuration`)

--- a/packages/use-wallet/src/manager.ts
+++ b/packages/use-wallet/src/manager.ts
@@ -417,6 +417,32 @@ export class WalletManager {
     this.logger.info(`✅ Updated algod configuration for ${networkId}`)
   }
 
+  public resetNetworkConfig(networkId: string): void {
+    // Verify network exists
+    if (!this.baseNetworkConfig[networkId]) {
+      throw new Error(`Network "${networkId}" not found in network configuration`)
+    }
+
+    // Reset to base configuration
+    this.networkConfig[networkId] = { ...this.baseNetworkConfig[networkId] }
+
+    // If this is the active network, update the algod client
+    if (this.activeNetwork === networkId) {
+      this.algodClient = this.createAlgodClient(networkId)
+    }
+
+    // Load current persisted state
+    const persistedState = this.loadPersistedState()
+    if (persistedState?.customNetworkConfigs) {
+      // Remove the network's customizations
+      delete persistedState.customNetworkConfigs[networkId]
+      // Save the updated state
+      StorageAdapter.setItem(LOCAL_STORAGE_KEY, JSON.stringify(persistedState))
+    }
+
+    this.logger.info(`✅ Reset network configuration for ${networkId}`)
+  }
+
   public get activeNetwork(): string {
     return this.store.state.activeNetwork
   }

--- a/packages/use-wallet/src/network.ts
+++ b/packages/use-wallet/src/network.ts
@@ -16,7 +16,7 @@ export interface NetworkConfig {
 }
 
 // Default configurations
-export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
+export const DEFAULT_NETWORK_CONFIG: Record<string, NetworkConfig> = {
   mainnet: {
     algod: {
       token: '',
@@ -82,19 +82,19 @@ export class NetworkConfigBuilder {
   private networks: Map<string, NetworkConfig>
 
   constructor() {
-    this.networks = new Map(Object.entries(DEFAULT_NETWORKS))
+    this.networks = new Map(Object.entries(DEFAULT_NETWORK_CONFIG))
   }
 
   // Methods to customize default networks
   mainnet(config: DefaultNetworkConfig) {
     this.networks.set('mainnet', {
-      ...DEFAULT_NETWORKS.mainnet,
+      ...DEFAULT_NETWORK_CONFIG.mainnet,
       ...config,
-      genesisHash: DEFAULT_NETWORKS.mainnet.genesisHash!,
-      genesisId: DEFAULT_NETWORKS.mainnet.genesisId!,
-      caipChainId: DEFAULT_NETWORKS.mainnet.caipChainId!,
+      genesisHash: DEFAULT_NETWORK_CONFIG.mainnet.genesisHash!,
+      genesisId: DEFAULT_NETWORK_CONFIG.mainnet.genesisId!,
+      caipChainId: DEFAULT_NETWORK_CONFIG.mainnet.caipChainId!,
       algod: {
-        ...DEFAULT_NETWORKS.mainnet.algod,
+        ...DEFAULT_NETWORK_CONFIG.mainnet.algod,
         ...(config.algod || {})
       }
     })
@@ -103,13 +103,13 @@ export class NetworkConfigBuilder {
 
   testnet(config: DefaultNetworkConfig) {
     this.networks.set('testnet', {
-      ...DEFAULT_NETWORKS.testnet,
+      ...DEFAULT_NETWORK_CONFIG.testnet,
       ...config,
-      genesisHash: DEFAULT_NETWORKS.testnet.genesisHash!,
-      genesisId: DEFAULT_NETWORKS.testnet.genesisId!,
-      caipChainId: DEFAULT_NETWORKS.testnet.caipChainId!,
+      genesisHash: DEFAULT_NETWORK_CONFIG.testnet.genesisHash!,
+      genesisId: DEFAULT_NETWORK_CONFIG.testnet.genesisId!,
+      caipChainId: DEFAULT_NETWORK_CONFIG.testnet.caipChainId!,
       algod: {
-        ...DEFAULT_NETWORKS.testnet.algod,
+        ...DEFAULT_NETWORK_CONFIG.testnet.algod,
         ...(config.algod || {})
       }
     })
@@ -118,13 +118,13 @@ export class NetworkConfigBuilder {
 
   betanet(config: DefaultNetworkConfig) {
     this.networks.set('betanet', {
-      ...DEFAULT_NETWORKS.betanet,
+      ...DEFAULT_NETWORK_CONFIG.betanet,
       ...config,
-      genesisHash: DEFAULT_NETWORKS.betanet.genesisHash!,
-      genesisId: DEFAULT_NETWORKS.betanet.genesisId!,
-      caipChainId: DEFAULT_NETWORKS.betanet.caipChainId!,
+      genesisHash: DEFAULT_NETWORK_CONFIG.betanet.genesisHash!,
+      genesisId: DEFAULT_NETWORK_CONFIG.betanet.genesisId!,
+      caipChainId: DEFAULT_NETWORK_CONFIG.betanet.caipChainId!,
       algod: {
-        ...DEFAULT_NETWORKS.betanet.algod,
+        ...DEFAULT_NETWORK_CONFIG.betanet.algod,
         ...(config.algod || {})
       }
     })
@@ -133,13 +133,13 @@ export class NetworkConfigBuilder {
 
   fnet(config: DefaultNetworkConfig) {
     this.networks.set('fnet', {
-      ...DEFAULT_NETWORKS.fnet,
+      ...DEFAULT_NETWORK_CONFIG.fnet,
       ...config,
-      genesisHash: DEFAULT_NETWORKS.fnet.genesisHash!,
-      genesisId: DEFAULT_NETWORKS.fnet.genesisId!,
-      caipChainId: DEFAULT_NETWORKS.fnet.caipChainId!,
+      genesisHash: DEFAULT_NETWORK_CONFIG.fnet.genesisHash!,
+      genesisId: DEFAULT_NETWORK_CONFIG.fnet.genesisId!,
+      caipChainId: DEFAULT_NETWORK_CONFIG.fnet.caipChainId!,
       algod: {
-        ...DEFAULT_NETWORKS.fnet.algod,
+        ...DEFAULT_NETWORK_CONFIG.fnet.algod,
         ...(config.algod || {})
       }
     })
@@ -148,10 +148,10 @@ export class NetworkConfigBuilder {
 
   localnet(config: Partial<NetworkConfig>) {
     this.networks.set('localnet', {
-      ...DEFAULT_NETWORKS.localnet,
+      ...DEFAULT_NETWORK_CONFIG.localnet,
       ...config,
       algod: {
-        ...DEFAULT_NETWORKS.localnet.algod,
+        ...DEFAULT_NETWORK_CONFIG.localnet.algod,
         ...(config.algod || {})
       }
     })
@@ -160,7 +160,7 @@ export class NetworkConfigBuilder {
 
   // Method to add custom networks (still needs full NetworkConfig)
   addNetwork(id: string, config: NetworkConfig) {
-    if (DEFAULT_NETWORKS[id]) {
+    if (DEFAULT_NETWORK_CONFIG[id]) {
       throw new Error(
         `Cannot add network with reserved id "${id}". Use the ${id}() method instead.`
       )

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -1,6 +1,6 @@
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { NetworkId } from 'src/network'
+import { NetworkConfig, NetworkId } from 'src/network'
 import { WalletId, type WalletAccount } from 'src/wallets/types'
 import type { Store } from '@tanstack/store'
 
@@ -19,6 +19,7 @@ export interface State {
   activeNetwork: string
   algodClient: algosdk.Algodv2
   managerStatus: ManagerStatus
+  customNetworkConfigs: Record<string, Partial<NetworkConfig>>
 }
 
 export const DEFAULT_STATE: State = {
@@ -26,7 +27,8 @@ export const DEFAULT_STATE: State = {
   activeWallet: null,
   activeNetwork: 'testnet',
   algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/'),
-  managerStatus: 'initializing'
+  managerStatus: 'initializing',
+  customNetworkConfigs: {}
 }
 
 export type PersistedState = Omit<State, 'algodClient' | 'managerStatus'>
@@ -186,14 +188,14 @@ export function isValidWalletState(wallet: any): wallet is WalletState {
   )
 }
 
-export function isValidPersistedState(state: any): state is PersistedState {
-  if (!state || typeof state !== 'object') return false
-  if (typeof state.wallets !== 'object') return false
-  for (const [walletId, wallet] of Object.entries(state.wallets)) {
-    if (!isValidWalletId(walletId) || !isValidWalletState(wallet)) return false
-  }
-  if (state.activeWallet !== null && !isValidWalletId(state.activeWallet)) return false
-  if (typeof state.activeNetwork !== 'string') return false
-
-  return true
+export function isValidPersistedState(state: unknown): state is PersistedState {
+  return (
+    typeof state === 'object' &&
+    state !== null &&
+    'wallets' in state &&
+    'activeWallet' in state &&
+    'activeNetwork' in state &&
+    (!('customNetworkConfigs' in state) ||
+      (typeof state.customNetworkConfigs === 'object' && state.customNetworkConfigs !== null))
+  )
 }

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -1,6 +1,6 @@
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { NetworkConfig, NetworkId } from 'src/network'
+import { DEFAULT_NETWORKS, NetworkConfig, NetworkId } from 'src/network'
 import { WalletId, type WalletAccount } from 'src/wallets/types'
 import type { Store } from '@tanstack/store'
 
@@ -19,6 +19,7 @@ export interface State {
   activeNetwork: string
   algodClient: algosdk.Algodv2
   managerStatus: ManagerStatus
+  networkConfig: Record<string, NetworkConfig>
   customNetworkConfigs: Record<string, Partial<NetworkConfig>>
 }
 
@@ -28,10 +29,11 @@ export const DEFAULT_STATE: State = {
   activeNetwork: 'testnet',
   algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/'),
   managerStatus: 'initializing',
+  networkConfig: DEFAULT_NETWORKS,
   customNetworkConfigs: {}
 }
 
-export type PersistedState = Omit<State, 'algodClient' | 'managerStatus'>
+export type PersistedState = Omit<State, 'algodClient' | 'managerStatus' | 'networkConfig'>
 
 export const LOCAL_STORAGE_KEY = '@txnlab/use-wallet:v3'
 

--- a/packages/use-wallet/src/store.ts
+++ b/packages/use-wallet/src/store.ts
@@ -1,6 +1,6 @@
 import algosdk from 'algosdk'
 import { logger } from 'src/logger'
-import { DEFAULT_NETWORKS, NetworkConfig, NetworkId } from 'src/network'
+import { DEFAULT_NETWORK_CONFIG, NetworkConfig, NetworkId } from 'src/network'
 import { WalletId, type WalletAccount } from 'src/wallets/types'
 import type { Store } from '@tanstack/store'
 
@@ -29,7 +29,7 @@ export const DEFAULT_STATE: State = {
   activeNetwork: 'testnet',
   algodClient: new algosdk.Algodv2('', 'https://testnet-api.4160.nodely.dev/'),
   managerStatus: 'initializing',
-  networkConfig: DEFAULT_NETWORKS,
+  networkConfig: DEFAULT_NETWORK_CONFIG,
   customNetworkConfigs: {}
 }
 

--- a/packages/use-wallet/src/wallets/base.ts
+++ b/packages/use-wallet/src/wallets/base.ts
@@ -14,7 +14,6 @@ interface WalletConstructorType {
 export abstract class BaseWallet {
   readonly id: WalletId
   readonly metadata: WalletMetadata
-  protected readonly networks: Record<string, NetworkConfig>
 
   protected store: Store<State>
   protected getAlgodClient: () => algosdk.Algodv2
@@ -28,14 +27,12 @@ export abstract class BaseWallet {
     metadata,
     store,
     subscribe,
-    getAlgodClient,
-    networks
+    getAlgodClient
   }: WalletConstructor<WalletId>) {
     this.id = id
     this.store = store
     this.subscribe = subscribe
     this.getAlgodClient = getAlgodClient
-    this.networks = networks
 
     const ctor = this.constructor as WalletConstructorType
     this.metadata = { ...ctor.defaultMetadata, ...metadata }
@@ -128,17 +125,9 @@ export abstract class BaseWallet {
     return state.activeWallet === this.id
   }
 
-  // Make networks accessible for testing
-  public get networkConfig(): Record<string, NetworkConfig> {
-    return this.networks
-  }
-
-  protected get activeNetworkConfig(): NetworkConfig {
-    const config = this.networks[this.activeNetwork]
-    if (!config) {
-      throw new Error(`No configuration found for network: ${this.activeNetwork}`)
-    }
-    return config
+  public get activeNetworkConfig(): NetworkConfig {
+    const { networkConfig, activeNetwork } = this.store.state
+    return networkConfig[activeNetwork]
   }
 
   // ---------- Protected Methods ------------------------------------- //

--- a/packages/use-wallet/src/wallets/custom.ts
+++ b/packages/use-wallet/src/wallets/custom.ts
@@ -38,11 +38,10 @@ export class CustomWallet extends BaseWallet {
     store,
     subscribe,
     getAlgodClient,
-    networks,
     options,
     metadata = {}
   }: WalletConstructor<WalletId.CUSTOM>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
     if (!options?.provider) {
       this.logger.error('Missing required option: provider')
       throw new Error('Missing required option: provider')

--- a/packages/use-wallet/src/wallets/defly-web.ts
+++ b/packages/use-wallet/src/wallets/defly-web.ts
@@ -18,8 +18,7 @@ export class DeflyWebWallet extends AVMProvider {
     store,
     subscribe,
     getAlgodClient,
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.DEFLY_WEB>) {
     super({
       id,
@@ -27,7 +26,6 @@ export class DeflyWebWallet extends AVMProvider {
       getAlgodClient,
       store,
       subscribe,
-      networks,
       providerId: DEFLY_WEB_PROVIDER_ID
     })
   }

--- a/packages/use-wallet/src/wallets/defly.ts
+++ b/packages/use-wallet/src/wallets/defly.ts
@@ -33,10 +33,9 @@ export class DeflyWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options = {},
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.DEFLY>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
     this.options = options
     this.store = store
   }

--- a/packages/use-wallet/src/wallets/exodus.ts
+++ b/packages/use-wallet/src/wallets/exodus.ts
@@ -90,10 +90,9 @@ export class ExodusWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options = {},
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.EXODUS>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
     this.options = options
     this.store = store
   }

--- a/packages/use-wallet/src/wallets/kibisis.ts
+++ b/packages/use-wallet/src/wallets/kibisis.ts
@@ -18,8 +18,7 @@ export class KibisisWallet extends AVMProvider {
     store,
     subscribe,
     getAlgodClient,
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.KIBISIS>) {
     super({
       id,
@@ -27,7 +26,6 @@ export class KibisisWallet extends AVMProvider {
       getAlgodClient,
       store,
       subscribe,
-      networks,
       providerId: KIBISIS_AVM_WEB_PROVIDER_ID
     })
   }

--- a/packages/use-wallet/src/wallets/kmd.ts
+++ b/packages/use-wallet/src/wallets/kmd.ts
@@ -70,11 +70,10 @@ export class KmdWallet extends BaseWallet {
     store,
     subscribe,
     getAlgodClient,
-    networks,
     options,
     metadata = {}
   }: WalletConstructor<WalletId.KMD>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
 
     const {
       token = 'a'.repeat(64),

--- a/packages/use-wallet/src/wallets/lute.ts
+++ b/packages/use-wallet/src/wallets/lute.ts
@@ -38,10 +38,9 @@ export class LuteWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.LUTE>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
     if (!options?.siteName) {
       this.logger.error('Missing required option: siteName')
       throw new Error('Missing required option: siteName')

--- a/packages/use-wallet/src/wallets/magic.ts
+++ b/packages/use-wallet/src/wallets/magic.ts
@@ -54,10 +54,9 @@ export class MagicAuth extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.MAGIC>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
     if (!options?.apiKey) {
       this.logger.error('Missing required option: apiKey')
       throw new Error('Missing required option: apiKey')

--- a/packages/use-wallet/src/wallets/mnemonic.ts
+++ b/packages/use-wallet/src/wallets/mnemonic.ts
@@ -35,10 +35,9 @@ export class MnemonicWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.MNEMONIC>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
 
     const {
       persistToStorage = false,

--- a/packages/use-wallet/src/wallets/pera.ts
+++ b/packages/use-wallet/src/wallets/pera.ts
@@ -38,10 +38,9 @@ export class PeraWallet extends BaseWallet {
     subscribe,
     getAlgodClient,
     options = {},
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.PERA>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
     this.options = options
     this.store = store
   }

--- a/packages/use-wallet/src/wallets/types.ts
+++ b/packages/use-wallet/src/wallets/types.ts
@@ -12,7 +12,6 @@ import { WalletConnect, type WalletConnectOptions } from './walletconnect'
 import { BiatecWallet } from './biatec'
 import type { Store } from '@tanstack/store'
 import type algosdk from 'algosdk'
-import type { NetworkConfig } from 'src/network'
 import type { State } from 'src/store'
 
 export enum WalletId {
@@ -94,7 +93,6 @@ export interface BaseWalletConstructor {
   getAlgodClient: () => algosdk.Algodv2
   store: Store<State>
   subscribe: (callback: (state: State) => void) => () => void
-  networks: Record<string, NetworkConfig>
 }
 
 export type WalletConstructor<T extends keyof WalletOptionsMap> = BaseWalletConstructor & {

--- a/packages/use-wallet/src/wallets/walletconnect.ts
+++ b/packages/use-wallet/src/wallets/walletconnect.ts
@@ -69,10 +69,9 @@ export class WalletConnect extends BaseWallet {
     subscribe,
     getAlgodClient,
     options,
-    metadata = {},
-    networks
+    metadata = {}
   }: WalletConstructor<WalletId.WALLETCONNECT>) {
-    super({ id, metadata, getAlgodClient, store, subscribe, networks })
+    super({ id, metadata, getAlgodClient, store, subscribe })
     if (!options?.projectId) {
       this.logger.error('Missing required option: projectId')
       throw new Error('Missing required option: projectId')
@@ -354,7 +353,7 @@ export class WalletConnect extends BaseWallet {
   }
 
   public get activeChainId(): string {
-    const network = this.networks[this.activeNetwork]
+    const network = this.activeNetworkConfig
     if (!network?.caipChainId) {
       this.logger.warn(`No CAIP-2 chain ID found for network: ${this.activeNetwork}`)
       return ''


### PR DESCRIPTION
## Description

This PR adds the ability to connect to custom Algorand nodes at runtime through the new `updateAlgodConfig` method. Users can now dynamically modify network configurations to connect to their own nodes after initialization, with their customizations persisting between sessions. As part of this change, network functionality has been refactored into a dedicated `useNetwork` hook for better organization and maintainability.

## Details
- Add `updateAlgodConfig` method to modify network configurations at runtime
- Enable dynamic switching between different Algorand nodes
- Preserve existing network configuration when partially updating
- Automatically update active algod client when modifying the active network
- Persist user network customizations between sessions while preserving developer defaults
- Split network functionality into dedicated `useNetwork` hook for better organization
- Add comprehensive test coverage for network configuration updates
- Update all framework adapters (React, Vue, Solid) for consistency