### PR TITLE
fix(core): export NetworkConfigBuilder class

### DIFF
--- a/packages/use-wallet/src/index.ts
+++ b/packages/use-wallet/src/index.ts
@@ -1,6 +1,12 @@
 export { LogLevel } from './logger'
 export { WalletManager, WalletManagerConfig, WalletManagerOptions } from './manager'
-export { AlgodConfig, NetworkConfig, NetworkId, DEFAULT_NETWORK_CONFIG } from './network'
+export {
+  AlgodConfig,
+  NetworkConfig,
+  NetworkConfigBuilder,
+  NetworkId,
+  DEFAULT_NETWORK_CONFIG
+} from './network'
 export { State, WalletState, ManagerStatus, DEFAULT_STATE } from './store'
 export { StorageAdapter } from './storage'
 export { webpackFallback } from './webpack'


### PR DESCRIPTION
## Description

This PR adds the missing export for the `NetworkConfigBuilder` class from the main entry point of the core `use-wallet` package. This class is a key component of the new network configuration API that enables customization of network settings.

## Details
- Add `NetworkConfigBuilder` to the main exports in `index.ts`
- Ensures users can access the builder pattern API for network configuration
- Fixes an oversight where this class was implemented but not exposed