### PR TITLE
docs(gitbook): sync v4 docs from GitBook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+---
+description: Easily integrate Algorand wallets in your dApps
+---
+
+# Overview
+
+Use-wallet is a comprehensive wallet management solution for Algorand/AVM dApps. It reduces the complexity of wallet integrations, letting developers focus on core application logic.
+
+The library is framework-agnostic and can be used in any modern front-end stack, with official adapters for [React](framework/react.md), [Vue](framework/vue.md), and [SolidJS](framework/solidjs.md).
+
+Version 4.x introduces several major improvements:
+
+* **Algorand SDK v3** - Full support for [Algorand JavaScript SDK](https://github.com/algorand/js-algorand-sdk) v3
+* **Runtime Node Configuration** - Let users connect to their private Algorand nodes ([guide](guides/runtime-node-configuration.md))
+* **Custom Networks** - Add support for custom network configurations
+
+See the [Migration Guide](guides/migrating-from-v3.x.md) for help upgrading from v3.x.
+
+{% hint style="info" %}
+**Looking for v3 docs?** You can find the use-wallet v3.x documentation [here](https://txnlab.gitbook.io/use-wallet/v3).
+{% endhint %}
+
+### Links
+
+* [GitHub Repository](https://github.com/TxnLab/use-wallet)
+* [Discord Support Channel](https://discord.gg/YkfksmJRrd) (#use-wallet on NFDomains Discord)
+
+{% embed url="https://www.youtube.com/watch?v=DdvrcBdnRCI" %}
+Awesome Algorand #22 - Doug Richar: How 'use-wallet' transformed Algorand wallet management
+{% endembed %}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,35 @@
+# Table of contents
+
+## Getting Started
+
+* [Overview](README.md)
+* [Installation](getting-started/installation.md)
+* [Configuration](getting-started/configuration.md)
+* [Supported Wallets](getting-started/supported-wallets.md)
+
+## Framework Adapters <a href="#framework" id="framework"></a>
+
+* [React](framework/react.md)
+* [Vue](framework/vue.md)
+* [SolidJS](framework/solidjs.md)
+
+## Guides & Concepts <a href="#guides" id="guides"></a>
+
+* [Connect Wallet Menu](guides/connect-wallet-menu.md)
+* [Signing Transactions](guides/signing-transactions.md)
+* [Switching Networks](guides/switching-networks.md)
+* [Runtime Node Configuration](guides/runtime-node-configuration.md)
+* [Testing with Mnemonic Wallet](guides/testing-with-mnemonic-wallet.md)
+* [Custom Provider](guides/custom-provider.md)
+* [Migrating from v3.x](guides/migrating-from-v3.x.md)
+
+## API Reference
+
+* [WalletManager](api-reference/walletmanager.md)
+* [useWallet](api-reference/usewallet.md)
+* [useNetwork](api-reference/usenetwork.md)
+
+## Resources
+
+* [Example Projects](resources/example-projects.md)
+* [AlgoKit Templates](resources/algokit-templates.md)

--- a/docs/api-reference/usenetwork.md
+++ b/docs/api-reference/usenetwork.md
@@ -1,0 +1,222 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# useNetwork
+
+The `useNetwork` hook/composable provides access to network-related state and methods from the WalletManager. It enables applications to switch between networks and customize node configurations at runtime.
+
+### Core Functionality
+
+All framework adapters provide access to the same core network state and methods, with framework-specific reactive wrappers.
+
+#### State Properties
+
+```typescript
+interface NetworkState {
+  // Currently active network ID (e.g., 'mainnet', 'testnet')
+  activeNetwork: string
+
+  // Complete network configuration object
+  networkConfig: Record<string, NetworkConfig>
+
+  // Configuration for the currently active network
+  activeNetworkConfig: NetworkConfig
+}
+
+interface NetworkConfig {
+  // Algod node configuration
+  algod: {
+    token: string | algosdk.AlgodTokenHeader | algosdk.CustomTokenHeader
+    baseServer: string
+    port?: string | number
+    headers?: Record<string, string>
+  }
+
+  // Optional network identifiers
+  genesisHash?: string
+  genesisId?: string
+  isTestnet?: boolean
+  caipChainId?: string
+}
+```
+
+#### Methods
+
+```typescript
+interface NetworkMethods {
+  // Switch to a different network
+  setActiveNetwork(networkId: NetworkId | string): Promise<void>
+
+  // Update Algod configuration for a specific network
+  updateAlgodConfig(networkId: string, config: Partial<AlgodConfig>): void
+
+  // Reset network configuration to default values
+  resetNetworkConfig(networkId: string): void
+}
+```
+
+### Framework-Specific Usage
+
+Each framework adapter provides the same functionality with patterns optimized for that framework's ecosystem.
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useNetwork } from '@txnlab/use-wallet-react'
+
+function NetworkComponent() {
+  const {
+    activeNetwork,          // string
+    networkConfig,          // Record<string, NetworkConfig>
+    activeNetworkConfig,    // NetworkConfig
+    setActiveNetwork,       // (networkId: string) => Promise<void>
+    updateAlgodConfig,      // (networkId: string, config: Partial<AlgodConfig>) => void
+    resetNetworkConfig      // (networkId: string) => void
+  } = useNetwork()
+
+  return (
+    <div>
+      <div>Current network: {activeNetwork}</div>
+      <div>Is testnet: {activeNetworkConfig.isTestnet ? 'Yes' : 'No'}</div>
+    </div>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup>
+import { useNetwork } from '@txnlab/use-wallet-vue'
+
+const {
+  activeNetwork,          // Ref<string>
+  networkConfig,          // NetworkConfig object
+  activeNetworkConfig,   // ComputedRef<NetworkConfig>
+  setActiveNetwork,      // (networkId: string) => Promise<void>
+  updateAlgodConfig,     // (networkId: string, config: Partial<AlgodConfig>) => void
+  resetNetworkConfig     // (networkId: string) => void
+} = useNetwork()
+</script>
+
+<template>
+  <div>
+    <div>Current network: {{ activeNetwork }}</div>
+    <div>Is testnet: {{ activeNetworkConfig.isTestnet ? 'Yes' : 'No' }}</div>
+  </div>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useNetwork } from '@txnlab/use-wallet-solid'
+
+function NetworkComponent() {
+  const {
+    activeNetwork,          // () => string
+    networkConfig,          // () => Record<string, NetworkConfig>
+    activeNetworkConfig,    // () => NetworkConfig
+    setActiveNetwork,       // (networkId: string) => Promise<void>
+    updateAlgodConfig,      // (networkId: string, config: Partial<AlgodConfig>) => void
+    resetNetworkConfig      // (networkId: string) => void
+  } = useNetwork()
+
+  return (
+    <div>
+      <div>Current network: {activeNetwork()}</div>
+      <div>Is testnet: {activeNetworkConfig().isTestnet ? 'Yes' : 'No'}</div>
+    </div>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Method Details
+
+#### setActiveNetwork
+
+```typescript
+setActiveNetwork(networkId: NetworkId | string): Promise<void>
+```
+
+Switch to a different network. The method:
+
+* Creates a new Algod client for the target network
+* Updates the active network in the store
+* Persists the selection to local storage
+* Maintains active wallet sessions (if supported by the wallet)
+
+Throws an error if the network ID is not found in the configuration.
+
+#### updateAlgodConfig
+
+```typescript
+updateAlgodConfig(networkId: string, config: Partial<AlgodConfig>): void
+```
+
+Update the Algod client configuration for a specific network. The method:
+
+* Merges the new configuration with existing settings
+* Creates a new Algod client if updating the active network
+* Persists the configuration to local storage
+
+Configuration options:
+
+```typescript
+interface AlgodConfig {
+  // API token or authentication header
+  token: string | algosdk.AlgodTokenHeader | algosdk.CustomTokenHeader
+
+  // Base URL of the node
+  baseServer: string
+
+  // Optional port number
+  port?: string | number
+
+  // Optional custom headers
+  headers?: Record<string, string>
+}
+```
+
+#### resetNetworkConfig
+
+```typescript
+resetNetworkConfig(networkId: string): void
+```
+
+Reset a network's configuration to its default values. The method:
+
+* Restores the original configuration for the specified network
+* Creates a new Algod client if resetting the active network
+* Removes any custom configuration from local storage
+
+### Error Handling
+
+The methods may throw errors in these situations:
+
+* Invalid network ID passed to `setActiveNetwork`
+* Invalid configuration passed to `updateAlgodConfig`
+* Network ID not found in configuration when calling `resetNetworkConfig`
+
+### TypeScript Support
+
+Full type definitions are available for all properties and methods. The types are consistent across frameworks, with framework-specific wrappers where needed (e.g., Vue refs, Solid signals).
+
+### See Also
+
+* [Network Switching Guide](../guides/switching-networks.md) - Detailed guide on network management
+* [Runtime Node Configuration](../guides/runtime-node-configuration.md) - Guide for customizing node configurations
+* [Configuration](../getting-started/configuration.md#network-configuration) - Network configuration documentation

--- a/docs/api-reference/usewallet.md
+++ b/docs/api-reference/usewallet.md
@@ -1,0 +1,478 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# useWallet
+
+The `useWallet` adapter provides reactive access to wallet state and methods from the WalletManager. It's available for React, Vue, and SolidJS, offering a consistent API across frameworks while respecting each framework's patterns and conventions.
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useWallet } from '@txnlab/use-wallet-react'
+
+function WalletStatus() {
+  const { activeAccount, activeNetwork } = useWallet()
+
+  if (!activeAccount) {
+    return <div>No wallet connected</div>
+  }
+
+  return (
+    <div>
+      <div>Account: {activeAccount.name}</div>
+      <div>Network: {activeNetwork}</div>
+    </div>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup>
+import { useWallet } from '@txnlab/use-wallet-vue'
+
+const { activeAccount, activeNetwork } = useWallet()
+</script>
+
+<template>
+  <div v-if="!activeAccount">
+    No wallet connected
+  </div>
+  <div v-else>
+    <div>Account: {{ activeAccount.name }}</div>
+    <div>Network: {{ activeNetwork }}</div>
+  </div>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useWallet } from '@txnlab/use-wallet-solid'
+
+function WalletStatus() {
+  const { activeAccount, activeNetwork } = useWallet()
+
+  return (
+    <Show when={activeAccount()} fallback={<div>No wallet connected</div>}>
+      <div>
+        <div>Account: {activeAccount()?.name}</div>
+        <div>Network: {activeNetwork()}</div>
+      </div>
+    </Show>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Core Functionality
+
+All framework adapters provide access to the same core wallet state and methods, with framework-specific reactive wrappers.
+
+#### State Properties
+
+```typescript
+interface WalletState {
+  activeAccount: WalletAccount | null
+  activeAddress: string | null
+  activeWallet: Wallet | null
+  activeWalletAccounts: WalletAccount[] | null
+  activeWalletAddresses: string[] | null
+  algodClient: algosdk.Algodv2
+  isReady: boolean
+  wallets: Wallet[]
+}
+```
+
+#### Methods
+
+```typescript
+interface WalletMethods {
+  signTransactions<T extends algosdk.Transaction[] | Uint8Array[]>(
+    txnGroup: T | T[],
+    indexesToSign?: number[]
+  ): Promise<(Uint8Array | null)[]>
+  transactionSigner: algosdk.TransactionSigner
+}
+```
+
+### Framework-Specific Usage
+
+Each framework adapter provides the same functionality with patterns optimized for that framework's ecosystem.
+
+#### Setup
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+// App.tsx
+import { WalletProvider, WalletManager } from '@txnlab/use-wallet-react'
+
+const manager = new WalletManager({
+  // ... WalletManager config
+})
+
+function App() {
+  return (
+    <WalletProvider manager={manager}>
+      <YourComponents />
+    </WalletProvider>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+// main.ts
+import { WalletManagerPlugin } from '@txnlab/use-wallet-vue'
+import { createApp } from 'vue'
+
+const app = createApp(App)
+app.use(WalletManagerPlugin, {
+  // ... WalletManager config
+})
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+// App.tsx
+import { WalletProvider, WalletManager } from '@txnlab/use-wallet-solid'
+
+const manager = new WalletManager({
+  // ... WalletManager config
+})
+
+function App() {
+  return (
+    <WalletProvider manager={manager}>
+      <YourComponents />
+    </WalletProvider>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+See the [framework-specific guides](broken-reference) for detailed setup instructions.
+
+#### State Access
+
+{% tabs %}
+{% tab title="React" %}
+React provides state directly as properties from the hook:
+
+```tsx
+import { useWallet } from '@txnlab/use-wallet-react'
+
+function Component() {
+  const { activeAccount } = useWallet()
+
+  return (
+    <div>
+      {activeAccount && (
+        <p>Connected to {activeAccount.name}</p>
+      )}
+    </div>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+Vue returns reactive refs that can be used in templates or unwrapped with `.value`:
+
+```typescript
+<script setup lang="ts">
+import { useWallet } from '@txnlab/use-wallet-vue'
+
+const { activeAccount } = useWallet()
+
+// Access ref value in script
+console.log('Account name:', activeAccount.value?.name)
+</script>
+
+<template>
+  <div v-if="activeAccount">
+    <p>Connected to {{ activeAccount.name }}</p>
+  </div>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+Solid provides state through a getter function and signals:
+
+```tsx
+import { useWallet } from '@txnlab/use-wallet-solid'
+import { Show } from 'solid-js'
+
+function Component() {
+  const { activeAccount } = useWallet()
+  
+  return (
+    <Show when={activeAccount()} fallback={null}>
+      <p>Connected to {activeAccount()?.name}</p>
+    </Show>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+#### Complete Example
+
+Here's a complete example showing wallet connection, transaction signing, and error handling in each framework:
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useWallet, WalletId } from '@txnlab/use-wallet-react'
+
+function WalletComponent() {
+  const {
+    activeAccount,
+    activeNetwork,
+    wallets,
+    signTransactions
+  } = useWallet()
+
+  const handleConnect = async () => {
+    const pera = wallets.find((w) => w.id === WalletId.PERA)
+    if (!pera) return
+
+    try {
+      await pera.connect()
+    } catch (error) {
+      console.error('Connection failed:', error)
+    }
+  }
+
+  const handleDisconnect = async () => {
+    const pera = wallets.find((w) => w.id === WalletId.PERA)
+    if (!pera) return
+
+    try {
+      await pera.disconnect()
+    } catch (error) {
+      console.error('Disconnect failed:', error)
+    }
+  }
+
+  const handleSign = async () => {
+    try {
+      // Example: Sign a transaction
+      // See the Signing Transactions guide for complete examples
+      const signedTxns = await signTransactions([/* transactions */])
+      console.log('Transaction signed!')
+    } catch (error) {
+      console.error('Signing failed:', error)
+    }
+  }
+
+  if (!activeAccount) {
+    return <button onClick={handleConnect}>Connect Wallet</button>
+  }
+
+  return (
+    <div>
+      <p>Connected to {activeAccount.name}</p>
+      <p>Network: {activeNetwork}</p>
+      <button onClick={handleDisconnect}>Disconnect</button>
+      <button onClick={handleSign}>Sign Transaction</button>
+    </div>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { useWallet, WalletId } from '@txnlab/use-wallet-vue'
+
+const {
+  activeAccount,
+  activeNetwork,
+  wallets,
+  signTransactions
+} = useWallet()
+
+const handleConnect = async () => {
+  const pera = wallets.value.find((w) => w.id === WalletId.PERA)
+  if (!pera) return
+
+  try {
+    await pera.connect()
+  } catch (error) {
+    console.error('Connection failed:', error)
+  }
+}
+
+const handleDisconnect = async () => {
+  const pera = wallets.value.find((w) => w.id === WalletId.PERA)
+  if (!pera) return
+
+  try {
+    await pera.disconnect()
+  } catch (error) {
+    console.error('Disconnect failed:', error)
+  }
+}
+
+const handleSign = async () => {
+  try {
+    // Example: Sign a transaction
+    // See the Signing Transactions guide for complete examples
+    const signedTxns = await signTransactions([/* transactions */])
+    console.log('Transaction signed!')
+  } catch (error) {
+    console.error('Signing failed:', error)
+    }
+}
+</script>
+
+<template>
+  <div>
+    <template v-if="!activeAccount">
+      <button @click="handleConnect">Connect Wallet</button>
+    </template>
+    <template v-else>
+      <p>Connected to {{ activeAccount.name }}</p>
+      <p>Network: {{ activeNetwork }}</p>
+      <button @click="handleDisconnect">Disconnect</button>
+      <button @click="handleSign">Sign Transaction</button>
+    </template>
+  </div>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useWallet, WalletId } from '@txnlab/use-wallet-solid'
+import { Show } from 'solid-js'
+
+function WalletComponent() {
+  const {
+    activeAccount,
+    activeNetwork,
+    wallets,
+    signTransactions
+  } = useWallet()
+
+  const handleConnect = async () => {
+    const pera = wallets().find((w) => w.id === WalletId.PERA)
+    if (!pera) return
+
+    try {
+      await pera.connect()
+    } catch (error) {
+      console.error('Connection failed:', error)
+    }
+  }
+
+  const handleDisconnect = async () => {
+    const pera = wallets().find((w) => w.id === WalletId.PERA)
+    if (!pera) return
+
+    try {
+      await pera.disconnect()
+    } catch (error) {
+      console.error('Disconnect failed:', error)
+    }
+  }
+
+  const handleSign = async () => {
+    try {
+      // Example: Sign a transaction
+      // See the Signing Transactions guide for complete examples
+      const signedTxns = await signTransactions([/* transactions */])
+      console.log('Transaction signed!')
+    } catch (error) {
+      console.error('Signing failed:', error)
+    }
+  }
+
+  return (
+    <Show when={activeAccount()} fallback={<button onClick={handleConnect}>Connect Wallet</button>}>
+      <div>
+        <p>Connected to {activeAccount()?.name}</p>
+        <p>Network: {activeNetwork()}</p>
+        <button onClick={handleDisconnect}>Disconnect</button>
+        <button onClick={handleSign}>Sign Transaction</button>
+      </div>
+    </Show>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Framework-Specific Considerations
+
+#### React
+
+* Uses React's Context API for state management
+* Compatible with React 16.8+ (requires Hooks)
+
+#### Vue
+
+* Integrated with Vue's reactivity system using `ref` and `computed`
+* Can be used in Options API via `inject`
+* State properties are automatically unwrapped in templates
+* Compatible with Vue 3.x
+
+#### SolidJS
+
+* Uses Solid's fine-grained reactivity system
+* State values are accessed via getter functions for reactivity
+* Compatible with Solid 1.x
+
+### Error Handling
+
+By design, wallet operations propagate errors to the consuming application. This allows applications to handle user feedback in a way that best fits their UI/UX patterns, such as displaying toasts, modals, or in-line error messages.
+
+Always wrap async operations in try/catch blocks:
+
+```typescript
+try {
+  await wallet.connect()
+} catch (error) {
+  // Handle connection error (e.g., show toast notification)
+  console.error('Connection failed:', error)
+}
+
+try {
+  const signedTxns = await signTransactions([/* transactions */])
+} catch (error) {
+  // Handle signing error (e.g., show modal with error details)
+  console.error('Signing failed:', error)
+}
+```
+
+See the [Connect Wallet Menu](../guides/connect-wallet-menu.md) and [Signing Transactions](../guides/signing-transactions.md) guide for more detailed error handling examples.
+
+### TypeScript Support
+
+All framework adapters are written in TypeScript and provide full type definitions. State and method types are consistent across frameworks, with framework-specific wrappers where needed (e.g., Vue refs, Solid signals).
+
+### See Also
+
+* [WalletManager](walletmanager.md) - Core functionality documentation
+* [Framework Adapters](broken-reference) - Detailed setup guides
+* [Example Projects](../resources/example-projects.md) - Complete examples in each framework

--- a/docs/api-reference/walletmanager.md
+++ b/docs/api-reference/walletmanager.md
@@ -1,0 +1,334 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# WalletManager
+
+The WalletManager class is the core of use-wallet, responsible for managing wallet connections, network configurations, and state persistence. It provides a framework-agnostic API that serves as the foundation for the React, Vue, and SolidJS adapters.
+
+### Constructor
+
+```typescript
+constructor(config?: WalletManagerConfig)
+```
+
+Creates a new WalletManager instance with optional configuration.
+
+#### Parameters
+
+```typescript
+interface WalletManagerConfig {
+  wallets?: SupportedWallet[]
+  networks?: Record<string, NetworkConfig>
+  defaultNetwork?: string
+  options?: WalletManagerOptions
+}
+```
+
+* `wallets` - Array of wallet providers to enable (see [Configuration](../getting-started/configuration.md#configuring-wallets) for details)
+* `networks` - Custom network configurations (optional, defaults provided)
+* `defaultNetwork` - Network to use on first load (optional, defaults to 'testnet')
+* `options` - Additional configuration options (optional)
+
+```typescript
+interface WalletManagerOptions {
+  resetNetwork?: boolean    // Reset to default network on page load
+  debug?: boolean           // Enable debug logging
+  logLevel?: LogLevel       // Set specific log level
+}
+```
+
+#### Example
+
+```typescript
+import { 
+  WalletManager, 
+  WalletId,
+  NetworkId,
+  LogLevel 
+} from '@txnlab/use-wallet'
+
+const manager = new WalletManager({
+  // Configure wallets
+  wallets: [
+    WalletId.PERA,
+    {
+      id: WalletId.WALLETCONNECT,
+      options: {
+        projectId: 'your-project-id'
+      }
+    }
+  ],
+
+  // Configure networks
+  networks: {
+    algod: {
+      baseServer: 'https://testnet-api.4160.nodely.dev',
+      port: '443',
+      token: ''
+    }
+  },
+  defaultNetwork: NetworkId.TESTNET, // or just 'testnet'
+
+  // Additional options
+  options: {
+    debug: true,
+    logLevel: LogLevel.INFO
+  }
+})
+```
+
+### Properties
+
+#### algodClient
+
+```typescript
+algodClient: algosdk.Algodv2
+```
+
+Algod client instance for the active network. Updates automatically when switching networks.
+
+#### activeNetwork
+
+```typescript
+activeNetwork: string
+```
+
+Currently active network identifier (e.g., 'mainnet', 'testnet').
+
+#### networkConfig
+
+```typescript
+networkConfig: Record<string, NetworkConfig>
+```
+
+Complete network configuration object containing settings for all networks.
+
+#### activeNetworkConfig
+
+```typescript
+activeNetworkConfig: NetworkConfig
+```
+
+Configuration object for the currently active network.
+
+#### wallets
+
+```typescript
+wallets: BaseWallet[]
+```
+
+Array of initialized wallet provider instances.
+
+#### activeWallet
+
+```typescript
+activeWallet: BaseWallet | null
+```
+
+Currently active wallet provider instance, if any.
+
+#### activeWalletAccounts
+
+```typescript
+activeWalletAccounts: WalletAccount[] | null
+```
+
+Array of accounts available in the active wallet.
+
+#### activeWalletAddresses
+
+```typescript
+activeWalletAddresses: string[] | null
+```
+
+Array of addresses available in the active wallet.
+
+#### activeAccount
+
+```typescript
+activeAccount: WalletAccount | null
+```
+
+Currently active account in the active wallet.
+
+#### activeAddress
+
+```typescript
+activeAddress: string | null
+```
+
+Address of the currently active account.
+
+#### store
+
+```typescript
+store: Store<State>
+```
+
+[TanStack Store](https://tanstack.com/store) instance containing wallet state. Used internally by framework adapters.
+
+#### isReady
+
+```typescript
+isReady: boolean
+```
+
+Whether all wallet providers have completed initialization.
+
+### Methods
+
+#### getWallet
+
+```typescript
+getWallet(walletId: WalletId): BaseWallet | undefined
+```
+
+Get a specific wallet provider instance by ID.
+
+#### resumeSessions
+
+```typescript
+resumeSessions(): Promise<void>
+```
+
+Resume previously connected wallet sessions. Called automatically by framework adapters.
+
+#### disconnect
+
+```typescript
+disconnect(): Promise<void>
+```
+
+Disconnect all connected wallets.
+
+#### setActiveNetwork
+
+```typescript
+setActiveNetwork(networkId: NetworkId | string): Promise<void>
+```
+
+Switch to a different network.
+
+#### updateAlgodConfig
+
+```typescript
+updateAlgodConfig(networkId: string, config: Partial<AlgodConfig>): void
+```
+
+Update Algod client configuration for a specific network.
+
+#### resetNetworkConfig
+
+```typescript
+resetNetworkConfig(networkId: string): void
+```
+
+Reset network configuration to default values.
+
+#### signTransactions
+
+```typescript
+signTransactions<T extends algosdk.Transaction[] | Uint8Array[]>(
+  txnGroup: T | T[],
+  indexesToSign?: number[]
+): Promise<(Uint8Array | null)[]>
+```
+
+Sign transactions using the active wallet. Delegates to the active wallet's `signTransactions` method.
+
+#### transactionSigner
+
+```typescript
+transactionSigner: algosdk.TransactionSigner
+```
+
+Typed transaction signer for use with [AtomicTransactionComposer](https://developer.algorand.org/docs/get-details/atc/). Delegates to the active wallet's `transactionSigner` method.
+
+### Events
+
+The WalletManager includes several event handlers that can be used to track state changes:
+
+#### subscribe
+
+```typescript
+subscribe(callback: (state: State) => void): () => void
+```
+
+Subscribe to state changes. Returns an unsubscribe function.
+
+```typescript
+interface State {
+  wallets: WalletStateMap
+  activeWallet: WalletId | null
+  activeNetwork: string
+  algodClient: algosdk.Algodv2
+  managerStatus: ManagerStatus
+  networkConfig: Record<string, NetworkConfig>
+}
+```
+
+#### Example
+
+```typescript
+const unsubscribe = manager.subscribe((state) => {
+  console.log('Active wallet:', state.activeWallet)
+  console.log('Active network:', state.activeNetwork)
+})
+
+// Later
+unsubscribe()
+```
+
+### Framework Integration
+
+The WalletManager can be used directly with the `subscribe` method to implement custom reactivity, or through one of the official [framework adapters](broken-reference) that provide hooks/composables for common frameworks:
+
+```tsx
+// React
+import { WalletProvider } from '@txnlab/use-wallet-react'
+
+function App() {
+  return (
+    <WalletProvider manager={manager}>
+      <YourApp />
+    </WalletProvider>
+  )
+}
+
+// Vue
+import { WalletManagerPlugin } from '@txnlab/use-wallet-vue'
+import { createApp } from 'vue'
+
+const app = createApp(App)
+app.use(WalletManagerPlugin, managerConfig)
+
+// Solid
+import { WalletProvider } from '@txnlab/use-wallet-solid'
+
+function App() {
+  return (
+    <WalletProvider manager={manager}>
+      <YourApp />
+    </WalletProvider>
+  )
+}
+```
+
+See these guides for more information:
+
+* [React Integration](../framework/react.md)
+* [Vue Integration](../framework/vue.md)
+* [SolidJS Integration](../framework/solidjs.md)
+
+The WalletManager's framework-agnostic design makes it possible to create adapters for other frameworks. Community contributions for additional framework adapters (e.g., Svelte, Angular) are welcome!

--- a/docs/framework/react.md
+++ b/docs/framework/react.md
@@ -1,0 +1,140 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# React
+
+The React adapter (`@txnlab/use-wallet-react`) provides a set of hooks and components for integrating use-wallet into React applications. This guide covers how to set up the adapter and use its features effectively.
+
+### Setup
+
+After installing the package and any required wallet dependencies (see [Installation](../getting-started/installation.md)) and [configuring your WalletManager](../getting-started/configuration.md), wrap your application with the `WalletProvider`:
+
+```tsx
+import {
+  WalletProvider,
+  WalletManager,
+  NetworkId,
+} from '@txnlab/use-wallet-react'
+
+// Create manager instance (see Configuration guide)
+const manager = new WalletManager({
+  wallets: [...],
+  networks: {...},
+  defaultNetwork: NetworkId.TESTNET // or just 'testnet'
+})
+
+function App() {
+  return (
+    <WalletProvider manager={manager}>
+      <YourApp />
+    </WalletProvider>
+  )
+}
+```
+
+The provider makes the wallet functionality available throughout your application via React hooks.
+
+### Using the Hooks
+
+The React adapter provides two hooks for accessing wallet functionality. In v4.0.0, network-related features were moved from `useWallet` into a new `useNetwork` hook to provide better separation of concerns:
+
+#### useWallet
+
+The `useWallet` hook provides access to wallet management features. Here's an example showing some commonly used values:
+
+```tsx
+import { useWallet } from '@txnlab/use-wallet-react'
+
+function WalletInfo() {
+  const { 
+    wallets,             // List of available wallets
+    activeWallet,        // Currently active wallet
+    activeAddress,       // Address of active account
+    isReady,             // Whether all wallet providers have finished initialization
+    signTransactions,    // Function to sign transactions
+    transactionSigner,   // Typed signer for ATC and Algokit Utils
+    algodClient          // Algod client for active network
+  } = useWallet()
+
+  // Checking isReady is important, especially in SSR environments
+  // to prevent hydration errors
+  if (!isReady) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <div>
+      {activeAddress ? (
+        <div>Connected: {activeAddress}</div>
+      ) : (
+        <div>Not connected</div>
+      )}
+    </div>
+  )
+}
+```
+
+For a complete list of all available properties and methods, see the [useWallet API Reference](../api-reference/usewallet.md).
+
+#### useNetwork
+
+The `useNetwork` hook serves two primary functions: managing the active network and supporting runtime node configuration.
+
+```tsx
+import { useNetwork } from '@txnlab/use-wallet-react'
+
+function NetworkSelector() {
+  const {
+    // Active network management
+    activeNetwork,         // Currently active network
+    setActiveNetwork,      // Function to change networks
+    
+    // Runtime node configuration
+    networkConfig,         // Complete configuration for all networks
+    activeNetworkConfig,   // Configuration for active network only
+    updateAlgodConfig,     // Update a network's Algod configuration
+    resetNetworkConfig     // Reset network config to initial values
+  } = useNetwork()
+
+  return (
+    <div>
+      {/* Example: Network selector dropdown */}
+      <select
+        value={activeNetwork}
+        onChange={(e) => setActiveNetwork(e.target.value)}
+      >
+        {Object.keys(networkConfig).map((networkId) => (
+          <option key={networkId} value={networkId}>
+            {networkId}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+```
+
+Active network management (previously part of `useWallet`) enables users to switch between different networks.
+
+Runtime node configuration, introduced in v4.0.0, enables users to override the application's default node settings and connect to any Algorand node. See the [Runtime Node Configuration](../guides/runtime-node-configuration.md) guide for details about implementing this feature.
+
+For a complete list of all available properties and methods, see the [useNetwork API Reference](../api-reference/usenetwork.md).
+
+### Next Steps
+
+* Check out the [Connect Wallet Menu](../guides/connect-wallet-menu.md) guide for creating a simple wallet connection interface
+* Learn about transaction signing patterns in the [Signing Transactions](../guides/signing-transactions.md) guide
+* Explore network features in the [Switching Networks](../guides/switching-networks.md) and [Runtime Node Configuration](../guides/runtime-node-configuration.md) guides
+* Read the [API Reference](broken-reference) for detailed documentation of the library's main exports
+* Browse [Example Projects](../resources/example-projects.md) for working implementations in Vite (React) and Next.js

--- a/docs/framework/solidjs.md
+++ b/docs/framework/solidjs.md
@@ -1,0 +1,143 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# SolidJS
+
+The SolidJS adapter (`@txnlab/use-wallet-solid`) provides primitives and components for integrating use-wallet into Solid applications. This guide covers how to set up the adapter and use its features effectively.
+
+### Setup
+
+After installing the package and any required wallet dependencies (see [Installation](../getting-started/installation.md)) and [configuring your WalletManager](../getting-started/configuration.md), wrap your application with the `WalletProvider`:
+
+```tsx
+import {
+  WalletProvider,
+  WalletManager,
+  NetworkId,
+} from '@txnlab/use-wallet-solid'
+
+// Create manager instance (see Configuration guide)
+const manager = new WalletManager({
+  wallets: [...],
+  networks: {...},
+  defaultNetwork: NetworkId.TESTNET
+})
+
+function App() {
+  return (
+    <WalletProvider manager={manager}>
+      <YourApp />
+    </WalletProvider>
+  )
+}
+```
+
+The provider makes the wallet functionality available throughout your application via Solid's primitives.
+
+### Using the Primitives
+
+The Solid adapter provides two primitives for accessing wallet functionality. In v4.0.0, network-related features were moved from `useWallet` into a new `useNetwork` primitive to provide better separation of concerns:
+
+#### useWallet
+
+The `useWallet` primitive provides access to wallet management features. Here's an example showing some commonly used values:
+
+```tsx
+import { useWallet } from '@txnlab/use-wallet-solid'
+
+function WalletInfo() {
+  const { 
+    wallets,             // List of available wallets
+    activeWallet,        // Currently active wallet (signal)
+    activeAccount,       // Active account in active wallet (signal)
+    activeAddress,       // Address of active account (signal)
+    isReady,             // Whether all wallet providers have finished initialization (signal)
+    signTransactions,    // Function to sign transactions
+    transactionSigner,   // Typed signer for ATC and Algokit Utils
+    algodClient          // Algod client for active network (signal)
+  } = useWallet()
+
+  return (
+    <Show
+      when={isReady()}
+      fallback={<div>Loading...</div>}
+    >
+      <Show
+        when={activeAddress()}
+        fallback={<div>Not connected</div>}
+      >
+        <div>Connected: {activeAddress()}</div>
+      </Show>
+    </Show>
+  )
+}
+```
+
+Note that unlike [React's hooks](react.md#using-the-hooks), Solid's primitives return signals (functions) that need to be called to access their current value. The values are automatically tracked and will trigger reactivity when they change.
+
+For a complete list of all available properties and methods, see the [useWallet API Reference](../api-reference/usewallet.md).
+
+#### useNetwork
+
+The `useNetwork` primitive serves two primary functions: managing the active network and supporting runtime node configuration.
+
+```tsx
+import { useNetwork } from '@txnlab/use-wallet-solid'
+
+function NetworkSelector() {
+  const {
+    // Active network management
+    activeNetwork,         // Currently active network (signal)
+    setActiveNetwork,      // Function to change networks
+    
+    // Runtime node configuration
+    networkConfig,         // Complete configuration for all networks
+    activeNetworkConfig,   // Configuration for active network only (signal)
+    updateAlgodConfig,     // Update a network's Algod configuration
+    resetNetworkConfig     // Reset network config to initial values
+  } = useNetwork()
+
+  return (
+    <div>
+      {/* Example: Network selector dropdown */}
+      <select
+        value={activeNetwork()}
+        onChange={(e) => setActiveNetwork(e.currentTarget.value)}
+      >
+        <For each={Object.keys(networkConfig())}>
+          {(networkId) => (
+            <option value={networkId}>
+              {networkId}
+            </option>
+          )}
+        </For>
+      </select>
+    </div>
+  )
+}
+```
+
+Active network management (previously part of `useWallet`) enables users to switch between different networks.
+
+Runtime node configuration, introduced in v4.0.0, enables users to override the application's default node settings and connect to any Algorand node. See the [Runtime Node Configuration](../guides/runtime-node-configuration.md) guide for details about implementing this feature.
+
+For a complete list of all available properties and methods, see the [useNetwork API Reference](../api-reference/usenetwork.md).
+
+### Next Steps
+
+* Check out the [Connect Wallet Menu](../guides/connect-wallet-menu.md) guide for creating a simple wallet connection interface
+* Learn about transaction signing patterns in the [Signing Transactions](../guides/signing-transactions.md) guide
+* Explore network features in the [Switching Networks](../guides/switching-networks.md) and [Runtime Node Configuration](../guides/runtime-node-configuration.md) guides
+* Read the [API Reference](broken-reference) for detailed documentation of the library's main exports
+* Browse [Example Projects](../resources/example-projects.md) for a working implementation in Vite (Solid)

--- a/docs/framework/vue.md
+++ b/docs/framework/vue.md
@@ -1,0 +1,135 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Vue
+
+The Vue adapter (`@txnlab/use-wallet-vue`) provides a plugin and composables for integrating use-wallet into Vue applications. This guide covers how to set up the adapter and use its features effectively.
+
+### Setup
+
+After installing the package, any required wallet dependencies (see [Installation](../getting-started/installation.md)), and [configuring your WalletManager](../getting-started/configuration.md), install the WalletManager plugin in your Vue application:
+
+```typescript
+// main.ts
+import { createApp } from 'vue'
+import { WalletManagerPlugin, NetworkId } from '@txnlab/use-wallet-vue'
+import App from './App.vue'
+
+const app = createApp(App)
+
+app.use(WalletManagerPlugin, {
+  wallets: [...],
+  networks: {...},
+  defaultNetwork: NetworkId.TESTNET
+})
+
+app.mount('#app')
+```
+
+The plugin makes the wallet functionality available throughout your application via Vue composables.
+
+### Using the Composables
+
+The Vue adapter provides two composables for accessing wallet functionality. In v4.0.0, network-related features were moved from `useWallet` into a new `useNetwork` composable to provide better separation of concerns:
+
+#### useWallet
+
+The `useWallet` composable provides access to wallet management features. Here's an example showing some commonly used values:
+
+```typescript
+<script setup lang="ts">
+import { useWallet } from '@txnlab/use-wallet-vue'
+
+const { 
+  wallets,             // List of available wallets
+  activeWallet,        // Currently active wallet
+  activeAccount,       // Active account in active wallet
+  activeAddress,       // Address of active account
+  isReady,             // Whether all wallet providers have finished initialization
+  signTransactions,    // Function to sign transactions
+  transactionSigner,   // Typed signer for ATC and Algokit Utils
+  algodClient          // Algod client for active network
+} = useWallet()
+</script>
+
+<template>
+  <div>
+    <div v-if="!isReady">Loading...</div>
+    <div v-else>
+      <div v-if="activeAddress">
+        Connected: {{ activeAddress }}
+      </div>
+      <div v-else>
+        Not connected
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+For a complete list of all available properties and methods, see the [useWallet API Reference](../api-reference/usewallet.md).
+
+#### useNetwork
+
+The `useNetwork` composable serves two primary functions: managing the active network and supporting runtime node configuration.
+
+```typescript
+<script setup lang="ts">
+import { useNetwork } from '@txnlab/use-wallet-vue'
+
+const {
+  // Active network management
+  activeNetwork,         // Currently active network
+  setActiveNetwork,      // Function to change networks
+  
+  // Runtime node configuration
+  networkConfig,         // Complete configuration for all networks
+  activeNetworkConfig,   // Configuration for active network only
+  updateAlgodConfig,     // Update a network's Algod configuration
+  resetNetworkConfig     // Reset network config to initial values
+} = useNetwork()
+</script>
+
+<template>
+  <div>
+    <!-- Example: Network selector dropdown -->
+    <select
+      :value="activeNetwork"
+      @change="(e) => setActiveNetwork(e.target.value)"
+    >
+      <option
+        v-for="networkId in Object.keys(networkConfig)"
+        :key="networkId"
+        :value="networkId"
+      >
+        {{ networkId }}
+      </option>
+    </select>
+  </div>
+</template>
+```
+
+Active network management (previously part of `useWallet`) enables users to switch between different networks.
+
+Runtime node configuration, introduced in v4.0.0, enables users to override the application's default node settings and connect to any Algorand node. See the [Runtime Node Configuration](../guides/runtime-node-configuration.md) guide for details about implementing this feature.
+
+For a complete list of all available properties and methods, see the [useNetwork API Reference](../api-reference/usenetwork.md).
+
+### Next Steps
+
+* Check out the [Connect Wallet Menu](../guides/connect-wallet-menu.md) guide for creating a simple wallet connection interface
+* Learn about transaction signing patterns in the [Signing Transactions](../guides/signing-transactions.md) guide
+* Explore network features in the [Switching Networks](../guides/switching-networks.md) and [Runtime Node Configuration](../guides/runtime-node-configuration.md) guides
+* Read the [API Reference](broken-reference) for detailed documentation of the library's main exports
+* Browse [Example Projects](../resources/example-projects.md) for working implementations in Vite (Vue) and Nuxt

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,410 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Configuration
+
+The `WalletManager` class is the core of use-wallet, responsible for managing wallet connections and network configurations. This guide covers how to configure the WalletManager for your application.
+
+### Basic Configuration
+
+The `WalletManager` constructor accepts a configuration object with the following structure:
+
+```typescript
+interface WalletManagerConfig {
+  wallets?: SupportedWallet[]      // Array of wallets to enable
+  networks?: Record<string, NetworkConfig>  // Custom network configurations
+  defaultNetwork?: string          // Network to use by default
+  options?: WalletManagerOptions   // Additional options
+}
+```
+
+Here's a basic example:
+
+```typescript
+import { WalletManager, WalletId, NetworkId } from '@txnlab/use-wallet'
+
+const manager = new WalletManager({
+  wallets: [WalletId.PERA, WalletId.DEFLY],
+  defaultNetwork: NetworkId.MAINNET // or just 'mainnet'
+})
+```
+
+### Configuring Wallets
+
+The `wallets` array determines which wallets will be available in your application. For each wallet, you can provide either:
+
+* Just the wallet identifier (for wallets with no required options)
+* A configuration object specifying required options and optional customizations
+
+Some wallets require specific options to be provided. TypeScript will show errors if these required options are omitted or if you try to use just the identifier.
+
+Here's an example showing common wallet configurations, including popular production wallets and those that require specific options:
+
+```typescript
+import {
+  WalletManager,
+  WalletId
+} from '@txnlab/use-wallet'
+
+const manager = new WalletManager({
+  wallets: [
+    // Wallets that can be used without configuration
+    WalletId.PERA,
+    WalletId.EXODUS,
+    WalletId.KIBISIS,
+    
+    // Example of a wallet with optional customizations
+    {
+      id: WalletId.DEFLY,
+      options: {
+        shouldShowSignTxnToast: false
+      },
+      metadata: {
+        name: 'Custom Defly Name',
+        icon: '/path/to/custom-icon.svg'
+      }
+    },
+    
+    // Wallets that require specific options
+    {
+      id: WalletId.WALLETCONNECT,
+      options: {
+        projectId: '<REOWN_PROJECT_ID>'  // Required
+      }
+    },
+    {
+      id: WalletId.MAGIC,
+      options: {
+        apiKey: '<MAGIC_API_KEY>'  // Required
+      }
+    },
+    {
+      id: WalletId.LUTE,
+      options: {
+        siteName: '<YOUR_SITE_NAME>'  // Required
+      }
+    },
+    {
+      id: WalletId.BIATEC,
+      options: {
+        projectId: '<REOWN_PROJECT_ID>'  // Required
+      }
+    }
+  ]
+})
+```
+
+See the [Supported Wallets](supported-wallets.md) page for details about all wallets available in the library, including those used for development and testing.
+
+### Network Configuration
+
+By default, use-wallet comes with configurations for:
+
+* MainNet
+* TestNet
+* BetaNet
+* LocalNet (for development)
+
+For all public Algorand networks (MainNet, TestNet, BetaNet), the default configurations use [Nodely's free public API](https://nodely.io/docs/free/start/), so you don't need to configure network settings to get started.
+
+{% hint style="info" %}
+[Nodely](https://nodely.io/) provides their public API free of charge with [certain usage requirements](https://nodely.io/docs/free/policy/). For production applications with significant traffic, consider either:
+
+* Using Nodely's [unlimited tier](https://nodely.io/docs/unlimited/start/) services
+* Connecting to your own node
+{% endhint %}
+
+If you need to use a different node or connect to other AVM-compatible networks, you can customize the network configuration in one of two ways:
+
+#### Direct Network Configuration
+
+For applications using a single network, you can provide the configuration directly:
+
+```typescript
+import { WalletManager } from '@txnlab/use-wallet'
+
+// Example using environment variables
+const network = process.env.ALGOD_NETWORK || 'testnet'
+
+const manager = new WalletManager({
+  wallets: [...],
+  defaultNetwork: network,
+  networks: {
+    [network]: {
+      algod: {
+        baseServer: process.env.ALGOD_SERVER!,
+        port: process.env.ALGOD_PORT!,
+        token: process.env.ALGOD_TOKEN!,
+      }
+    }
+  }
+})
+```
+
+This approach is particularly useful when the network configuration comes from environment variables.
+
+#### Using NetworkConfigBuilder
+
+For applications that support multiple networks with custom configurations, the `NetworkConfigBuilder` class provides a convenient, fluent interface:
+
+```typescript
+import { 
+  WalletManager,
+  NetworkConfigBuilder,
+  NetworkId
+} from '@txnlab/use-wallet'
+
+// Customize Algorand networks
+const networks = new NetworkConfigBuilder()
+  .testnet({
+    algod: {
+      baseServer: 'https://your-testnet-node.com',
+      port: '443',
+      token: 'your-token'
+    }
+  })
+  .mainnet({
+    algod: {
+      baseServer: 'https://your-mainnet-node.com',
+      port: '443',
+      token: 'your-token'
+    }
+  })
+  .build()
+
+const manager = new WalletManager({
+  wallets: [...],
+  networks,
+  defaultNetwork: NetworkId.TESTNET // or just 'testnet'
+})
+```
+
+#### Custom Networks
+
+To add configurations for other AVM-compatible networks, use the `addNetwork` method:
+
+```typescript
+import { 
+  WalletManager,
+  NetworkConfigBuilder
+} from '@txnlab/use-wallet'
+
+// Add other AVM-compatible networks
+const networks = new NetworkConfigBuilder()
+  .addNetwork('voi-mainnet', {
+    algod: {
+      token: '',
+      baseServer: 'https://mainnet-api.voi.nodely.dev',
+      port: ''
+    },
+    isTestnet: false,
+    genesisHash: 'r20fSQI8gWe/kFZziNonSPCXLwcQmH/nxROvnnueWOk=',
+    genesisId: 'voimain-v1.0',
+    caipChainId: 'algorand:r20fSQI8gWe_kFZziNonSPCXLwcQmH_n'
+  })
+  .addNetwork('voi-testnet', {
+    algod: {
+      token: '',
+      baseServer: 'https://testnet-api.voi.nodely.dev',
+      port: ''
+    },
+    isTestnet: true,
+    genesisHash: 'IXnoWtviVVJW5LGivNFc0Dq14V3kqaXuK2u5OQrdVZo=',
+    genesisId: 'voitest-v1'
+  })
+  .build()
+
+const manager = new WalletManager({
+  wallets: [...],
+  networks,
+  defaultNetwork: 'voi-testnet'
+})
+```
+
+When adding a custom network, in addition to setting the Algod configuration (`token`, `baseServer`, `port`), you should also set the [optional properties](configuration.md#optional-properties) that are used by the specific wallet providers you want to support.
+
+### Network Configuration Details
+
+Each network configuration consists of required Algod client settings and optional network identifiers. For the public Algorand networks (MainNet, TestNet, BetaNet), use-wallet provides default configurations with all necessary properties pre-configured.
+
+Most users will only need to customize the Algod client settings:
+
+```typescript
+interface NetworkConfig {
+  // Required: Algod client configuration
+  algod: {
+    token: string | algosdk.AlgodTokenHeader | algosdk.CustomTokenHeader
+    baseServer: string
+    port?: string | number
+    headers?: Record<string, string>
+  }
+  
+  // Optional: Network identifiers (only needed for custom networks)
+  genesisHash?: string    // Network genesis hash
+  genesisId?: string      // Network genesis ID
+  isTestnet?: boolean     // Whether network is a testnet
+  caipChainId?: string    // CAIP-2 chain ID for WalletConnect
+}
+```
+
+#### Algod Configuration
+
+The `token` property can be provided in several formats:
+
+```typescript
+// Simple string token
+token: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+// AlgodTokenHeader
+token: { 'X-Algo-API-Token': 'your-token' }
+
+// CustomTokenHeader
+token: { 'Custom-Header-Name': 'your-token' }
+```
+
+Most applications will use either a string token or an `AlgodTokenHeader`.
+
+The remaining Algod client settings include:
+
+* `baseServer`: The URL of the Algod node you want to connect to.
+* `port`: The port number the Algod node is listening on. Common values include '443' for HTTPS connections and '4001' for local development. Some hosting providers may use different ports.
+* `headers`: Optional additional HTTP headers to include with requests.
+
+{% hint style="info" %}
+**Note:** Starting with v4.0.0, use-wallet supports user-customizable node settings at runtime. If your application implements the necessary UI components, users can override the configured Algod settings to connect to a different node.
+
+See the [Runtime Node Configuration](../guides/runtime-node-configuration.md) guide for details.
+{% endhint %}
+
+#### Optional Properties
+
+The optional network properties are only needed when defining [custom networks](configuration.md#custom-networks). They serve specific purposes for different wallet providers:
+
+* `genesisHash`: Required by [Kibisis Wallet](supported-wallets.md#kibisis) during initialization
+* `genesisId`: Required by [Lute Wallet](supported-wallets.md#lute-wallet) during initialization
+* `isTestnet`: Used by the [Mnemonic Wallet](supported-wallets.md#mnemonic-wallet) provider (which only works on test networks for security)
+* `caipChainId`: Required by [WalletConnect](supported-wallets.md#walletconnect) when connecting and signing transactions (see ChainAgnostic [CAIP-2 specification](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md))
+
+For example, when adding a custom network:
+
+```typescript
+const networks = {
+  'custom-network': {
+    algod: {
+      token: 'your-token',
+      baseServer: 'https://custom-node.example.com',
+      port: '443'
+    },
+    // Optional properties needed for custom networks
+    genesisHash: 'your-network-genesis-hash',
+    genesisId: 'custom-net-v1.0',
+    isTestnet: true,
+    caipChainId: 'algorand:your-network-identifier'
+  }
+}
+```
+
+If any of these optional properties are missing when required by a wallet, use-wallet will attempt to fetch them from the node (for `genesisHash` and `genesisId`) or use sensible defaults (setting `isTestnet` to false).
+
+However, providing them in your configuration can save network requests and ensure proper wallet functionality.
+
+### Manager Options
+
+The optional `options` object allows you to configure the WalletManager's behavior:
+
+```typescript
+import { 
+  WalletManager,
+  LogLevel 
+} from '@txnlab/use-wallet'
+
+const manager = new WalletManager({
+  // ...
+  options: {
+    // Reset to default network on page load
+    resetNetwork: true,
+    
+    // Enable debug logging
+    debug: true,
+    
+    // Or set a specific log level
+    logLevel: LogLevel.INFO
+  }
+})
+```
+
+### Complete Example
+
+Here's a complete configuration example combining all the elements:
+
+```typescript
+import { 
+  WalletManager,
+  WalletId,
+  NetworkConfigBuilder,
+  NetworkId,
+  LogLevel
+} from '@txnlab/use-wallet'
+
+// Configure networks
+const networks = new NetworkConfigBuilder()
+  .testnet({
+    algod: {
+      baseServer: 'https://testnet-api.algonode.cloud',
+      port: '443',
+      token: ''
+    }
+  })
+  .localnet({
+    algod: {
+      baseServer: 'http://localhost',
+      port: '4001',
+      token: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    }
+  })
+  .build()
+
+// Create manager instance
+const manager = new WalletManager({
+  // Configure wallets
+  wallets: [
+    WalletId.DEFLY,
+    {
+      id: WalletId.PERA,
+      options: {
+        shouldShowSignTxnToast: false
+      }
+    }
+  ],
+  
+  // Use custom network configurations
+  networks,
+  defaultNetwork: NetworkId.TESTNET,
+  
+  // Set manager options
+  options: {
+    debug: true,
+    logLevel: LogLevel.INFO,
+    resetNetwork: false
+  }
+})
+```
+
+### Next Steps
+
+The configuration options described in this guide apply to all framework adapters. However, each framework has its own specific setup steps for integrating the configured `WalletManager` into your application. See the framework-specific guides for detailed setup instructions:
+
+* [React](../framework/react.md)
+* [Vue](../framework/vue.md)
+* [SolidJS](../framework/solidjs.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,382 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Installation
+
+### Requirements
+
+* `algosdk` v3
+* Environment with support for dynamic imports (e.g., modern build tools like Vite, Next.js, or Webpack 5+)
+
+### Install Package
+
+Use-wallet is available as a core library and as framework-specific adapters for React, Vue, and SolidJS. Choose the appropriate package for your project's framework.
+
+#### React
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @txnlab/use-wallet-react
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @txnlab/use-wallet-react
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @txnlab/use-wallet-react
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @txnlab/use-wallet-react
+```
+{% endtab %}
+{% endtabs %}
+
+#### Vue
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @txnlab/use-wallet-vue
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @txnlab/use-wallet-vue
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @txnlab/use-wallet-vue
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @txnlab/use-wallet-vue
+```
+{% endtab %}
+{% endtabs %}
+
+#### SolidJS
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @txnlab/use-wallet-solid
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @txnlab/use-wallet-solid
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @txnlab/use-wallet-solid
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @txnlab/use-wallet-solid
+```
+{% endtab %}
+{% endtabs %}
+
+#### Core Library
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @txnlab/use-wallet
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @txnlab/use-wallet
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @txnlab/use-wallet
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @txnlab/use-wallet
+```
+{% endtab %}
+{% endtabs %}
+
+### Install Dependencies
+
+Some [supported wallet providers](supported-wallets.md) require additional packages to be installed. You only need to install the packages for wallets that you plan to support in your application.
+
+#### Pera Wallet
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @perawallet/connect
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @perawallet/connect
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @perawallet/connect
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @perawallet/connect
+```
+{% endtab %}
+{% endtabs %}
+
+#### Defly Wallet
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @blockshake/defly-connect
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @blockshake/defly-connect
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @blockshake/defly-connect
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @blockshake/defly-connect
+```
+{% endtab %}
+{% endtabs %}
+
+#### Defly Wallet (Web)
+
+{% hint style="warning" %}
+The Defly Web Wallet is currently in beta.
+{% endhint %}
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @agoralabs-sh/avm-web-provider
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @agoralabs-sh/avm-web-provider
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @agoralabs-sh/avm-web-provider
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @agoralabs-sh/avm-web-provider
+```
+{% endtab %}
+{% endtabs %}
+
+#### WalletConnect
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @walletconnect/sign-client @walletconnect/modal
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @walletconnect/sign-client @walletconnect/modal
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @walletconnect/sign-client @walletconnect/modal
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @walletconnect/sign-client @walletconnect/modal
+```
+{% endtab %}
+{% endtabs %}
+
+#### Lute Wallet
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install lute-connect
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add lute-connect
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add lute-connect
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add lute-connect
+```
+{% endtab %}
+{% endtabs %}
+
+#### Kibisis
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install @agoralabs-sh/avm-web-provider
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add @agoralabs-sh/avm-web-provider
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add @agoralabs-sh/avm-web-provider
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add @agoralabs-sh/avm-web-provider
+```
+{% endtab %}
+{% endtabs %}
+
+#### Magic Auth
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm install magic-sdk @magic-ext/algorand
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add magic-sdk @magic-ext/algorand
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm add magic-sdk @magic-ext/algorand
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun add magic-sdk @magic-ext/algorand
+```
+{% endtab %}
+{% endtabs %}
+
+### Webpack Configuration
+
+When using this library in a project that uses Webpack as its build tool, you may encounter "module not found" errors for optional dependencies of wallets you choose not to support. To resolve this, you can use the `webpackFallback` export.
+
+Here's how to configure Webpack to handle these optional dependencies:
+
+```javascript
+// webpack.config.js
+import { webpackFallback } from '@txnlab/use-wallet' // exported by all packages
+
+export default {
+  // ... other webpack configuration
+  resolve: {
+    fallback: {
+      ...webpackFallback
+    }
+  }
+}
+```
+
+For Next.js specifically, add this to your `next.config.js`:
+
+```javascript
+import { webpackFallback } from '@txnlab/use-wallet-react'
+
+const nextConfig = {
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        ...webpackFallback
+      }
+    }
+    return config
+  }
+}
+
+export default nextConfig
+```
+
+This configuration allows your application to build and run without these packages installed, enabling you to include only the wallet packages you need. The `webpackFallback` object is maintained within the `@txnlab/use-wallet` library and will be automatically updated when new optional dependencies are added.

--- a/docs/getting-started/supported-wallets.md
+++ b/docs/getting-started/supported-wallets.md
@@ -1,0 +1,269 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Supported Wallets
+
+Use-wallet supports several popular Algorand wallets. This guide covers the available wallet providers and their configuration options. For complete configuration examples and additional setup details, see the [Installation](installation.md#install-dependencies) and [Configuration](configuration.md#configuring-wallets) guides.
+
+### Production Wallets
+
+#### Pera Wallet
+
+Mobile-first wallet with robust dApp integration features. [Installation instructions](installation.md#pera-wallet).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Basic usage (no options required)
+WalletId.PERA
+
+// With optional configuration
+{
+  id: WalletId.PERA,
+  options: {
+    shouldShowSignTxnToast?: boolean
+    chainId?: number // Defaults to active network
+  }
+}
+```
+
+* [Pera Website](https://perawallet.app)
+* [Pera Connect Documentation](https://github.com/perawallet/connect)
+
+#### Defly Wallet
+
+Mobile wallet with advanced DeFi features. [Installation instructions](installation.md#defly-wallet).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Basic usage (no options required)
+WalletId.DEFLY
+
+// With optional configuration
+{
+  id: WalletId.DEFLY,
+  options: {
+    shouldShowSignTxnToast?: boolean
+    chainId?: number // Defaults to active network
+  }
+}
+```
+
+* [Defly Website](https://defly.app)
+* [Defly Connect Documentation](https://github.com/blockshake-io/defly-connect)
+
+#### Defly Wallet (Web)
+
+{% hint style="warning" %}
+The Defly Web Wallet is currently in beta.
+{% endhint %}
+
+Browser extension wallet by Defly, optimized for web interactions. [Installation instructions](installation.md#defly-wallet-web).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Basic usage (no options required)
+WalletId.DEFLY_WEB
+```
+
+* [Defly Website](https://defly.app)
+
+#### WalletConnect
+
+Universal wallet connection protocol that enables secure communication between mobile wallets and desktop dApps. Supports any wallet that implements the WalletConnect v2 protocol. Project IDs must be obtained from Reown Cloud. [Installation instructions](installation.md#walletconnect).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Configuration required
+{
+  id: WalletId.WALLETCONNECT,
+  options: {
+    projectId: string      // Required: Project ID from cloud.reown.com
+    relayUrl?: string      // Optional: Custom relay server
+    metadata?: {           // Optional: dApp metadata
+      name?: string
+      description?: string
+      url?: string
+      icons?: string[]
+    }
+  }
+}
+```
+
+* [WalletConnect Network](https://walletconnect.network)
+* [Sign API Documentation](https://docs.reown.com/api/sign/dapp-usage)
+* [Reown Cloud Dashboard](https://cloud.reown.com/)
+
+#### Lute Wallet
+
+Web and browser extension wallet with Ledger hardware support. [Installation instructions](installation.md#lute-wallet).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Configuration required
+{
+  id: WalletId.LUTE,
+  options: {
+    siteName: string // Required: Your site name
+  }
+}
+```
+
+* [Lute Website](https://lute.app)
+* [Lute Connect Documentation](https://github.com/GalaxyPay/lute-connect)
+
+#### Kibisis
+
+Browser extension wallet for AVM-compatible chains (Algorand and Voi). [Installation instructions](installation.md#kibisis).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Basic usage (no options required)
+WalletId.KIBISIS
+```
+
+* [Kibisis Website](https://kibis.is)
+* [AVM Web Provider Documentation](https://avm-web-provider.agoralabs.sh)
+
+#### Exodus
+
+Multi-currency wallet with desktop, mobile, and browser extension support.
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Basic usage (no options required)
+WalletId.EXODUS
+
+// With optional configuration
+{
+  id: WalletId.EXODUS,
+  options: {
+    genesisID?: string    // Network identifier
+    genesisHash?: string  // Network hash
+  }
+}
+```
+
+* [Exodus Website](https://www.exodus.com)
+* [Exodus Algorand Provider API](https://docs.exodus.com/web3-providers/algorand-provider-arc-api/)
+
+#### Magic Auth
+
+Email-based authentication provider with built-in wallet functionality. [Installation instructions](installation.md#magic-auth).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Configuration required
+{
+  id: WalletId.MAGIC,
+  options: {
+    apiKey: string // Required: Magic Auth API key
+  }
+}
+```
+
+* [Magic Website](https://magic.link)
+* [Magic Algorand Documentation](https://magic.link/docs/blockchains/other-chains/other/algorand)
+
+#### Biatec
+
+Open-source mobile wallet with community focus and WalletConnect support. [Installation instructions](installation.md#walletconnect).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Basic usage (no options required)
+WalletId.BIATEC
+```
+
+* [Biatec Website](https://wallet.biatec.io)
+* [Biatec GitHub Repository](https://github.com/scholtz/wallet)
+
+### Development Wallets
+
+#### KMD
+
+Development wallet provider for use with Algorand's [`goal`](https://developer.algorand.org/docs/get-details/algokit/features/goal/) CLI tool and [AlgoKit](https://algorand.co/algokit).
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Configuration required
+{
+  id: WalletId.KMD,
+  options: {
+    wallet?: string           // Optional: KMD wallet name
+    token?: string            // Optional: KMD API token
+    baseServer?: string       // Optional: KMD server URL
+    port?: string | number    // Optional: KMD server port
+    promptForPassword?: () => Promise<string>  // Optional: Custom password prompt
+  }
+}
+```
+
+* [KMD Documentation](https://algorand.github.io/js-algorand-sdk/classes/Kmd.html)
+
+#### Mnemonic Wallet
+
+Simple wallet provider for testing environments.
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Configuration required
+{
+  id: WalletId.MNEMONIC,
+  options: {
+    persistToStorage?: boolean          // Optional: Save mnemonic in localStorage
+    promptForMnemonic?: () => Promise<string> // Optional: Custom mnemonic prompt
+  }
+}
+```
+
+{% hint style="danger" %}
+**Warning:** The Mnemonic Wallet provider is for testing only and will not work on MainNet. Never use with real assets.
+{% endhint %}
+
+See the [Testing with Mnemonic Wallet](../guides/testing-with-mnemonic-wallet.md) guide for details about end-to-end (E2E) testing.
+
+### Custom Provider
+
+For integrating unsupported wallets or implementing specialized wallet interactions.
+
+```typescript
+import { WalletId } from '@txnlab/use-wallet'
+
+// Configuration required
+{
+  id: WalletId.CUSTOM,
+  options: {
+    provider: {
+      connect: (args?: Record<string, any>) => Promise<WalletAccount[]>
+      disconnect?: () => Promise<void>
+      resumeSession?: () => Promise<WalletAccount[] | void>
+      signTransactions?: <T>(txnGroup: T | T[], indexesToSign?: number[]) => Promise<(Uint8Array | null)[]>
+      transactionSigner?: (txnGroup: Transaction[], indexesToSign: number[]) => Promise<Uint8Array[]>
+    }
+  }
+}
+```
+
+See the [Custom Provider](../guides/custom-provider.md) guide for implementation details.

--- a/docs/guides/connect-wallet-menu.md
+++ b/docs/guides/connect-wallet-menu.md
@@ -1,0 +1,462 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Connect Wallet Menu
+
+This guide demonstrates one approach to building a wallet connection interface using use-wallet. Being a headless library, use-wallet gives you complete control over your wallet UI implementation - you're free to design the interface that best suits your application's needs.
+
+### A Simple Pattern
+
+One straightforward approach is to implement a wallet menu with two distinct states:
+
+1. **Disconnected State**: Shows a list of available wallets to choose from
+2. **Connected State**: Shows details and controls for a single active wallet
+
+While use-wallet supports connecting multiple wallets simultaneously, focusing on a single active wallet can:
+
+* Simplify the user experience
+* Reduce complexity in state management
+* Make edge cases easier to handle
+* Help avoid potential conflicts between certain wallet providers
+
+This is just one possible pattern - the library's flexible design allows you to implement whatever interface makes sense for your application.
+
+### Basic Implementation
+
+Here's a simple implementation that follows this pattern:
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useWallet, type Wallet } from '@txnlab/use-wallet-react'
+import { useState } from 'react'
+
+const WalletMenu = () => {
+  const { wallets, activeWallet } = useWallet()
+  
+  // If we have an active wallet, show the connected view
+  if (activeWallet) {
+    return <ConnectedWallet wallet={activeWallet} />
+  }
+  
+  // Otherwise, show the wallet selection list
+  return <WalletList wallets={wallets} />
+}
+
+const WalletList = ({ wallets }: { wallets: Wallet[] }) => {
+  return (
+    <div className="wallet-list">
+      <h3>Connect Wallet</h3>
+      <div className="wallet-options">
+        {wallets.map((wallet) => (
+          <WalletOption
+            key={wallet.id}
+            wallet={wallet}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const WalletOption = ({ wallet }: { wallet: Wallet }) => {
+  const [connecting, setConnecting] = useState(false)
+  
+  const handleConnect = async () => {
+    setConnecting(true)
+    try {
+      await wallet.connect()
+    } catch (error) {
+      console.error('Failed to connect:', error)
+    } finally {
+      setConnecting(false)
+    }
+  }
+  
+  return (
+    <button
+      onClick={handleConnect}
+      disabled={connecting}
+      className="wallet-option"
+    >
+      <img
+        src={wallet.metadata.icon}
+        alt={wallet.metadata.name}
+        width={32}
+        height={32}
+      />
+      <span>{wallet.metadata.name}</span>
+    </button>
+  )
+}
+
+const ConnectedWallet = ({ wallet }: { wallet: Wallet }) => {
+  return (
+    <div className="connected-wallet">
+      {/* Wallet header */}
+      <div className="wallet-header">
+        <img
+          src={wallet.metadata.icon}
+          alt={wallet.metadata.name}
+          width={32}
+          height={32}
+        />
+        <span>{wallet.metadata.name}</span>
+      </div>
+      
+      {/* Account selector */}
+      {wallet.accounts.length > 1 && (
+        <select
+          value={wallet.activeAccount?.address}
+          onChange={(e) => wallet.setActiveAccount(e.target.value)}
+        >
+          {wallet.accounts.map((account) => (
+            <option key={account.address} value={account.address}>
+              {account.name}
+            </option>
+          ))}
+        </select>
+      )}
+      
+      {/* Account details */}
+      {wallet.activeAccount && (
+        <div className="account-info">
+          <span>{wallet.activeAccount.name}</span>
+          <span>{wallet.activeAccount.address}</span>
+        </div>
+      )}
+      
+      {/* Disconnect button */}
+      <button onClick={wallet.disconnect}>
+        Disconnect
+      </button>
+    </div>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { useWallet, type Wallet } from '@txnlab/use-wallet-vue'
+import { ref } from 'vue'
+
+const { wallets, activeWallet } = useWallet()
+const connecting = ref(false)
+
+const handleConnect = async (wallet: Wallet) => {
+  connecting.value = true
+  try {
+    await wallet.connect()
+  } catch (error) {
+    console.error('Failed to connect:', error)
+  } finally {
+    connecting.value = false
+  }
+}
+
+const setActiveAccount = (event: Event, wallet: Wallet) => {
+  const selectElement = event.target as HTMLSelectElement
+  wallet.setActiveAccount(selectElement.value)
+}
+</script>
+
+<template>
+  <div>
+    <!-- Connected state -->
+    <div v-if="activeWallet" class="connected-wallet">
+      <div class="wallet-header">
+        <img
+          :src="activeWallet.metadata.icon"
+          :alt="activeWallet.metadata.name"
+          width="32"
+          height="32"
+        />
+        <span>{{ activeWallet.metadata.name }}</span>
+      </div>
+
+      <select
+        v-if="activeWallet.accounts.length > 1"
+        :value="activeWallet.activeAccount?.address"
+        @change="(event) => setActiveAccount(event, activeWallet)"
+      >
+        <option
+          v-for="account in activeWallet.accounts"
+          :key="account.address"
+          :value="account.address"
+        >
+          {{ account.name }}
+        </option>
+      </select>
+
+      <div v-if="activeWallet.activeAccount" class="account-info">
+        <span>{{ activeWallet.activeAccount.name }}</span>
+        <span>{{ activeWallet.activeAccount.address }}</span>
+      </div>
+
+      <button @click="activeWallet.disconnect">
+        Disconnect
+      </button>
+    </div>
+
+    <!-- Disconnected state -->
+    <div v-else class="wallet-list">
+      <h3>Connect Wallet</h3>
+      <div class="wallet-options">
+        <button
+          v-for="wallet in wallets"
+          :key="wallet.id"
+          @click="() => handleConnect(wallet)"
+          :disabled="connecting"
+          class="wallet-option"
+        >
+          <img
+            :src="wallet.metadata.icon"
+            :alt="wallet.metadata.name"
+            width="32"
+            height="32"
+          />
+          <span>{{ wallet.metadata.name }}</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useWallet, type BaseWallet } from '@txnlab/use-wallet-solid'
+import { createSignal, For, Show } from 'solid-js'
+
+const WalletMenu = () => {
+  const { wallets, activeWallet, activeAccount } = useWallet()
+  const [connecting, setConnecting] = createSignal(false)
+
+  const handleConnect = async (wallet: BaseWallet) => {
+    setConnecting(true)
+    try {
+      await wallet.connect()
+    } catch (error) {
+      console.error('Failed to connect:', error)
+    } finally {
+      setConnecting(false)
+    }
+  }
+
+  const setActiveAccount = (event: Event, wallet: BaseWallet) => {
+    const target = event.target as HTMLSelectElement
+    wallet.setActiveAccount(target.value)
+  }
+
+  return (
+    <div>
+      <Show
+        when={activeWallet()}
+        fallback={
+          <div class="wallet-list">
+            <h3>Connect Wallet</h3>
+            <div class="wallet-options">
+              <For each={wallets}>
+                {(wallet) => (
+                  <button
+                    onClick={() => handleConnect(wallet)}
+                    disabled={connecting()}
+                    class="wallet-option"
+                  >
+                    <img
+                      src={wallet.metadata.icon}
+                      alt={wallet.metadata.name}
+                      width={32}
+                      height={32}
+                    />
+                    <span>{wallet.metadata.name}</span>
+                  </button>
+                )}
+              </For>
+            </div>
+          </div>
+        }
+      >
+        {(wallet) => (
+          <div class="connected-wallet">
+            <div class="wallet-header">
+              <img
+                src={wallet().metadata.icon}
+                alt={wallet().metadata.name}
+                width={32}
+                height={32}
+              />
+              <span>{wallet().metadata.name}</span>
+            </div>
+
+            <Show when={wallet().accounts.length > 1}>
+              <select onChange={(e) => setActiveAccount(e, wallet())}>
+                <For each={wallet().accounts}>
+                  {(account) => (
+                    <option value={account.address}>
+                      {account.name}
+                    </option>
+                  )}
+                </For>
+              </select>
+            </Show>
+
+            <Show when={activeAccount()}>
+              {(account) => (
+                <div class="account-info">
+                  <span>{account().name}</span>
+                  <span>{account().address}</span>
+                </div>
+              )}
+            </Show>
+
+            <button onClick={() => wallet().disconnect()}>
+              Disconnect
+            </button>
+          </div>
+        )}
+      </Show>
+    </div>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Error Handling and Loading States
+
+Here's how to implement basic error handling and loading states for wallet interactions:
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+const WalletOption = ({ wallet }: { wallet: Wallet }) => {
+  const [status, setStatus] = useState('idle')
+  
+  const handleConnect = async () => {
+    setStatus('connecting')
+    try {
+      await wallet.connect()
+      setStatus('connected')
+    } catch (error) {
+      setStatus('error')
+      showNotification('Failed to connect wallet')
+      console.error('Connection error:', error)
+    }
+  }
+  
+  return (
+    <button
+      onClick={handleConnect}
+      disabled={status === 'connecting'}
+    >
+      {status === 'connecting' ? 'Connecting...' : 'Connect'}
+    </button>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+const status = ref('idle')
+
+const handleConnect = async (wallet: Wallet) => {
+  status.value = 'connecting'
+  try {
+    await wallet.connect()
+    status.value = 'connected'
+  } catch (error) {
+    status.value = 'error'
+    showNotification('Failed to connect wallet')
+    console.error('Connection error:', error)
+  }
+}
+</script>
+
+<template>
+  <button
+    @click="handleConnect"
+    :disabled="status === 'connecting'"
+  >
+    {{ status === 'connecting' ? 'Connecting...' : 'Connect' }}
+  </button>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+const WalletOption = ({ wallet }: { wallet: BaseWallet }) => {
+  const [status, setStatus] = createSignal('idle')
+  
+  const handleConnect = async () => {
+    setStatus('connecting')
+    try {
+      await wallet.connect()
+      setStatus('connected')
+    } catch (error) {
+      setStatus('error')
+      showNotification('Failed to connect wallet')
+      console.error('Connection error:', error)
+    }
+  }
+  
+  return (
+    <button
+      onClick={handleConnect}
+      disabled={status() === 'connecting'}
+    >
+      {status() === 'connecting' ? 'Connecting...' : 'Connect'}
+    </button>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Accessibility
+
+Ensure your wallet menu is accessible:
+
+```tsx
+<div
+  role="dialog"
+  aria-labelledby="wallet-menu-title"
+  className="wallet-menu"
+>
+  <h2 id="wallet-menu-title">
+    {activeWallet ? 'Connected Wallet' : 'Connect Wallet'}
+  </h2>
+  
+  {/* Menu content */}
+</div>
+```
+
+### Next Steps
+
+* Add styling to match your application's design
+* Implement a modal/dropdown container for the menu
+* Add balance display for active account
+* Optional: Add network selection (see [Switching Networks](switching-networks.md))
+
+### See Also
+
+* [Signing Transactions](signing-transactions.md)
+* [Runtime Node Configuration](runtime-node-configuration.md)
+* [Example Projects](../resources/example-projects.md)

--- a/docs/guides/custom-provider.md
+++ b/docs/guides/custom-provider.md
@@ -1,0 +1,375 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Custom Provider
+
+While use-wallet includes support for many popular Algorand wallets, you may need to integrate an unsupported wallet or implement custom wallet behaviors. The custom provider feature enables this by allowing you to create and configure your own wallet implementation.
+
+### Basic Implementation
+
+To create a custom provider, you'll need to:
+
+1. Create a class that implements the `CustomProvider` interface
+2. Add the provider to your WalletManager configuration
+
+Here's a minimal example:
+
+```typescript
+import { CustomProvider, WalletAccount } from '@txnlab/use-wallet'
+
+class MyWalletProvider implements CustomProvider {
+  async connect(): Promise<WalletAccount[]> {
+    // Connect to your wallet and return array of accounts
+    return [{
+      name: 'Account 1',
+      address: 'ABC...'
+    }]
+  }
+
+  async signTransactions(
+    txnGroup: algosdk.Transaction[] | Uint8Array[],
+    indexesToSign?: number[]
+  ): Promise<(Uint8Array | null)[]> {
+    // Sign transactions and return array of signed txns
+    // Return null for unsigned transactions
+    return [/* signed transaction */]
+  }
+}
+
+// Add to WalletManager configuration
+const manager = new WalletManager({
+  wallets: [{
+    id: WalletId.CUSTOM,
+    options: {
+      provider: new MyWalletProvider()
+    },
+    metadata: {
+      name: 'My Wallet',
+      icon: '/path/to/icon.svg'
+    }
+  }],
+  defaultNetwork: 'testnet'
+})
+```
+
+### Provider Interface
+
+The `CustomProvider` interface defines the following methods:
+
+```typescript
+interface CustomProvider {
+  // Required: Connect to wallet and return accounts
+  connect(args?: Record<string, any>): Promise<WalletAccount[]>
+  
+  // Optional: Clean up when disconnecting
+  disconnect?(): Promise<void>
+  
+  // Optional: Restore previous session
+  resumeSession?(): Promise<WalletAccount[] | void>
+  
+  // Optional: Sign transactions (implement at least one signing method)
+  signTransactions?(
+    txnGroup: algosdk.Transaction[] | Uint8Array[] | (algosdk.Transaction[] | Uint8Array[])[],
+    indexesToSign?: number[]
+  ): Promise<(Uint8Array | null)[]>
+  
+  // Optional: Sign with ATC-compatible signer
+  transactionSigner?(
+    txnGroup: algosdk.Transaction[],
+    indexesToSign: number[]
+  ): Promise<Uint8Array[]>
+}
+```
+
+### Required Methods
+
+#### **connect**
+
+The `connect` method is the only required method. It should:
+
+* Connect to the wallet provider
+* Return an array of `WalletAccount` objects
+* Accept an optional `args` parameter for custom configuration
+
+```typescript
+interface WalletAccount {
+  name: string           // Display name
+  address: string        // Algorand address
+}
+```
+
+### Optional Methods
+
+#### **disconnect**
+
+The `disconnect` method should clean up any resources or state when the wallet is disconnected. This might include:
+
+* Removing event listeners
+* Clearing cached data
+* Notifying the wallet provider
+
+#### **resumeSession**
+
+The `resumeSession` method enables automatic reconnection when the application loads. If implemented, it should:
+
+* Check for an existing wallet connection
+* Return connected accounts if found
+* Return void if no session exists
+
+### Signing Methods
+
+At least one of the signing methods should be implemented to enable transaction signing.
+
+#### **signTransactions**
+
+The `signTransactions` method provides direct transaction signing:
+
+```typescript
+async signTransactions(
+  txnGroup: algosdk.Transaction[] | Uint8Array[],
+  indexesToSign?: number[]
+): Promise<(Uint8Array | null)[]> {
+  // Sign transactions at specified indexes
+  // Return array matching input length with:
+  // - Uint8Array for signed transactions
+  // - null for unsigned transactions
+}
+```
+
+#### **transactionSigner**
+
+The `transactionSigner` method provides an ATC-compatible signer:
+
+```typescript
+async transactionSigner(
+  txnGroup: algosdk.Transaction[],
+  indexesToSign: number[]
+): Promise<Uint8Array[]> {
+  // Sign specified transactions
+  // Return array containing only signed transactions
+}
+```
+
+### Complete Example
+
+Here's a complete example showing a custom provider with all optional methods implemented:
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { CustomProvider, WalletAccount, useWallet } from '@txnlab/use-wallet-react'
+import algosdk from 'algosdk'
+
+class MyWalletProvider implements CustomProvider {
+  private accounts: WalletAccount[] = []
+  
+  async connect(): Promise<WalletAccount[]> {
+    // Connect to wallet
+    this.accounts = [{
+      name: 'Account 1',
+      address: 'ABC...'
+    }]
+    return this.accounts
+  }
+  
+  async disconnect(): Promise<void> {
+    // Clean up
+    this.accounts = []
+  }
+  
+  async resumeSession(): Promise<WalletAccount[] | void> {
+    // Check for existing session
+    if (localStorage.getItem('wallet-connected')) {
+      return this.connect()
+    }
+  }
+  
+  async signTransactions(
+    txnGroup: algosdk.Transaction[] | Uint8Array[],
+    indexesToSign?: number[]
+  ): Promise<(Uint8Array | null)[]> {
+    // Convert to Transaction objects if needed
+    const txns = txnGroup.map(txn => {
+      return txn instanceof Uint8Array
+        ? algosdk.decodeSignedTransaction(txn).txn
+        : txn
+    })
+    
+    // Default to signing all transactions
+    const idxs = indexesToSign ?? txns.map((_, i) => i)
+    
+    // Return array matching input length
+    return txns.map((txn, i) => {
+      if (!idxs.includes(i)) return null
+      return /* signed transaction */
+    })
+  }
+  
+  async transactionSigner(
+    txnGroup: algosdk.Transaction[],
+    indexesToSign: number[]
+  ): Promise<Uint8Array[]> {
+    const signed = await this.signTransactions(txnGroup, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  }
+}
+
+// Usage in component
+function WalletConnect() {
+  const { activeAccount } = useWallet()
+  
+  return (
+    <div>
+      {activeAccount ? (
+        <div>Connected: {activeAccount.address}</div>
+      ) : (
+        <div>Not connected</div>
+      )}
+    </div>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { CustomProvider, WalletAccount, useWallet } from '@txnlab/use-wallet-vue'
+import algosdk from 'algosdk'
+
+class MyWalletProvider implements CustomProvider {
+  private accounts: WalletAccount[] = []
+  
+  async connect(): Promise<WalletAccount[]> {
+    // Connect to wallet
+    this.accounts = [{
+      name: 'Account 1',
+      address: 'ABC...',
+      providerId: 'my-wallet'
+    }]
+    return this.accounts
+  }
+  
+  async disconnect(): Promise<void> {
+    // Clean up
+    this.accounts = []
+  }
+  
+  async resumeSession(): Promise<WalletAccount[] | void> {
+    // Check for existing session
+    if (localStorage.getItem('wallet-connected')) {
+      return this.connect()
+    }
+  }
+  
+  async signTransactions(
+    txnGroup: algosdk.Transaction[] | Uint8Array[],
+    indexesToSign?: number[]
+  ): Promise<(Uint8Array | null)[]> {
+    // Implementation details same as React example
+  }
+  
+  async transactionSigner(
+    txnGroup: algosdk.Transaction[],
+    indexesToSign: number[]
+  ): Promise<Uint8Array[]> {
+    const signed = await this.signTransactions(txnGroup, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  }
+}
+
+const { activeAccount } = useWallet()
+</script>
+
+<template>
+  <div>
+    <div v-if="activeAccount">
+      Connected: {{ activeAccount.address }}
+    </div>
+    <div v-else>
+      Not connected
+    </div>
+  </div>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { CustomProvider, WalletAccount, useWallet } from '@txnlab/use-wallet-solid'
+import algosdk from 'algosdk'
+
+class MyWalletProvider implements CustomProvider {
+  private accounts: WalletAccount[] = []
+  
+  async connect(): Promise<WalletAccount[]> {
+    // Connect to wallet
+    this.accounts = [{
+      name: 'Account 1',
+      address: 'ABC...',
+      providerId: 'my-wallet'
+    }]
+    return this.accounts
+  }
+  
+  async disconnect(): Promise<void> {
+    // Clean up
+    this.accounts = []
+  }
+  
+  async resumeSession(): Promise<WalletAccount[] | void> {
+    // Check for existing session
+    if (localStorage.getItem('wallet-connected')) {
+      return this.connect()
+    }
+  }
+  
+  async signTransactions(
+    txnGroup: algosdk.Transaction[] | Uint8Array[],
+    indexesToSign?: number[]
+  ): Promise<(Uint8Array | null)[]> {
+    // Implementation details same as React example
+  }
+  
+  async transactionSigner(
+    txnGroup: algosdk.Transaction[],
+    indexesToSign: number[]
+  ): Promise<Uint8Array[]> {
+    const signed = await this.signTransactions(txnGroup, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  }
+}
+
+function WalletConnect() {
+  const { activeAccount } = useWallet()
+  
+  return (
+    <div>
+      {activeAccount() ? (
+        <div>Connected: {activeAccount().address}</div>
+      ) : (
+        <div>Not connected</div>
+      )}
+    </div>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Next Steps
+
+* See the [Signing Transactions](signing-transactions.md) guide for more details about implementing signing methods
+* Read about setting up the provider in your application in the [Configuration](../getting-started/configuration.md) guide
+* Browse the [Example Projects](../resources/example-projects.md) for complete implementation examples

--- a/docs/guides/migrating-from-v3.x.md
+++ b/docs/guides/migrating-from-v3.x.md
@@ -1,0 +1,298 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Migrating from v3.x
+
+Version 4.0.0 brings improvements to use-wallet while maintaining the core architecture from v3:
+
+* Updated to support algosdk v3
+* Enhanced network configuration capabilities
+* Reorganized framework adapter APIs for better separation of concerns
+
+This guide will walk you through the changes needed to upgrade from v3.x. Most applications will require only minor updates to network configuration and imports.
+
+### Upgrading Dependencies
+
+1. Update your use-wallet package:
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm upgrade @txnlab/use-wallet@^4.0.0
+# if using React adapter
+npm upgrade @txnlab/use-wallet-react@^4.0.0
+# if using Vue adapter
+npm upgrade @txnlab/use-wallet-vue@^4.0.0
+# if using Solid adapter
+npm upgrade @txnlab/use-wallet-solid@^4.0.0
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn upgrade @txnlab/use-wallet@^4.0.0
+# if using React adapter
+yarn upgrade @txnlab/use-wallet-react@^4.0.0
+# if using Vue adapter
+yarn upgrade @txnlab/use-wallet-vue@^4.0.0
+# if using Solid adapter
+yarn upgrade @txnlab/use-wallet-solid@^4.0.0
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm update @txnlab/use-wallet@^4.0.0
+# if using React adapter
+pnpm update @txnlab/use-wallet-react@^4.0.0
+# if using Vue adapter
+pnpm update @txnlab/use-wallet-vue@^4.0.0
+# if using Solid adapter
+pnpm update @txnlab/use-wallet-solid@^4.0.0
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun update @txnlab/use-wallet@^4.0.0
+# if using React adapter
+bun update @txnlab/use-wallet-react@^4.0.0
+# if using Vue adapter
+bun update @txnlab/use-wallet-vue@^4.0.0
+# if using Solid adapter
+bun update @txnlab/use-wallet-solid@^4.0.0
+```
+{% endtab %}
+{% endtabs %}
+
+2. Update algosdk:
+
+{% tabs %}
+{% tab title="npm" %}
+```bash
+npm upgrade algosdk@^3.0.0
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn upgrade algosdk@^3.0.0
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```bash
+pnpm update algosdk@^3.0.0
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```bash
+bun update algosdk@^3.0.0
+```
+{% endtab %}
+{% endtabs %}
+
+### Support for algosdk v3
+
+Version 4 upgrades from algosdk v2 to v3. The extent of required changes will depend on how your application uses the SDK. Some applications may need minimal changes, while others may require more extensive updates.
+
+For a complete guide to migrating from algosdk v2 to v3, see the [official migration guide](https://github.com/algorand/js-algorand-sdk/blob/develop/v2_TO_v3_MIGRATION_GUIDE.md).
+
+### Network Configuration Changes
+
+Along with algosdk v3 support, v4 includes improvements to network configuration. The new approach is more flexible and allows configuring custom AVM-compatible networks without modifying the library's codebase.
+
+#### Single Network Configuration
+
+If your application uses a single public Algorand network (MainNet, TestNet, BetaNet), migrate from:
+
+```typescript
+const manager = new WalletManager({
+  wallets: [...],
+  network: NetworkId.TESTNET,
+  algod: {
+    token: '<YOUR_TOKEN>',
+    baseServer: '<YOUR_SERVER_URL>',
+    port: '<YOUR_PORT>'
+  }
+})
+```
+
+to:
+
+```typescript
+const manager = new WalletManager({
+  wallets: [...],
+  defaultNetwork: NetworkId.TESTNET, // or just 'testnet'
+  networks: {
+    testnet: {
+      algod: {
+        token: '<YOUR_TOKEN>',
+        baseServer: '<YOUR_SERVER_URL>',
+        port: '<YOUR_PORT>'
+      }
+    }
+  }
+})
+```
+
+#### Multiple Network Configuration
+
+If your application supports multiple networks, migrate from:
+
+```typescript
+const manager = new WalletManager({
+  wallets: [...],
+  network: NetworkId.TESTNET,
+  algod: {
+    [NetworkId.TESTNET]: {
+      token: '<YOUR_TOKEN>',
+      baseServer: '<YOUR_SERVER_URL>',
+      port: '<YOUR_PORT>'
+    },
+    [NetworkId.MAINNET]: {
+      token: '<YOUR_TOKEN>',
+      baseServer: '<YOUR_SERVER_URL>',
+      port: '<YOUR_PORT>'
+    }
+  }
+})
+```
+
+to using the `NetworkConfigBuilder`:
+
+```typescript
+const networks = new NetworkConfigBuilder()
+  .testnet({
+    algod: {
+      token: '<YOUR_TOKEN>',
+      baseServer: '<YOUR_SERVER_URL>',
+      port: '<YOUR_PORT>'
+    }
+  })
+  .mainnet({
+    algod: {
+      token: '<YOUR_TOKEN>',
+      baseServer: '<YOUR_SERVER_URL>',
+      port: '<YOUR_PORT>'
+    }
+  })
+  .build()
+
+const manager = new WalletManager({
+  wallets: [...],
+  networks,
+  defaultNetwork: NetworkId.TESTNET, // or just 'testnet'
+})
+```
+
+#### Custom Networks
+
+For other AVM networks (like [Voi](https://voi.network/)), you can use the `NetworkConfigBuilder` and its `addNetwork`method:
+
+```typescript
+const networks = new NetworkConfigBuilder()
+  .addNetwork('voi-mainnet', {
+    algod: {
+      token: '',
+      baseServer: 'https://mainnet-api.voi.nodely.dev',
+      port: ''
+    },
+    isTestnet: false,
+    genesisHash: 'r20fSQI8gWe/kFZziNonSPCXLwcQmH/nxROvnnueWOk=',
+    genesisId: 'voimain-v1.0',
+    caipChainId: 'algorand:r20fSQI8gWe_kFZziNonSPCXLwcQmH_n'
+  })
+  .build()
+
+const manager = new WalletManager({
+  wallets: [...],
+  networks,
+  defaultNetwork: 'voi-mainnet'
+})
+```
+
+See the [Configuration](../getting-started/configuration.md#network-configuration) guide for more details about network configuration options.
+
+### Framework Adapter Changes
+
+Network-related functionality has been moved from `useWallet` to a dedicated `useNetwork` hook:
+
+Before (v3.x):
+
+```typescript
+// Network-related returns were part of useWallet
+const {
+  activeNetwork,
+  setActiveNetwork
+} = useWallet()
+```
+
+After (v4.x):
+
+```typescript
+// Now provided by useNetwork
+const {
+  activeNetwork,
+  setActiveNetwork,
+  networkConfig,
+  activeNetworkConfig,
+  updateAlgodConfig,
+  resetNetworkConfig
+} = useNetwork()
+```
+
+If your project supports [network switching](switching-networks.md), you'll need to update your imports and split the network functionality between hooks:
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+// Before - all functionality from useWallet
+import { useWallet } from '@txnlab/use-wallet-react'
+const { activeNetwork, setActiveNetwork, /* other wallet returns */ } = useWallet()
+
+// After - network returns moved to useNetwork
+import { useWallet, useNetwork } from '@txnlab/use-wallet-react'
+const { /* wallet returns */ } = useWallet()
+const { activeNetwork, setActiveNetwork } = useNetwork()
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+// Before - all functionality from useWallet
+import { useWallet } from '@txnlab/use-wallet-vue'
+const { activeNetwork, setActiveNetwork, /* other wallet returns */ } = useWallet()
+
+// After - network returns moved to useNetwork
+import { useWallet, useNetwork } from '@txnlab/use-wallet-vue'
+const { /* wallet returns */ } = useWallet()
+const { activeNetwork, setActiveNetwork } = useNetwork()
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+// Before - all functionality from useWallet
+import { useWallet } from '@txnlab/use-wallet-solid'
+const { activeNetwork, setActiveNetwork, /* other wallet returns */ } = useWallet()
+
+// After - network returns moved to useNetwork
+import { useWallet, useNetwork } from '@txnlab/use-wallet-solid'
+const { /* wallet returns */ } = useWallet()
+const { activeNetwork, setActiveNetwork } = useNetwork()
+```
+{% endtab %}
+{% endtabs %}

--- a/docs/guides/runtime-node-configuration.md
+++ b/docs/guides/runtime-node-configuration.md
@@ -1,0 +1,446 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Runtime Node Configuration
+
+Starting with v4.0.0, use-wallet provides methods to update Algod node configurations at runtime. This feature gives users the freedom to connect to their preferred nodes while maintaining your application's default configuration as a fallback option.
+
+Common use cases include:
+
+* Users running their own private Algod nodes
+* Teams working with custom network configurations
+* Connecting to fallback nodes (like Nodely's [backup endpoints](https://nodely.io/docs/free/backup/)) when the primary node is unavailable
+
+### Basic Usage
+
+The `useNetwork` hook/composable provides two methods for managing node configurations:
+
+* `updateAlgodConfig` - Update a network's node configuration
+* `resetNetworkConfig` - Reset a network's configuration to defaults
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useNetwork } from '@txnlab/use-wallet-react'
+
+function NodeConfig() {
+  const { updateAlgodConfig, resetNetworkConfig } = useNetwork()
+
+  const handleNodeChange = () => {
+    // Update node configuration for MainNet
+    updateAlgodConfig('mainnet', {
+      baseServer: 'https://secondary-node.com',
+      port: '443',
+      token: ''
+    })
+  }
+
+  const handleReset = () => {
+    // Reset MainNet back to default configuration
+    resetNetworkConfig('mainnet')
+  }
+
+  return (
+    <div>
+      <button onClick={handleNodeChange}>
+        Use Secondary Node
+      </button>
+      <button onClick={handleReset}>
+        Reset Node
+      </button>
+    </div>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { useNetwork } from '@txnlab/use-wallet-vue'
+
+const { updateAlgodConfig, resetNetworkConfig } = useNetwork()
+
+const handleNodeChange = () => {
+  // Update node configuration for TestNet
+  updateAlgodConfig('testnet', {
+    baseServer: 'https://testnet-api.algonode.cloud',
+    port: '443',
+    token: ''
+  })
+}
+
+const handleReset = () => {
+  // Reset TestNet back to default configuration
+  resetNetworkConfig('testnet')
+}
+</script>
+
+<template>
+  <div>
+    <button @click="handleNodeChange">
+      Use AlgoNode
+    </button>
+    <button @click="handleReset">
+      Reset Node
+    </button>
+  </div>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useNetwork } from '@txnlab/use-wallet-solid'
+
+function NodeConfig() {
+  const { updateAlgodConfig, resetNetworkConfig } = useNetwork()
+
+  const handleNodeChange = () => {
+    // Update node configuration for TestNet
+    updateAlgodConfig('testnet', {
+      baseServer: 'https://testnet-api.algonode.cloud',
+      port: '443',
+      token: ''
+    })
+  }
+
+  const handleReset = () => {
+    // Reset TestNet back to default configuration
+    resetNetworkConfig('testnet')
+  }
+
+  return (
+    <div>
+      <button onClick={handleNodeChange}>
+        Use AlgoNode
+      </button>
+      <button onClick={handleReset}>
+        Reset Node
+      </button>
+    </div>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Configuration Persistence
+
+Node configurations are automatically saved to local storage. This means:
+
+* Custom configurations persist across page reloads
+* Each network's configuration can be customized independently
+* Resetting a network only affects that specific network's configuration
+
+### Configuration Options
+
+When updating node configurations, you can provide any of these settings:
+
+```typescript
+interface AlgodConfig {
+  // API token or authentication header
+  token: string | algosdk.AlgodTokenHeader | algosdk.CustomTokenHeader
+
+  // Base URL of the node
+  baseServer: string
+
+  // Port number (optional)
+  port?: string | number
+
+  // Custom headers (optional)
+  headers?: Record<string, string>
+}
+```
+
+### Automatic Updates
+
+When updating the configuration for the active network, use-wallet automatically:
+
+1. Creates a new Algod client with the updated configuration
+2. Updates all components that depend on the Algod client
+3. Saves the configuration to local storage
+
+No additional steps are needed to start using the new node.
+
+### Example Form
+
+Here's a complete example showing how to implement a node configuration form:
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useState } from 'react'
+import { useNetwork } from '@txnlab/use-wallet-react'
+
+function NodeConfigForm() {
+  const {
+    activeNetwork,
+    activeNetworkConfig,
+    updateAlgodConfig,
+    resetNetworkConfig
+  } = useNetwork()
+  
+  const [formData, setFormData] = useState({
+    baseServer: activeNetworkConfig.algod.baseServer,
+    port: activeNetworkConfig.algod.port || '',
+    token: ''
+  })
+  const [error, setError] = useState('')
+
+  const handleSubmit = async ((e): React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    try {
+      await updateAlgodConfig(activeNetwork, {
+        baseServer: formData.baseServer,
+        port: formData.port || undefined,
+        token: formData.token || ''
+      })
+    } catch (error: any) {
+      setError(error.message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Configure {activeNetwork} Node</h3>
+      
+      <div>
+        <label>Server URL:</label>
+        <input
+          type="url"
+          value={formData.baseServer}
+          onChange={(e) => setFormData((d) => ({ ...d, baseServer: e.target.value }))}
+          required
+        />
+      </div>
+
+      <div>
+        <label>Port:</label>
+        <input
+          type="text"
+          value={formData.port}
+          onChange={(e) => setFormData((d) => ({ ...d, port: e.target.value }))}
+          placeholder="Optional"
+        />
+      </div>
+
+      <div>
+        <label>Token:</label>
+        <input
+          type="password"
+          value={formData.token}
+          onChange={(e) => setFormData((d) => ({ ...d, token: e.target.value }))}
+          placeholder="Optional"
+        />
+      </div>
+
+      {error && (
+        <div className="error">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <button type="submit">
+          Update Node
+        </button>
+        <button type="button" onClick={() => resetNetworkConfig(activeNetwork)}>
+          Reset to Default
+        </button>
+      </div>
+    </form>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useNetwork } from '@txnlab/use-wallet-vue'
+
+const {
+  activeNetwork,
+  activeNetworkConfig,
+  updateAlgodConfig,
+  resetNetworkConfig
+} = useNetwork()
+
+const formData = ref({
+  baseServer: activeNetworkConfig.value.algod.baseServer,
+  port: activeNetworkConfig.value.algod.port || '',
+  token: ''
+})
+
+const error = ref('')
+
+const handleSubmit = async ((e): Event) => {
+  e.preventDefault()
+  error.value = ''
+
+  try {
+    await updateAlgodConfig(activeNetwork.value, {
+      baseServer: formData.value.baseServer,
+      port: formData.value.port || undefined,
+      token: formData.value.token || ''
+    })
+  } catch (err: any) {
+    error.value = err.message
+  }
+}
+</script>
+
+<template>
+  <form @submit="handleSubmit">
+    <h3>Configure {{ activeNetwork }} Node</h3>
+    
+    <div>
+      <label>Server URL:</label>
+      <input
+        type="url"
+        v-model="formData.baseServer"
+        required
+      />
+    </div>
+
+    <div>
+      <label>Port:</label>
+      <input
+        type="text"
+        v-model="formData.port"
+        placeholder="Optional"
+      />
+    </div>
+
+    <div>
+      <label>Token:</label>
+      <input
+        type="password"
+        v-model="formData.token"
+        placeholder="Optional"
+      />
+    </div>
+
+    <div v-if="error" class="error">
+      {{ error }}
+    </div>
+
+    <div>
+      <button type="submit">
+        Update Node
+      </button>
+      <button type="button" @click="() => resetNetworkConfig(activeNetwork)">
+        Reset to Default
+      </button>
+    </div>
+  </form>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { createSignal } from 'solid-js'
+import { useNetwork } from '@txnlab/use-wallet-solid'
+
+function NodeConfigForm() {
+  const {
+    activeNetwork,
+    activeNetworkConfig,
+    updateAlgodConfig,
+    resetNetworkConfig
+  } = useNetwork()
+  
+  const [formData, setFormData] = createSignal({
+    baseServer: activeNetworkConfig().algod.baseServer,
+    port: activeNetworkConfig().algod.port || '',
+    token: ''
+  })
+  
+  const [error, setError] = createSignal('')
+
+  const handleSubmit = async ((e): Event) => {
+    e.preventDefault()
+    setError('')
+
+    try {
+      await updateAlgodConfig(activeNetwork(), {
+        baseServer: formData().baseServer,
+        port: formData().port || undefined,
+        token: formData().token || ''
+      })
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Configure {activeNetwork()} Node</h3>
+      
+      <div>
+        <label>Server URL:</label>
+        <input
+          type="url"
+          value={formData().baseServer}
+          onChange={(e) => setFormData((d) => ({ ...d, baseServer: e.currentTarget.value }))}
+          required
+        />
+      </div>
+
+      <div>
+        <label>Port:</label>
+        <input
+          type="text"
+          value={formData().port}
+          onChange={(e) => setFormData((d) => ({ ...d, port: e.currentTarget.value }))}
+          placeholder="Optional"
+        />
+      </div>
+
+      <div>
+        <label>Token:</label>
+        <input
+          type="password"
+          value={formData().token}
+          onChange={(e) => setFormData((d) => ({ ...d, token: e.currentTarget.value }))}
+          placeholder="Optional"
+        />
+      </div>
+
+      {error() && (
+        <div class="error">
+          {error()}
+        </div>
+      )}
+
+      <div>
+        <button type="submit">
+          Update Node
+        </button>
+        <button type="button" onClick={() => resetNetworkConfig(activeNetwork())}>
+          Reset to Default
+        </button>
+      </div>
+    </form>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+

--- a/docs/guides/signing-transactions.md
+++ b/docs/guides/signing-transactions.md
@@ -1,0 +1,556 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Signing Transactions
+
+The `useWallet` hook/composable/primitive provides two methods for signing Algorand transactions:
+
+* `signTransactions` - For directly signing transactions
+* `transactionSigner` - For use with transaction composers that accept an `algosdk.TransactionSigner`
+
+### signTransactions
+
+The [`signTransactions`](../api-reference/usewallet.md) method accepts either:
+
+* An array of `algosdk.Transaction` objects
+* An array of encoded transactions (`Uint8Array`)
+* An array of arrays of either of the above (for transaction groups)
+
+It returns an array of `Uint8Array | null`, where `null` indicates an unsigned transaction.
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useWallet } from '@txnlab/use-wallet-react'
+import algosdk from 'algosdk'
+
+function SendTransaction() {
+  const {
+    activeAddress,
+    signTransactions,
+    algodClient
+  } = useWallet()
+
+  const handleSend = async () => {
+    if (!activeAddress) return
+
+    try {
+      // Create transaction
+      const suggestedParams = await algodClient.getTransactionParams().do()
+      const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        sender: activeAddress,
+        receiver: activeAddress,
+        amount: 0,
+        suggestedParams
+      })
+
+      // Sign transaction
+      const signedTxns = await signTransactions([transaction])
+
+      // Send transaction
+      const { txid } = await algodClient.sendRawTransaction(signedTxns).do()
+      
+      // Wait for confirmation
+      const result = await algosdk.waitForConfirmation(algodClient, txid, 4)
+      console.log(`Transaction confirmed at round ${result['confirmed-round']}`)
+    } catch (error) {
+      console.error('Error:', error)
+    }
+  }
+
+  return (
+    <button onClick={handleSend}>Send Transaction</button>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { useWallet } from '@txnlab/use-wallet-vue'
+import algosdk from 'algosdk'
+
+const {
+  activeAddress,
+  signTransactions,
+  algodClient
+} = useWallet()
+
+const handleSend = async () => {
+  if (!activeAddress.value) return
+
+  try {
+    // Create transaction
+    const suggestedParams = await algodClient.value.getTransactionParams().do()
+    const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+      sender: activeAddress.value,
+      receiver: activeAddress.value,
+      amount: 0,
+      suggestedParams
+    })
+
+    // Sign transaction
+    const signedTxns = await signTransactions([transaction])
+
+    // Send transaction
+    const { txid } = await algodClient.value.sendRawTransaction(signedTxns).do()
+    
+    // Wait for confirmation
+    const result = await algosdk.waitForConfirmation(algodClient.value, txid, 4)
+    console.log(`Transaction confirmed at round ${result['confirmed-round']}`)
+  } catch (error) {
+    console.error('Error:', error)
+  }
+}
+</script>
+
+<template>
+  <button @click="handleSend">Send Transaction</button>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useWallet } from '@txnlab/use-wallet-solid'
+import algosdk from 'algosdk'
+
+function SendTransaction() {
+  const {
+    activeAddress,
+    signTransactions,
+    algodClient
+  } = useWallet()
+
+  const handleSend = async () => {
+    if (!activeAddress()) return
+
+    try {
+      // Create transaction
+      const suggestedParams = await algodClient().getTransactionParams().do()
+      const transaction = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        sender: activeAddress(),
+        receiver: activeAddress(),
+        amount: 0,
+        suggestedParams
+      })
+
+      // Sign transaction
+      const signedTxns = await signTransactions([transaction])
+
+      // Send transaction
+      const { txid } = await algodClient().sendRawTransaction(signedTxns).do()
+      
+      // Wait for confirmation
+      const result = await algosdk.waitForConfirmation(algodClient(), txid, 4)
+      console.log(`Transaction confirmed at round ${result['confirmed-round']}`)
+    } catch (error) {
+      console.error('Error:', error)
+    }
+  }
+
+  return (
+    <button onClick={handleSend}>Send Transaction</button>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+For more information about constructing and sending transactions with the Algorand JavaScript SDK, see the [JS SDK: Your First Transaction](https://developer.algorand.org/docs/sdks/javascript/) guide in the Algorand Developer Portal.
+
+### transactionSigner
+
+The [`transactionSigner`](../api-reference/usewallet.md) provides a typed `algosdk.TransactionSigner` that can be used with transaction composers. This is particularly useful when working with ABI method calls or when you need to compose multiple transactions.
+
+#### With Atomic Transaction Composer
+
+The `AtomicTransactionComposer` (ATC) is the recommended way to build and execute groups of transactions, especially when working with smart contracts.
+
+Here's an example using ATC to combine an ABI method call with a payment transaction:
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useWallet } from '@txnlab/use-wallet-react'
+import algosdk from 'algosdk'
+
+function CallContractAtc() {
+  const {
+    activeAddress,
+    transactionSigner,
+    algodClient
+  } = useWallet()
+
+  const handleCall = async () => {
+    if (!activeAddress) return
+
+    try {
+      // Create ATC instance
+      const atc = new algosdk.AtomicTransactionComposer()
+      
+      // Get suggested params
+      const suggestedParams = await algodClient.getTransactionParams().do()
+      
+      // Add ABI method call
+      const method = algosdk.ABIMethod.fromSignature('hello(string)string')
+      atc.addMethodCall({
+        sender: activeAddress,
+        signer: transactionSigner,
+        appID: 123,
+        method,
+        methodArgs: ['World'],
+        suggestedParams,
+      })
+
+      // Add payment transaction
+      const paymentTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        sender: activeAddress,
+        receiver: activeAddress,
+        amount: 1000,
+        suggestedParams,
+      })
+      atc.addTransaction({ txn: paymentTxn, signer: transactionSigner })
+
+      // Execute transaction group
+      const result = await atc.execute(algodClient, 4)
+      console.log('Transaction confirmed:', result.txIDs[0])
+      
+      // Get return value from ABI method
+      const returnValue = result.methodResults[0].returnValue
+      console.log('Return value:', returnValue)
+    } catch (error) {
+      console.error('Error:', error)
+    }
+  }
+
+  return (
+    <button onClick={handleCall}>Call Contract</button>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { useWallet } from '@txnlab/use-wallet-vue'
+import algosdk from 'algosdk'
+
+const {
+  activeAddress,
+  transactionSigner,
+  algodClient
+} = useWallet()
+
+const handleCall = async () => {
+  if (!activeAddress.value) return
+
+  try {
+    // Create ATC instance
+    const atc = new algosdk.AtomicTransactionComposer()
+    
+    // Get suggested params
+    const suggestedParams = await algodClient.value.getTransactionParams().do()
+    
+    // Add ABI method call
+    const method = algosdk.ABIMethod.fromSignature('hello(string)string')
+    atc.addMethodCall({
+      sender: activeAddress.value,
+      signer: transactionSigner,
+      appID: 123,
+      method,
+      methodArgs: ['World'],
+      suggestedParams,
+    })
+
+    // Add payment transaction
+    const paymentTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+      sender: activeAddress.value,
+      receiver: activeAddress.value,
+      amount: 1000,
+      suggestedParams,
+    })
+    atc.addTransaction({ txn: paymentTxn, signer: transactionSigner })
+
+    // Execute transaction group
+    const result = await atc.execute(algodClient.value, 4)
+    console.log('Transaction confirmed:', result.txIDs[0])
+    
+    // Get return value from ABI method
+    const returnValue = result.methodResults[0].returnValue
+    console.log('Return value:', returnValue)
+  } catch (error) {
+    console.error('Error:', error)
+  }
+}
+</script>
+
+<template>
+  <button @click="handleCall">Call Contract</button>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useWallet } from '@txnlab/use-wallet-solid'
+import algosdk from 'algosdk'
+
+function CallContractAtc() {
+  const {
+    activeAddress,
+    transactionSigner,
+    algodClient
+  } = useWallet()
+
+  const handleCall = async () => {
+    if (!activeAddress()) return
+
+    try {
+      // Create ATC instance
+      const atc = new algosdk.AtomicTransactionComposer()
+      
+      // Get suggested params
+      const suggestedParams = await algodClient().getTransactionParams().do()
+      
+      // Add ABI method call
+      const method = algosdk.ABIMethod.fromSignature('hello(string)string')
+      atc.addMethodCall({
+        sender: activeAddress(),
+        signer: transactionSigner,
+        appID: 123,
+        method,
+        methodArgs: ['World'],
+        suggestedParams,
+      })
+
+      // Add payment transaction
+      const paymentTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        sender: activeAddress(),
+        receiver: activeAddress(),
+        amount: 1000,
+        suggestedParams,
+      })
+      atc.addTransaction({ txn: paymentTxn, signer: transactionSigner })
+
+      // Execute transaction group
+      const result = await atc.execute(algodClient(), 4)
+      console.log('Transaction confirmed:', result.txIDs[0])
+      
+      // Get return value from ABI method
+      const returnValue = result.methodResults[0].returnValue
+      console.log('Return value:', returnValue)
+    } catch (error) {
+      console.error('Error:', error)
+    }
+  }
+
+  return (
+    <button onClick={handleCall}>Call Contract</button>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+For more information, see the [Atomic Transaction Composer guide](https://developer.algorand.org/docs/get-details/atc/) in the Algorand Developer Portal.
+
+#### With AlgoKit Utils
+
+The most powerful way to interact with Algorand is using [AlgoKit Utils](https://github.com/algorandfoundation/algokit-utils-ts)' `AlgorandClient`. This class provides a unified interface for all Algorand functionality, including:
+
+* Smart contract interactions via typed clients
+* Transaction creation and composition
+* Fee calculations and simulation
+
+Here's the same transaction group (ABI method call + payment) composed using AlgoKit Utils:
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useWallet } from '@txnlab/use-wallet-react'
+import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { HelloWorldClient } from './artifacts/HelloWorld/client'
+
+function CallContractAlgoKit() {
+  const {
+    activeAddress,
+    transactionSigner,
+    algodClient
+  } = useWallet()
+
+  const handleCall = async () => {
+    if (!activeAddress) return
+
+    try {
+      // Initialize AlgorandClient with algodClient and signer from use-wallet
+      const algorand = AlgorandClient
+        .fromClients({ algod: algodClient })
+        .setSigner(activeAddress, transactionSigner)
+
+      // Get typed app client instance
+      const client = algorand.client.getTypedAppClientById(HelloWorldClient, {
+        appId: 123n,
+      })
+      
+      // Compose and send transaction group
+      const result = await client
+        .newGroup()
+        // Add ABI method call (type-safe!)
+        .hello({ args: { name: 'World' } })
+        // Add payment transaction
+        .addTransaction(
+          algorand.createTransaction.payment({
+            sender: activeAddress(),
+            receiver: activeAddress(),
+            amount: (1000).microAlgo()
+          })
+        )
+        .execute()
+
+      console.log('Transaction confirmed:', result.transaction.txID())
+      console.log('Return value:', result.return)
+    } catch (error) {
+      console.error('Error:', error)
+    }
+  }
+
+  return (
+    <button onClick={handleCall}>Call Contract</button>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { useWallet } from '@txnlab/use-wallet-vue'
+import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { HelloWorldClient } from './artifacts/HelloWorld/client'
+
+const {
+  activeAddress,
+  transactionSigner,
+  algodClient
+} = useWallet()
+
+const handleCall = async () => {
+  if (!activeAddress.value) return
+
+  try {
+    // Initialize AlgorandClient with algodClient and signer from use-wallet
+    const algorand = AlgorandClient
+      .fromClients({ algod: algodClient.value })
+      .setSigner(activeAddress.value, transactionSigner)
+
+    // Get typed app client instance
+    const client = algorand.client.getTypedAppClientById(HelloWorldClient, {
+      appId: 123n,
+    })
+    
+    // Compose and send transaction group
+    const result = await client
+      .newGroup()
+      // Add ABI method call (type-safe!)
+      .hello({ args: { name: 'World' } })
+      // Add payment transaction
+      .addTransaction(
+        algorand.createTransaction.payment({
+          sender: activeAddress(),
+          receiver: activeAddress(),
+          amount: (1000).microAlgo()
+        })
+      )
+      .execute()
+
+    console.log('Transaction confirmed:', result.transaction.txID())
+    console.log('Return value:', result.return)
+  } catch (error) {
+    console.error('Error:', error)
+  }
+}
+</script>
+
+<template>
+  <button @click="handleCall">Call Contract</button>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useWallet } from '@txnlab/use-wallet-solid'
+import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { HelloWorldClient } from './artifacts/HelloWorld/client'
+
+function CallContractAlgoKit() {
+  const {
+    activeAddress,
+    transactionSigner,
+    algodClient
+  } = useWallet()
+
+  const handleCall = async () => {
+    if (!activeAddress()) return
+
+    try {
+      // Initialize AlgorandClient with algodClient and signer from use-wallet
+      const algorand = AlgorandClient
+        .fromClients({ algod: algodClient() })
+        .setSigner(activeAddress(), transactionSigner)
+
+      // Get typed app client instance
+      const client = algorand.client.getTypedAppClientById(HelloWorldClient, {
+        appId: 123n,
+      })
+      
+      // Compose and send transaction group
+      const result = await client
+        .newGroup()
+        // Add ABI method call (type-safe!)
+        .hello({ args: { name: 'World' } })
+        // Add payment transaction
+        .addTransaction(
+          algorand.createTransaction.payment({
+            sender: activeAddress(),
+            receiver: activeAddress(),
+            amount: (1000).microAlgo()
+          })
+        )
+        .execute()
+
+      console.log('Transaction confirmed:', result.transaction.txID())
+      console.log('Return value:', result.return)
+    } catch (error) {
+      console.error('Error:', error)
+    }
+  }
+
+  return (
+    <button onClick={handleCall}>Call Contract</button>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+For more information, see:
+
+* [AlgoKit Utils (GitHub)](https://github.com/algorandfoundation/algokit-utils-ts)
+* [AlgorandClient documentation](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/docs/capabilities/algorand-client.md)
+* [Application Client Usage documentation](https://github.com/algorandfoundation/algokit-client-generator-ts/blob/main/docs/usage.md)
+* [TransactionComposer documentation](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/docs/capabilities/transaction-composer.md)

--- a/docs/guides/switching-networks.md
+++ b/docs/guides/switching-networks.md
@@ -1,0 +1,209 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Switching Networks
+
+use-wallet provides two ways to switch between Algorand networks:
+
+* Setting the default network at startup
+* Switching networks at runtime using the `useNetwork` hook/composable/primitive
+
+### Default Network
+
+When initializing the WalletManager, you can specify which network to use as the default:
+
+```typescript
+import { WalletManager, NetworkId } from '@txnlab/use-wallet'
+
+const manager = new WalletManager({
+  defaultNetwork: NetworkId.TESTNET
+})
+```
+
+You can also control whether the manager should reset to the default network on page load using the `resetNetwork` option:
+
+```typescript
+const manager = new WalletManager({
+  defaultNetwork: NetworkId.TESTNET,
+  options: {
+    // Always start on TestNet, even if the user was previously on a different network
+    resetNetwork: true
+  }
+})
+```
+
+When `resetNetwork` is `false` (the default), use-wallet will attempt to restore the last active network from local storage.
+
+### Runtime Network Switching
+
+The `useNetwork` hook/composable provides methods for switching networks at runtime.
+
+{% tabs %}
+{% tab title="React" %}
+```tsx
+import { useNetwork } from '@txnlab/use-wallet-react'
+
+function NetworkSwitch() {
+  const {
+    activeNetwork,
+    setActiveNetwork,
+    networkConfig
+  } = useNetwork()
+
+  return (
+    <select
+      value={activeNetwork}
+      onChange={(e) => setActiveNetwork(e.target.value)}
+    >
+      {Object.entries(networkConfig).map(([id, network]) => (
+        <option key={id} value={id}>
+          {id}
+        </option>
+      ))}
+    </select>
+  )
+}
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+import { useNetwork } from '@txnlab/use-wallet-vue'
+
+const {
+  activeNetwork,
+  setActiveNetwork,
+  networkConfig
+} = useNetwork()
+</script>
+
+<template>
+  <select
+    :value="activeNetwork"
+    @change="(e) => setActiveNetwork((e.target as HTMLSelectElement).value)"
+  >
+    <option
+      v-for="[id, network] in Object.entries(networkConfig)"
+      :key="id"
+      :value="id"
+    >
+      {{ id }}
+    </option>
+  </select>
+</template>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```tsx
+import { useNetwork } from '@txnlab/use-wallet-solid'
+
+function NetworkSwitch() {
+  const {
+    activeNetwork,
+    setActiveNetwork,
+    networkConfig
+  } = useNetwork()
+
+  return (
+    <select
+      value={activeNetwork()}
+      onChange={(e) => setActiveNetwork(e.currentTarget.value)}
+    >
+      {Object.entries(networkConfig()).map(([id, network]) => (
+        <option value={id}>
+          {id}
+        </option>
+      ))}
+    </select>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Network Status
+
+You can use the `activeNetworkConfig` to access information about the current network:
+
+{% tabs %}
+{% tab title="React" %}
+```typescript
+const { activeNetworkConfig } = useNetwork()
+
+// Check if we're on a test network
+const isTestnet = activeNetworkConfig.isTestnet
+
+// Get genesis ID
+const genesisId = activeNetworkConfig.genesisId
+```
+{% endtab %}
+
+{% tab title="Vue" %}
+```typescript
+<script setup lang="ts">
+const { activeNetworkConfig } = useNetwork()
+
+// Check if we're on a test network
+const isTestnet = computed(() => activeNetworkConfig.value.isTestnet)
+
+// Get genesis ID
+const genesisId = computed(() => activeNetworkConfig.value.genesisId)
+</script>
+```
+{% endtab %}
+
+{% tab title="Solid" %}
+```typescript
+const { activeNetworkConfig } = useNetwork()
+
+// Check if we're on a test network
+const isTestnet = () => activeNetworkConfig().isTestnet
+
+// Get genesis ID
+const genesisId = () => activeNetworkConfig().genesisId
+```
+{% endtab %}
+{% endtabs %}
+
+### Network Events
+
+When switching networks, several things happen automatically:
+
+1. The `algodClient` is updated to point to the new network
+2. Active wallet sessions are maintained (if the wallet supports the new network)
+3. The active network is saved to local storage
+
+### Wallet Compatibility
+
+Not all wallets support all networks. For example:
+
+* Exodus only works on MainNet
+* Defly and Pera only support MainNet and TestNet
+* The Mnemonic wallet only works on test networks
+* Custom networks may not be supported by all wallets
+
+Please refer to each wallet's documentation to determine which networks they support.
+
+### Default Networks
+
+use-wallet supports any AVM-compatible network and comes with default configurations for these Algorand networks:
+
+* MainNet
+* TestNet
+* BetaNet
+* LocalNet (for development)
+
+For details about configuring networks, including how to customize default networks and add custom networks, see the [Configuration](../getting-started/configuration.md#network-configuration) guide.

--- a/docs/guides/testing-with-mnemonic-wallet.md
+++ b/docs/guides/testing-with-mnemonic-wallet.md
@@ -1,0 +1,187 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Testing with Mnemonic Wallet
+
+The Mnemonic wallet provider enables automated testing of dApps by allowing direct entry of account mnemonics. While this removes the security features of traditional wallets that require explicit user interaction, it provides a way to automate end-to-end testing of your application.
+
+### Overview
+
+Most supported wallets are designed for production use and require manual user interaction for security. The Mnemonic provider removes these security constraints, making it ideal for:
+
+* End-to-end (E2E) testing
+* CI/CD pipelines
+* Test automation
+
+{% hint style="danger" %}
+The Mnemonic wallet is strictly for testing and development. For security reasons:
+
+* It cannot be used on MainNet
+* Mnemonics are stored in plaintext if persistence is enabled
+* Accounts should never hold real assets
+{% endhint %}
+
+### Configuration
+
+Add the Mnemonic provider to your WalletManager configuration:
+
+```typescript
+import { WalletManager, WalletId } from '@txnlab/use-wallet'
+
+const manager = new WalletManager({
+  wallets: [
+    // Production wallets...
+    WalletId.PERA,
+    WalletId.DEFLY,
+    
+    // Test wallet
+    {
+      id: WalletId.MNEMONIC,
+      options: {
+        // Optional: persist mnemonic to localStorage
+        persistToStorage: false
+      }
+    }
+  ],
+  defaultNetwork: 'testnet'
+})
+```
+
+### Session Persistence
+
+By default, the Mnemonic provider does not persist sessions to localStorage. This means:
+
+* The mnemonic must be re-entered after page reloads
+* The wallet disconnects when closing/reloading the page
+* Sessions cannot be resumed automatically
+
+To match the behavior of production wallets in tests, enable persistence:
+
+```typescript
+{
+  id: WalletId.MNEMONIC,
+  options: {
+    persistToStorage: true
+  }
+}
+```
+
+{% hint style="warning" %}
+When persistence is enabled:
+
+* Mnemonics are stored in plaintext in localStorage
+* Sessions persist until explicitly disconnected
+* Any stored mnemonics should be considered compromised
+{% endhint %}
+
+### End-to-End Testing
+
+The Mnemonic provider enables automated E2E testing with frameworks like [Playwright](https://playwright.dev/), [Cypress](https://www.cypress.io/), or [Selenium](https://www.selenium.dev/). It enables automated wallet connections and transaction signing without requiring manual user interaction.
+
+#### Example Test
+
+Here's a basic example using Playwright that demonstrates connecting to the wallet and verifying the connection:
+
+```typescript
+import { test, expect } from '@playwright/test'
+
+test('wallet connection flow', async ({ page }) => {
+  // Navigate to app
+  await page.goto('/')
+  
+  // Mock Algod responses
+  await mockAlgodResponses(page)
+  
+  // Handle mnemonic prompt
+  page.on('dialog', (dialog) => dialog.accept(
+    // !! WARNING !!
+    // THIS ACCOUNT IS COMPROMISED
+    // Use for testing only!
+    // !! WARNING !!
+    'sugar bronze century excuse animal jacket what rail biology symbol want craft annual soul increase question army win execute slim girl chief exhaust abstract wink'
+  ))
+  
+  // Verify Mnemonic wallet is available
+  await expect(page.getByRole('heading', { name: 'Mnemonic' })).toBeVisible()
+  
+  // Connect to wallet
+  await page
+    .locator('.wallet-group', {
+      has: page.locator('h4', { hasText: 'Mnemonic' })
+    })
+    .getByRole('button', { name: 'Connect' })
+    .click()
+    
+  // Verify connection succeeded
+  await expect(page.getByRole('heading', { name: 'Mnemonic [active]' })).toBeVisible()
+  
+  // Verify correct account is connected
+  await expect(page.getByRole('combobox')).toHaveValue(
+    '3F3FPW6ZQQYD6JDC7FKKQHNGVVUIBIZOUI5WPSJEHBRABZDRN6LOTBMFEY'
+  )
+})
+```
+
+#### Mocking Node Responses
+
+To create reliable and predictable tests, it's recommended to mock responses from the Algorand node. This prevents tests from failing due to network issues or rate limits, and allows testing specific scenarios:
+
+```typescript
+async function mockAlgodResponses(page: Page) {
+  // Mock transaction parameters
+  await page.route('**/v2/transactions/params', (route) => {
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({
+        'last-round': 1000,
+        'consensus-version': 'test-1.0',
+        'min-fee': 1000,
+        'genesis-hash': 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
+        'genesis-id': 'testnet-v1.0'
+      })
+    })
+  })
+
+  // Mock transaction submission
+  await page.route('**/v2/transactions', (route) => {
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ txId: 'TEST_TX_ID' })
+    })
+  })
+}
+```
+
+### Best Practices
+
+When using the Mnemonic provider for testing:
+
+* **Test Account Security**: Generate dedicated test accounts that will never be used in production. Consider these accounts compromised as their mnemonics are stored in test files.
+* **Mock API Responses**: Mock responses from the Algorand node to:
+  * Prevent overwhelming API providers with test requests
+  * Create predictable test scenarios
+  * Test error handling
+  * Speed up test execution
+* **Test Organization**: Structure tests to cover different wallet operations:
+  * Connection/disconnection flows
+  * Account switching
+  * Transaction signing
+  * Error handling
+  * Network switching
+* **CI/CD Integration**: The Mnemonic provider works well in CI/CD pipelines since it doesn't require user interaction. Consider:
+  * Storing test mnemonics securely (e.g., in CI environment variables)
+  * Running tests against LocalNet (sandbox) or a private network
+  * Including wallet tests in your automated test suite
+
+For complete testing examples, including mocking strategies and common test scenarios, see the [E2E test examples](https://github.com/TxnLab/use-wallet/tree/main/examples/e2e-tests) in the repository.

--- a/docs/resources/algokit-templates.md
+++ b/docs/resources/algokit-templates.md
@@ -1,0 +1,6 @@
+---
+hidden: true
+---
+
+# AlgoKit Templates
+

--- a/docs/resources/example-projects.md
+++ b/docs/resources/example-projects.md
@@ -1,0 +1,196 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Example Projects
+
+This page provides an overview of the example projects available in the use-wallet repository. Each example demonstrates key features and best practices for integrating use-wallet into different frameworks and environments.
+
+All examples are built with Vite or their respective meta-frameworks and include:
+
+* Complete wallet integration with all supported providers
+* Transaction signing demonstration
+* End-to-end tests with Playwright
+* TypeScript configuration
+* Runtime node configuration UI (Vite examples only)
+
+### Framework Examples
+
+#### **Vite (React)**
+
+```bash
+git clone https://github.com/TxnLab/use-wallet
+cd use-wallet/examples/react-ts
+pnpm install
+pnpm dev
+```
+
+The React example demonstrates:
+
+* React-specific hooks and patterns
+* Component composition with TypeScript
+* Integration with React's state management
+* Advanced features like runtime node configuration
+
+#### **Vite (Vue)**
+
+```bash
+git clone https://github.com/TxnLab/use-wallet
+cd use-wallet/examples/vue-ts
+pnpm install
+pnpm dev
+```
+
+The Vue example showcases:
+
+* Vue composables and plugins
+* Integration with Vue's reactivity system
+* TypeScript support in Vue components
+* Advanced features like runtime node configuration
+
+#### **Vite (SolidJS)**
+
+```bash
+git clone https://github.com/TxnLab/use-wallet
+cd use-wallet/examples/solid-ts
+pnpm install
+pnpm dev
+```
+
+The Solid example illustrates:
+
+* Solid.js primitives and patterns
+* Fine-grained reactivity integration
+* TypeScript configuration for Solid
+* Advanced features like runtime node configuration
+
+#### **Vite (Vanilla TypeScript)**
+
+```bash
+git clone https://github.com/TxnLab/use-wallet
+cd use-wallet/examples/vanilla-ts
+pnpm install
+pnpm dev
+```
+
+The Vanilla TypeScript example demonstrates:
+
+* Framework-agnostic usage
+* Direct WalletManager implementation
+* Custom state management
+* TypeScript configuration without a framework
+
+### Meta-Framework Examples
+
+#### **Next.js**
+
+```bash
+git clone https://github.com/TxnLab/use-wallet
+cd use-wallet/examples/nextjs
+pnpm install
+pnpm dev
+```
+
+The Next.js example demonstrates:
+
+* Server-side rendering considerations
+* Next.js-specific configuration
+* Integration with Next.js App Router
+* TypeScript configuration for Next.js
+
+#### **Nuxt**
+
+```bash
+git clone https://github.com/TxnLab/use-wallet
+cd use-wallet/examples/nuxt
+pnpm install
+pnpm dev
+```
+
+The Nuxt example showcases:
+
+* Server-side rendering with Vue
+* Nuxt module integration
+* Auto-imports configuration
+* TypeScript configuration for Nuxt
+
+### Key Features
+
+#### Wallet Integration
+
+All examples include a complete wallet connection interface demonstrating:
+
+* Connecting/disconnecting wallets
+* Switching active accounts
+* Transaction signing
+* Network management
+
+#### Runtime Node Configuration
+
+The Vite examples include a UI for configuring Algorand node settings at runtime:
+
+* Custom node URL/port/headers
+* Network switching
+* Configuration persistence
+
+For more information about this feature, see the [Runtime Node Configuration](../guides/runtime-node-configuration.md) guide.
+
+#### Testing
+
+All examples include end-to-end tests using Playwright, demonstrating:
+
+* Mocked Algorand node responses
+* Wallet connection testing
+* Transaction signing tests
+* Network switching tests
+
+For more information about testing, see the [Testing with Mnemonic Wallet](../guides/testing-with-mnemonic-wallet.md) guide.
+
+### Getting Started
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/TxnLab/use-wallet
+```
+
+2. Install dependencies:
+
+```bash
+cd use-wallet
+pnpm install
+```
+
+3. Build the packages:
+
+```bash
+pnpm build
+```
+
+4. Run an example using the provided scripts:
+
+```bash
+pnpm example:react   # Run React example
+pnpm example:vue     # Run Vue example
+pnpm example:solid   # Run Solid example
+pnpm example:ts      # Run Vanilla TypeScript example
+pnpm example:nextjs  # Run Next.js example
+pnpm example:nuxt    # Run Nuxt example
+```
+
+### Next Steps
+
+* Read the [framework-specific integration](broken-reference) guides for detailed setup instructions
+* Explore the [Connect Wallet Menu](../guides/connect-wallet-menu.md) guide to understand core wallet integration concepts and best practices
+* Learn about advanced features in the [Runtime Node Configuration](../guides/runtime-node-configuration.md) guide
+* Set up testing with the [Testing with Mnemonic Wallet](../guides/testing-with-mnemonic-wallet.md) guide


### PR DESCRIPTION
## Description

This PR integrates the v4 documentation from GitBook into the monorepo using GitBook's sync feature. The documentation is synchronized from GitBook ([use-wallet docs](https://txnlab.gitbook.io/use-wallet)) to the `docs` folder in the root of the monorepo.

## Details
- Add initial v4 documentation files from GitBook sync
- Configure GitBook sync to commit changes to `gitbook/v4` branch
- Place all documentation Markdown files in the `docs` folder
- Establish foundation for future documentation updates through GitBook sync
- Documentation covers v4.x features including:
  - Algorand SDK v3 support
  - Runtime node configuration
  - Custom networks support
  - Framework adapters (React, Vue, SolidJS)