### PR TITLE
fix(useWallet): ensure consistent wallet interface across adapters

### DIFF
--- a/packages/use-wallet-solid/src/index.tsx
+++ b/packages/use-wallet-solid/src/index.tsx
@@ -4,10 +4,8 @@ import { JSX, createContext, createMemo, onMount, useContext } from 'solid-js'
 import type {
   AlgodConfig,
   NetworkId,
-  WalletAccount,
   WalletId,
   WalletManager,
-  WalletMetadata,
   WalletState
 } from '@txnlab/use-wallet'
 
@@ -118,19 +116,6 @@ export const useNetwork = () => {
     updateAlgodConfig,
     resetNetworkConfig
   }
-}
-
-export interface Wallet {
-  id: () => string
-  metadata: () => WalletMetadata
-  accounts: () => WalletAccount[]
-  activeAccount: () => WalletAccount | null
-  isConnected: () => boolean
-  isActive: () => boolean
-  connect: (args?: Record<string, any>) => Promise<WalletAccount[]>
-  disconnect: () => Promise<void>
-  setActive: () => void
-  setActiveAccount: (address: string) => void
 }
 
 export const useWallet = () => {


### PR DESCRIPTION
## Description

This PR fixes inconsistencies in how wallet objects are returned across framework adapters. Previously, `activeWallet` could return a `BaseWallet` while `wallets` returned `Wallet[]`, leading to potential type mismatches.

## Details
- Ensure `activeWallet` returns same `Wallet` interface as items in `wallets` array
- Extract `transformToWallet` helper in React/Vue adapters to maintain consistency
- Preserve `BaseWallet` internally for transaction signing only
- Fix `Wallet` interface to use `WalletId` type instead of string
- Remove unused `Wallet` interface from Solid adapter (uses individual reactive properties instead)