### PR TITLE
Add `canonify` to signData docs, examples, and tests

### DIFF
--- a/docs/guides/signing-data.md
+++ b/docs/guides/signing-data.md
@@ -20,7 +20,7 @@ Here's how to implement ARC-60 authentication:
 import { useWallet } from '@txnlab/use-wallet-react'
 import algosdk from 'algosdk'
 import { ed } from '@noble/ed25519'
-import { canonify } from "canonify";
+import { canonify } from "canonify"
 
 function Authenticate() {
   const { activeAddress, activeWallet, signData } = useWallet()
@@ -90,7 +90,7 @@ function Authenticate() {
 import { useWallet } from '@txnlab/use-wallet-vue'
 import algosdk from 'algosdk'
 import { ed } from '@noble/ed25519'
-import { canonify } from "canonify";
+import { canonify } from "canonify"
 
 const { activeAddress, activeWallet, signData } = useWallet()
 
@@ -158,7 +158,7 @@ const handleAuth = async () => {
 import { useWallet } from '@txnlab/use-wallet-solid'
 import algosdk from 'algosdk'
 import { ed } from '@noble/ed25519'
-import { canonify } from "canonify";
+import { canonify } from "canonify"
 
 function Authenticate() {
   const { activeAddress, activeWallet, signData } = useWallet()

--- a/docs/guides/signing-data.md
+++ b/docs/guides/signing-data.md
@@ -20,6 +20,7 @@ Here's how to implement ARC-60 authentication:
 import { useWallet } from '@txnlab/use-wallet-react'
 import algosdk from 'algosdk'
 import { ed } from '@noble/ed25519'
+import { canonify } from "canonify";
 
 function Authenticate() {
   const { activeAddress, activeWallet, signData } = useWallet()
@@ -46,7 +47,8 @@ function Authenticate() {
       }
 
       // Convert request to base64
-      const dataString = JSON.stringify(siwaRequest)
+      const dataString = canonify(siwaRequest)
+      if (!dataString) throw Error('Invalid JSON')
       const data = btoa(dataString)
       
       // Sign data with authentication scope
@@ -88,6 +90,7 @@ function Authenticate() {
 import { useWallet } from '@txnlab/use-wallet-vue'
 import algosdk from 'algosdk'
 import { ed } from '@noble/ed25519'
+import { canonify } from "canonify";
 
 const { activeAddress, activeWallet, signData } = useWallet()
 
@@ -113,7 +116,8 @@ const handleAuth = async () => {
     }
 
     // Convert request to base64
-    const dataString = JSON.stringify(siwaRequest)
+    const dataString = canonify(siwaRequest)
+    if (!dataString) throw Error('Invalid JSON')
     const data = btoa(dataString)
     
     // Sign data with authentication scope
@@ -154,6 +158,7 @@ const handleAuth = async () => {
 import { useWallet } from '@txnlab/use-wallet-solid'
 import algosdk from 'algosdk'
 import { ed } from '@noble/ed25519'
+import { canonify } from "canonify";
 
 function Authenticate() {
   const { activeAddress, activeWallet, signData } = useWallet()
@@ -180,7 +185,8 @@ function Authenticate() {
       }
 
       // Convert request to base64
-      const dataString = JSON.stringify(siwaRequest)
+      const dataString = canonify(siwaRequest)
+      if (!dataString) throw Error('Invalid JSON')
       const data = btoa(dataString)
       
       // Sign data with authentication scope

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -16,6 +16,7 @@
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.19.2",
     "algosdk": "3.2.0",
+    "canonify": "^2.1.1",
     "lute-connect": "^1.6.1",
     "next": "14.2.26",
     "react": "18.3.1",

--- a/examples/nextjs/src/app/Connect.tsx
+++ b/examples/nextjs/src/app/Connect.tsx
@@ -12,6 +12,7 @@ import {
   type Wallet
 } from '@txnlab/use-wallet-react'
 import algosdk from 'algosdk'
+import { canonify } from 'canonify'
 import * as React from 'react'
 import styles from './Connect.module.css'
 
@@ -96,7 +97,8 @@ export function Connect() {
         version: '1',
         'issued-at': new Date().toISOString()
       }
-      const dataString = JSON.stringify(siwaRequest)
+      const dataString = canonify(siwaRequest)
+      if (!dataString) throw Error('Invalid JSON')
       const data = btoa(dataString)
       const metadata = { scope: ScopeType.AUTH, encoding: 'base64' }
       const resp = await signData(data, metadata)

--- a/examples/nuxt/components/Connect.vue
+++ b/examples/nuxt/components/Connect.vue
@@ -11,6 +11,7 @@ import {
   type Wallet
 } from '@txnlab/use-wallet-vue'
 import algosdk from 'algosdk'
+import { canonify } from 'canonify'
 import { ref } from 'vue'
 
 const { activeAddress, algodClient, signData, transactionSigner, wallets: walletsRef } = useWallet()
@@ -89,7 +90,8 @@ const auth = async () => {
       version: '1',
       'issued-at': new Date().toISOString()
     }
-    const dataString = JSON.stringify(siwaRequest)
+    const dataString = canonify(siwaRequest)
+    if (!dataString) throw Error('Invalid JSON')
     const data = btoa(dataString)
     const metadata = { scope: ScopeType.AUTH, encoding: 'base64' }
     const resp = await signData(data, metadata)

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -20,6 +20,7 @@
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.19.2",
     "algosdk": "3.2.0",
+    "canonify": "^2.1.1",
     "lute-connect": "^1.6.1",
     "nuxt": "3.16.1",
     "vue": "3.5.13",

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -17,6 +17,7 @@
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.19.2",
     "algosdk": "3.2.0",
+    "canonify": "^2.1.1",
     "lute-connect": "^1.6.1",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/examples/react-ts/src/Connect.tsx
+++ b/examples/react-ts/src/Connect.tsx
@@ -8,6 +8,7 @@ import {
   type Wallet
 } from '@txnlab/use-wallet-react'
 import algosdk from 'algosdk'
+import { canonify } from 'canonify'
 import * as React from 'react'
 
 export function Connect() {
@@ -90,7 +91,8 @@ export function Connect() {
         version: '1',
         'issued-at': new Date().toISOString()
       }
-      const dataString = JSON.stringify(siwaRequest)
+      const dataString = canonify(siwaRequest)
+      if (!dataString) throw Error('Invalid JSON')
       const data = btoa(dataString)
       const metadata = { scope: ScopeType.AUTH, encoding: 'base64' }
       const resp = await signData(data, metadata)

--- a/examples/solid-ts/package.json
+++ b/examples/solid-ts/package.json
@@ -18,6 +18,7 @@
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.19.2",
     "algosdk": "3.2.0",
+    "canonify": "^2.1.1",
     "lute-connect": "^1.6.1",
     "solid-js": "1.9.5"
   },

--- a/examples/solid-ts/src/Connect.tsx
+++ b/examples/solid-ts/src/Connect.tsx
@@ -8,6 +8,7 @@ import {
   type BaseWallet
 } from '@txnlab/use-wallet-solid'
 import algosdk from 'algosdk'
+import { canonify } from 'canonify'
 import { For, Show, createSignal } from 'solid-js'
 
 export function Connect() {
@@ -101,7 +102,8 @@ export function Connect() {
         version: '1',
         'issued-at': new Date().toISOString()
       }
-      const dataString = JSON.stringify(siwaRequest)
+      const dataString = canonify(siwaRequest)
+      if (!dataString) throw Error('Invalid JSON')
       const data = btoa(dataString)
       const metadata = { scope: ScopeType.AUTH, encoding: 'base64' }
       const resp = await signData(data, metadata)

--- a/examples/vanilla-ts/package.json
+++ b/examples/vanilla-ts/package.json
@@ -22,6 +22,7 @@
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.19.2",
     "algosdk": "3.2.0",
+    "canonify": "^2.1.1",
     "lute-connect": "^1.6.1"
   }
 }

--- a/examples/vanilla-ts/src/WalletComponent.ts
+++ b/examples/vanilla-ts/src/WalletComponent.ts
@@ -8,6 +8,7 @@ import {
   WalletManager
 } from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
+import { canonify } from 'canonify'
 
 export class WalletComponent {
   wallet: BaseWallet
@@ -91,7 +92,8 @@ export class WalletComponent {
         version: '1',
         'issued-at': new Date().toISOString()
       }
-      const dataString = JSON.stringify(siwaRequest)
+      const dataString = canonify(siwaRequest)
+      if (!dataString) throw Error('Invalid JSON')
       const data = btoa(dataString)
       const metadata = { scope: ScopeType.AUTH, encoding: 'base64' }
       const resp = await this.wallet.signData(data, metadata)

--- a/examples/vue-ts/package.json
+++ b/examples/vue-ts/package.json
@@ -17,6 +17,7 @@
     "@walletconnect/modal": "^2.7.0",
     "@walletconnect/sign-client": "^2.19.2",
     "algosdk": "3.2.0",
+    "canonify": "^2.1.1",
     "lute-connect": "^1.6.1",
     "vue": "3.5.13"
   },

--- a/examples/vue-ts/src/components/Connect.vue
+++ b/examples/vue-ts/src/components/Connect.vue
@@ -9,6 +9,7 @@ import {
   type Wallet
 } from '@txnlab/use-wallet-vue'
 import algosdk from 'algosdk'
+import { canonify } from 'canonify'
 import { ref } from 'vue'
 
 const { activeAddress, algodClient, transactionSigner, signData, wallets } = useWallet()
@@ -82,7 +83,8 @@ const auth = async () => {
       version: '1',
       'issued-at': new Date().toISOString()
     }
-    const dataString = JSON.stringify(siwaRequest)
+    const dataString = canonify(siwaRequest)
+    if (!dataString) throw Error('Invalid JSON')
     const data = btoa(dataString)
     const metadata = { scope: ScopeType.AUTH, encoding: 'base64' }
     const resp = await signData(data, metadata)

--- a/packages/use-wallet/package.json
+++ b/packages/use-wallet/package.json
@@ -51,6 +51,7 @@
     "@walletconnect/sign-client": "2.19.2",
     "@walletconnect/types": "2.19.2",
     "algosdk": "3.2.0",
+    "canonify": "^2.1.1",
     "lute-connect": "1.6.1",
     "magic-sdk": "28.21.1",
     "tsup": "8.4.0",

--- a/packages/use-wallet/src/__tests__/wallets/lute.test.ts
+++ b/packages/use-wallet/src/__tests__/wallets/lute.test.ts
@@ -1,5 +1,6 @@
 import { Store } from '@tanstack/store'
 import algosdk from 'algosdk'
+import { canonify } from 'canonify'
 import { logger } from 'src/logger'
 import { StorageAdapter } from 'src/storage'
 import { LOCAL_STORAGE_KEY, State, WalletState, DEFAULT_STATE } from 'src/store'
@@ -473,7 +474,8 @@ describe('LuteWallet', () => {
         'issued-at': new Date().toISOString()
       }
 
-      const dataString = JSON.stringify(siwaRequest)
+      const dataString = canonify(siwaRequest)
+      if (!dataString) throw Error('Invalid JSON')
       const data = btoa(dataString)
       const metadata = { scope: ScopeType.AUTH, encoding: 'base64' }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       algosdk:
         specifier: 3.2.0
         version: 3.2.0
+      canonify:
+        specifier: ^2.1.1
+        version: 2.1.1
       lute-connect:
         specifier: ^1.6.1
         version: 1.6.1
@@ -144,6 +147,9 @@ importers:
       algosdk:
         specifier: 3.2.0
         version: 3.2.0
+      canonify:
+        specifier: ^2.1.1
+        version: 2.1.1
       lute-connect:
         specifier: ^1.6.1
         version: 1.6.1
@@ -190,6 +196,9 @@ importers:
       algosdk:
         specifier: 3.2.0
         version: 3.2.0
+      canonify:
+        specifier: ^2.1.1
+        version: 2.1.1
       lute-connect:
         specifier: ^1.6.1
         version: 1.6.1
@@ -254,6 +263,9 @@ importers:
       algosdk:
         specifier: 3.2.0
         version: 3.2.0
+      canonify:
+        specifier: ^2.1.1
+        version: 2.1.1
       lute-connect:
         specifier: ^1.6.1
         version: 1.6.1
@@ -294,6 +306,9 @@ importers:
       algosdk:
         specifier: 3.2.0
         version: 3.2.0
+      canonify:
+        specifier: ^2.1.1
+        version: 2.1.1
       lute-connect:
         specifier: ^1.6.1
         version: 1.6.1
@@ -331,6 +346,9 @@ importers:
       algosdk:
         specifier: 3.2.0
         version: 3.2.0
+      canonify:
+        specifier: ^2.1.1
+        version: 2.1.1
       lute-connect:
         specifier: ^1.6.1
         version: 1.6.1
@@ -390,6 +408,9 @@ importers:
       algosdk:
         specifier: 3.2.0
         version: 3.2.0
+      canonify:
+        specifier: ^2.1.1
+        version: 2.1.1
       lute-connect:
         specifier: 1.6.1
         version: 1.6.1
@@ -2549,6 +2570,9 @@ packages:
 
   caniuse-lite@1.0.30001707:
     resolution: {integrity: sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==}
+
+  canonify@2.1.1:
+    resolution: {integrity: sha512-bDHlvXhY1fmi9P6cF8PVvs0G7+zOGKYww+5OLBM30+TotDif8tvKFCpdIqP0MJT5vDAgdgvm6CToLnH3RRIhAA==}
 
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
@@ -8953,6 +8977,8 @@ snapshots:
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001707: {}
+
+  canonify@2.1.1: {}
 
   chai@5.2.0:
     dependencies:


### PR DESCRIPTION
Documentation, examples, and tests for `signData` need to canonize the JSON rather than just stringify it. I published a `canonify` package and implemented it in all the mentioned places.

https://www.npmjs.com/package/canonify