### PR TITLE
feat: generic accounts

### DIFF
--- a/packages/core/src/__tests__/generic-store.test.ts
+++ b/packages/core/src/__tests__/generic-store.test.ts
@@ -1,0 +1,474 @@
+import { Store } from '@tanstack/store'
+import { logger } from 'src/logger'
+import { WalletManager } from 'src/manager'
+import {
+  DEFAULT_STATE,
+  LOCAL_STORAGE_KEY,
+  PersistedState,
+  State,
+  addWallet,
+  removeWallet,
+  setAccounts,
+  setActiveAccount,
+  setActiveWallet
+} from 'src/store'
+import { StorageAdapter } from 'src/storage'
+import type {
+  InferWalletAccounts,
+  Wallet,
+  WalletAccount,
+  WalletAdapterConfig
+} from 'src/wallets/types'
+
+vi.mock('src/logger', () => {
+  const mockLogger = {
+    createScopedLogger: vi.fn().mockReturnValue({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+  return {
+    Logger: {
+      setLevel: vi.fn()
+    },
+    LogLevel: {
+      DEBUG: 0,
+      INFO: 1,
+      WARN: 2,
+      ERROR: 3
+    },
+    logger: mockLogger
+  }
+})
+
+// Mock storage adapter
+vi.mock('src/storage', () => ({
+  StorageAdapter: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn()
+  }
+}))
+
+// Suppress console output
+vi.spyOn(console, 'info').mockImplementation(() => {})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(logger.createScopedLogger).mockReturnValue({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+})
+
+// Custom account type extending WalletAccount with rich, optional extras
+interface RichAccount extends WalletAccount {
+  balance?: bigint
+  type?: string
+}
+
+describe('Generic store mutations', () => {
+  let store: Store<State<RichAccount>>
+
+  const account1: RichAccount = {
+    name: 'Rich Account 1',
+    address: 'address1',
+    balance: 1000n,
+    type: 'keystore-account'
+  }
+  const account2: RichAccount = {
+    name: 'Rich Account 2',
+    address: 'address2'
+  }
+
+  beforeEach(() => {
+    store = new Store<State<RichAccount>>(DEFAULT_STATE as State<RichAccount>)
+  })
+
+  it('accepts a Store<State<T>> with a custom account type', () => {
+    addWallet(store, {
+      walletId: 'custom',
+      wallet: { accounts: [account1], activeAccount: account1 }
+    })
+
+    const wallet = store.state.wallets['custom']
+    expect(wallet?.accounts).toEqual([account1])
+    // Rich fields are statically typed, no casts needed
+    expect(wallet?.accounts[0].balance).toBe(1000n)
+    expect(wallet?.activeAccount?.type).toBe('keystore-account')
+    expect(store.state.activeWallet).toBe('custom')
+  })
+
+  it('setAccounts preserves the custom account type', () => {
+    addWallet(store, {
+      walletId: 'custom',
+      wallet: { accounts: [account1], activeAccount: account1 }
+    })
+
+    setAccounts(store, { walletId: 'custom', accounts: [account1, account2] })
+
+    const wallet = store.state.wallets['custom']
+    expect(wallet?.accounts).toEqual([account1, account2])
+    expect(wallet?.activeAccount).toEqual(account1)
+  })
+
+  it('setActiveAccount and removeWallet operate on the generic store', () => {
+    addWallet(store, {
+      walletId: 'custom',
+      wallet: { accounts: [account1, account2], activeAccount: account1 }
+    })
+
+    setActiveAccount(store, { walletId: 'custom', address: 'address2' })
+    expect(store.state.wallets['custom']?.activeAccount).toEqual(account2)
+
+    removeWallet(store, { walletId: 'custom' })
+    expect(store.state.wallets['custom']).toBeUndefined()
+    expect(store.state.activeWallet).toBeNull()
+  })
+
+  it('mutations preserve extra state fields (shape preservation)', () => {
+    addWallet(store, {
+      walletId: 'custom',
+      wallet: { accounts: [account1], activeAccount: account1 }
+    })
+    setActiveWallet(store, { walletId: 'custom' })
+
+    expect(store.state.activeNetwork).toBe(DEFAULT_STATE.activeNetwork)
+    expect(store.state.algodClient).toBe(DEFAULT_STATE.algodClient)
+    expect(store.state.networkConfig).toEqual(DEFAULT_STATE.networkConfig)
+    expect(store.state.managerStatus).toBe(DEFAULT_STATE.managerStatus)
+  })
+})
+
+describe('WalletManager with injected store', () => {
+  it('adopts the injected store instance', () => {
+    const store = new Store<State>(DEFAULT_STATE)
+    const manager = new WalletManager({ options: { store } })
+
+    expect(manager.store).toBe(store)
+  })
+
+  it('hydrates manager-derived state into the injected store', () => {
+    const store = new Store<State>(DEFAULT_STATE)
+    const manager = new WalletManager({ defaultNetwork: 'mainnet', options: { store } })
+
+    expect(manager.store).toBe(store)
+    expect(store.state.activeNetwork).toBe('mainnet')
+    expect(store.state.networkConfig['mainnet']).toBeDefined()
+    expect(store.state.algodClient).toBeDefined()
+  })
+
+  it('hydrates persisted state into the injected store like the private path', () => {
+    const persistedAccount = { name: 'Persisted Account', address: 'persisted-address' }
+    const persistedState: PersistedState = {
+      wallets: {
+        defly: { accounts: [persistedAccount], activeAccount: persistedAccount }
+      },
+      activeWallet: 'defly',
+      activeNetwork: 'testnet',
+      customNetworkConfigs: {}
+    }
+    vi.mocked(StorageAdapter.getItem).mockImplementation((key: string) =>
+      key === LOCAL_STORAGE_KEY ? JSON.stringify(persistedState) : null
+    )
+
+    const store = new Store<State>(DEFAULT_STATE)
+    new WalletManager({ options: { store } })
+
+    // Persisted entry without a registered adapter is cleaned up, exactly
+    // as it would be with a privately created store
+    expect(store.state.wallets['defly']).toBeUndefined()
+    expect(store.state.activeWallet).toBeNull()
+  })
+
+  it('keeps wallet entries written to the injected store before construction', () => {
+    const account = { name: 'Extension Account', address: 'ext-address' }
+    const store = new Store<State>({
+      ...DEFAULT_STATE,
+      wallets: {
+        'provider-id': { accounts: [account], activeAccount: account }
+      },
+      activeWallet: 'provider-id'
+    })
+
+    const manager = new WalletManager({ options: { store } })
+
+    // Externally owned keys are honored: hydration spreads the manager's
+    // initial state over them and stale-wallet cleanup never touches keys
+    // the manager did not hydrate itself
+    expect(manager.store.state.wallets['provider-id']).toEqual({
+      accounts: [account],
+      activeAccount: account
+    })
+    expect(manager.store.state.activeWallet).toBe('provider-id')
+  })
+
+  it('live entries win over persisted entries on colliding wallet keys', () => {
+    const persistedAccount = { name: 'Persisted Account', address: 'persisted-address' }
+    const persistedState: PersistedState = {
+      wallets: {
+        'provider-id': { accounts: [persistedAccount], activeAccount: persistedAccount }
+      },
+      activeWallet: null,
+      activeNetwork: 'testnet',
+      customNetworkConfigs: {}
+    }
+    vi.mocked(StorageAdapter.getItem).mockImplementation((key: string) =>
+      key === LOCAL_STORAGE_KEY ? JSON.stringify(persistedState) : null
+    )
+
+    const liveAccount = { name: 'Live Account', address: 'live-address' }
+    const store = new Store<State>({
+      ...DEFAULT_STATE,
+      wallets: {
+        'provider-id': { accounts: [liveAccount], activeAccount: liveAccount }
+      },
+      activeWallet: null
+    })
+
+    new WalletManager({ options: { store } })
+
+    // A key that already exists in the store is owned by an outside writer;
+    // the stale persisted entry neither replaces it nor marks it for cleanup
+    expect(store.state.wallets['provider-id']).toEqual({
+      accounts: [liveAccount],
+      activeAccount: liveAccount
+    })
+  })
+
+  it('keeps wallet entries written to the injected store after construction', () => {
+    const store = new Store<State>(DEFAULT_STATE)
+    const manager = new WalletManager({ options: { store } })
+
+    // e.g. a wallet-provider extension writing under its own wallet key
+    const account = { name: 'Extension Account', address: 'ext-address' }
+    addWallet(store, {
+      walletId: 'provider-id',
+      wallet: { accounts: [account], activeAccount: account }
+    })
+
+    // Stale-wallet cleanup only runs during construction, so entries written
+    // afterwards are untouched by the manager
+    expect(manager.store.state.wallets['provider-id']).toEqual({
+      accounts: [account],
+      activeAccount: account
+    })
+    expect(manager.store.state.activeWallet).toBe('provider-id')
+  })
+
+  it('falls back to creating a private store when none is injected', () => {
+    const manager = new WalletManager()
+    expect(manager.store).toBeInstanceOf(Store)
+    expect(manager.store.state.wallets).toEqual({})
+  })
+})
+
+// ---------- Downstream account narrowing ---------------------------- //
+
+// A single wallet's `accounts` can be a mix of unique account types that
+// only share the base `WalletAccount` shape (name/address). Any per-type
+// extras live off the common base, so consumers recast/narrow individually.
+interface QuantumAccount extends WalletAccount {
+  kind: 'quantum'
+  handleQuantumOperation: () => string
+}
+
+interface ClassicAccount extends WalletAccount {
+  kind: 'classic'
+  legacyId: number
+}
+
+// User-defined type guards operating on the open base type
+function isQuantumAccount(account: WalletAccount): account is QuantumAccount {
+  return (account as Partial<QuantumAccount>).kind === 'quantum'
+}
+
+function isClassicAccount(account: WalletAccount): account is ClassicAccount {
+  return (account as Partial<ClassicAccount>).kind === 'classic'
+}
+
+// The preferred, documented way to type a wallet whose accounts are a mix of
+// known kinds is an *open union* carried by the manager (e.g.
+// `WalletManager<MixedAccount>`), mirroring the wallet-provider accounts store
+// and its open account type unions. Consumers receive the union through the
+// framework hooks via a `Register` declaration; each element then narrows to a
+// specific member via a type guard, with no cast at the call site.
+type MixedAccount = QuantumAccount | ClassicAccount
+
+describe('Downstream account narrowing', () => {
+  const quantum: QuantumAccount = {
+    name: 'Quantum Account',
+    address: 'q-address',
+    kind: 'quantum',
+    handleQuantumOperation: () => 'entangled'
+  }
+
+  const classic: ClassicAccount = {
+    name: 'Classic Account',
+    address: 'c-address',
+    kind: 'classic',
+    legacyId: 7
+  }
+
+  it('narrows a heterogeneous accounts array from the default Wallet shape', () => {
+    // This is exactly what `const { wallets } = useWallet()` yields: the
+    // account type defaults to the open base `WalletAccount`, so a single
+    // wallet may hold a mix of subtypes.
+    const wallet: Wallet = {
+      id: 'mixed',
+      walletKey: 'mixed',
+      metadata: { name: 'Mixed', icon: '' },
+      accounts: [quantum, classic],
+      activeAccount: quantum,
+      isConnected: true,
+      isActive: true,
+      canSignData: false,
+      canUsePrivateKey: false,
+      connect: async () => [],
+      disconnect: async () => {},
+      setActive: () => {},
+      setActiveAccount: () => {}
+    }
+
+    // Recast/narrow in the downstream consumer via the type guard.
+    const first = wallet.accounts[0]
+    if (isQuantumAccount(first)) {
+      // `first` is now `QuantumAccount`; subtype members are available.
+      expect(first.handleQuantumOperation()).toBe('entangled')
+    } else {
+      throw new Error('expected the first account to narrow to QuantumAccount')
+    }
+
+    // A sibling subtype in the same wallet narrows independently.
+    const second = wallet.accounts[1]
+    expect(isQuantumAccount(second)).toBe(false)
+  })
+
+  it('narrows the mixed accounts held by the base store', () => {
+    // The manager owns a single `Store<State>` at the base account type;
+    // heterogeneous accounts round-trip and stay narrowable afterwards.
+    const store = new Store<State>(DEFAULT_STATE)
+    addWallet(store, {
+      walletId: 'mixed',
+      wallet: { accounts: [quantum, classic], activeAccount: quantum }
+    })
+
+    const accounts = store.state.wallets['mixed']?.accounts ?? []
+    const quantumAccounts = accounts.filter(isQuantumAccount)
+
+    expect(quantumAccounts).toHaveLength(1)
+    expect(quantumAccounts[0].handleQuantumOperation()).toBe('entangled')
+  })
+
+  it('narrows within a union account type passed to the generic seat', () => {
+    // The preferred pattern: a registered `WalletManager<MixedAccount>` makes
+    // the hooks yield `Wallet<MixedAccount>`, so `accounts` is `(QuantumAccount | ClassicAccount)[]`.
+    // The type param does NOT collapse the wallet to a single kind; it keeps
+    // every member of the union statically visible, ready to narrow per element.
+    const wallet: Wallet<MixedAccount> = {
+      id: 'mixed',
+      walletKey: 'mixed',
+      metadata: { name: 'Mixed', icon: '' },
+      accounts: [quantum, classic],
+      activeAccount: quantum,
+      isConnected: true,
+      isActive: true,
+      canSignData: false,
+      canUsePrivateKey: false,
+      connect: async () => [],
+      disconnect: async () => {},
+      setActive: () => {},
+      setActiveAccount: () => {}
+    }
+
+    // Each element is already `QuantumAccount | ClassicAccount`; a type guard
+    // narrows it to the exact member without any cast at the call site.
+    for (const account of wallet.accounts) {
+      if (isQuantumAccount(account)) {
+        expect(account.handleQuantumOperation()).toBe('entangled')
+      } else if (isClassicAccount(account)) {
+        expect(account.legacyId).toBe(7)
+      } else {
+        throw new Error('account did not narrow to a known union member')
+      }
+    }
+
+    // `activeAccount` carries the same union and narrows the same way.
+    if (wallet.activeAccount && isQuantumAccount(wallet.activeAccount)) {
+      expect(wallet.activeAccount.handleQuantumOperation()).toBe('entangled')
+    } else {
+      throw new Error('expected the active account to narrow to QuantumAccount')
+    }
+  })
+})
+
+// ---------- Account type inference from construction ---------------- //
+
+// Type-level equality assertion helpers: `Eq<A, B>` resolves to the literal
+// type `true` only when A and B are identical, so `const x: Eq<A, B> = true`
+// fails to compile if the inference ever regresses.
+type Eq<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false
+
+// Adapter configs declaring dedicated account types (as future adapter
+// factories will, e.g. `WalletAdapterConfig<PQAccount>`). Declared
+// type-only; they are never evaluated at runtime.
+declare const quantumConfig: WalletAdapterConfig<QuantumAccount>
+declare const classicConfig: WalletAdapterConfig<ClassicAccount>
+
+// Never executed; exists purely to exercise the real inference path of
+// `WalletManager.create` with a heterogeneous wallets array.
+function typeOnlyCreate() {
+  return WalletManager.create({ wallets: [quantumConfig, classicConfig] })
+}
+
+describe('Account type inference from construction', () => {
+  it('infers the union of adapter account types (type-level)', () => {
+    // WalletManager.create([quantum, classic]) => WalletManager<Quantum | Classic>
+    const inferredUnion: Eq<
+      ReturnType<typeof typeOnlyCreate>,
+      WalletManager<QuantumAccount | ClassicAccount>
+    > = true
+
+    // InferWalletAccounts unites the account types of a configs tuple
+    const tupleUnion: Eq<
+      InferWalletAccounts<
+        [WalletAdapterConfig<QuantumAccount>, WalletAdapterConfig<ClassicAccount>]
+      >,
+      QuantumAccount | ClassicAccount
+    > = true
+
+    // Configs without a dedicated account type resolve to the base account
+    const baseDefault: Eq<InferWalletAccounts<WalletAdapterConfig[]>, WalletAccount> = true
+
+    // An empty wallets array resolves to the base account, not `never`
+    const emptyDefault: Eq<InferWalletAccounts<[]>, WalletAccount> = true
+
+    expect(inferredUnion && tupleUnion && baseDefault && emptyDefault).toBe(true)
+    expect(typeof typeOnlyCreate).toBe('function')
+  })
+
+  it('create() without wallets behaves like the constructor', () => {
+    const manager = WalletManager.create()
+    expect(manager).toBeInstanceOf(WalletManager)
+    expect(manager.store.state.wallets).toEqual({})
+
+    // Bare create() defaults to the base account type
+    const baseAccount: Eq<typeof manager, WalletManager<WalletAccount>> = true
+    expect(baseAccount).toBe(true)
+  })
+
+  it('create() adopts an injected store typed at the inferred account type', () => {
+    const store = new Store<State>(DEFAULT_STATE)
+    const manager = WalletManager.create({ options: { store } })
+
+    expect(manager.store).toBe(store)
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,19 @@ export {
   type AlgodConfig,
   type NetworkConfig
 } from './network'
-export { DEFAULT_STATE, type State, type WalletState, type ManagerStatus } from './store'
+export {
+  DEFAULT_STATE,
+  addWallet,
+  removeWallet,
+  setAccounts,
+  setActiveAccount,
+  setActiveWallet,
+  type State,
+  type WalletState,
+  type WalletStateMap,
+  type PersistedState,
+  type ManagerStatus
+} from './store'
 export { StorageAdapter } from './storage'
 export {
   SecureKeyContainer,

--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -28,31 +28,33 @@ import type { BaseWallet } from 'src/wallets/base'
 import type {
   AdapterConstructorParams,
   AdapterStoreAccessor,
+  InferWalletAccounts,
   WalletAccount,
   WalletAdapterConfig,
   WalletCapabilities,
   WalletKey
 } from 'src/wallets/types'
 
-export interface WalletManagerOptions {
+export interface WalletManagerOptions<TAccount extends WalletAccount = WalletAccount> {
   persistNetwork?: boolean
   debug?: boolean
   logLevel?: LogLevel
+  store?: Store<State<TAccount>>
 }
 
-export interface WalletManagerConfig {
-  wallets?: WalletAdapterConfig[]
+export interface WalletManagerConfig<TAccount extends WalletAccount = WalletAccount> {
+  wallets?: readonly WalletAdapterConfig<any>[]
   networks?: Record<string, NetworkConfig>
   defaultNetwork?: string
-  options?: WalletManagerOptions
+  options?: WalletManagerOptions<TAccount>
 }
 
-export class WalletManager {
-  public _clients: Map<WalletKey, BaseWallet> = new Map()
+export class WalletManager<TAccount extends WalletAccount = WalletAccount> {
+  public _clients: Map<WalletKey, BaseWallet<any>> = new Map()
   private _capabilities: Map<WalletKey, WalletCapabilities> = new Map()
   private baseNetworkConfig: Record<string, NetworkConfig>
-  public store: Store<State>
-  public subscribe: (callback: (state: State) => void) => () => void
+  public store: Store<State<TAccount>>
+  public subscribe: (callback: (state: State<TAccount>) => void) => () => void
   public options: { persistNetwork: boolean }
 
   private logger: ReturnType<typeof logger.createScopedLogger>
@@ -63,7 +65,7 @@ export class WalletManager {
     networks,
     defaultNetwork = 'testnet',
     options = {}
-  }: WalletManagerConfig = {}) {
+  }: WalletManagerConfig<TAccount> = {}) {
     // Initialize scoped logger
     this.logger = this.initializeLogger(options)
 
@@ -100,7 +102,7 @@ export class WalletManager {
     const algodClient = this.createAlgodClient(networkConfig[activeNetwork].algod)
 
     // Create initial state
-    const initialState: State = {
+    const initialState: State<TAccount> = {
       ...DEFAULT_STATE,
       ...persistedState,
       networkConfig,
@@ -108,8 +110,22 @@ export class WalletManager {
       algodClient
     }
 
-    // Create store
-    this.store = new Store<State>(initialState)
+    // Create store, or adopt an injected instance and hydrate it.
+    const injectedStore = options.store
+    const preExistingWalletKeys = injectedStore ? Object.keys(injectedStore.state.wallets) : []
+    if (injectedStore) {
+      this.store = injectedStore
+      injectedStore.setState((state) => ({
+        ...initialState,
+        wallets: {
+          ...initialState.wallets,
+          ...state.wallets
+        },
+        activeWallet: state.activeWallet ?? initialState.activeWallet
+      }))
+    } else {
+      this.store = new Store<State<TAccount>>(initialState)
+    }
 
     // Track active network for change detection
     let previousNetwork = activeNetwork
@@ -138,7 +154,7 @@ export class WalletManager {
     this.savePersistedState()
 
     // Subscribe to store updates
-    this.subscribe = (callback: (state: State) => void): (() => void) => {
+    this.subscribe = (callback: (state: State<TAccount>) => void): (() => void) => {
       const subscription = this.store.subscribe(() => {
         callback(this.store.state)
       })
@@ -147,7 +163,27 @@ export class WalletManager {
     }
 
     // Initialize wallets
-    this.initializeWallets(wallets)
+    const hydratedWalletKeys = Object.keys(initialState.wallets).filter(
+      (key) => !preExistingWalletKeys.includes(key)
+    ) as WalletKey[]
+    this.initializeWallets(wallets, hydratedWalletKeys)
+  }
+
+  // Creates a WalletManager whose account type parameter is inferred as the
+  // union of the account types declared by the given adapter configs, e.g.
+  // WalletManager<PQAccount>. Direct construction (new WalletManager<T>(...))
+  // cannot perform this inference: TypeScript fixes the class type parameter
+  // from the first array element instead of uniting the candidates. The static
+  // factory captures the configs as a tuple type and derives the union from it.
+  static create<TConfigs extends readonly WalletAdapterConfig<any>[] = WalletAdapterConfig[]>(
+    config?: Omit<WalletManagerConfig, 'wallets' | 'options'> & {
+      wallets?: TConfigs
+      options?: WalletManagerOptions<NoInfer<InferWalletAccounts<TConfigs>>>
+    }
+  ): WalletManager<InferWalletAccounts<TConfigs>> {
+    return new WalletManager<InferWalletAccounts<TConfigs>>(
+      config as WalletManagerConfig<InferWalletAccounts<TConfigs>>
+    )
   }
 
   // ---------- Events ------------------------------------------------- //
@@ -166,7 +202,7 @@ export class WalletManager {
     this.events.emit(event, ...args)
   }
 
-  private emitLifecycleEvents(prev: State, next: State): void {
+  private emitLifecycleEvents(prev: State<TAccount>, next: State<TAccount>): void {
     if (next.wallets !== prev.wallets) {
       for (const [walletId, walletState] of Object.entries(next.wallets)) {
         if (!walletState) continue
@@ -196,14 +232,14 @@ export class WalletManager {
   // ---------- Logging ----------------------------------------------- //
 
   private initializeLogger(
-    options: WalletManagerOptions
+    options: WalletManagerOptions<TAccount>
   ): ReturnType<typeof logger.createScopedLogger> {
     const logLevel = this.determineLogLevel(options)
     Logger.setLevel(logLevel)
     return logger.createScopedLogger('WalletManager')
   }
 
-  private determineLogLevel(options: WalletManagerOptions): LogLevel {
+  private determineLogLevel(options: WalletManagerOptions<TAccount>): LogLevel {
     if (options?.debug) {
       return LogLevel.DEBUG
     }
@@ -223,14 +259,14 @@ export class WalletManager {
     }))
   }
 
-  private loadPersistedState(): PersistedState | null {
+  private loadPersistedState(): PersistedState<TAccount> | null {
     try {
       const serializedState = StorageAdapter.getItem(LOCAL_STORAGE_KEY)
       if (serializedState === null) {
         return null
       }
       const parsedState = JSON.parse(serializedState)
-      if (!isValidPersistedState(parsedState)) {
+      if (!isValidPersistedState<TAccount>(parsedState)) {
         this.logger.warn('Parsed state:', parsedState)
         throw new Error('Persisted state is invalid')
       }
@@ -244,7 +280,7 @@ export class WalletManager {
   private savePersistedState(): void {
     try {
       const { wallets, activeWallet, activeNetwork, networkConfig } = this.store.state
-      const persistedState: PersistedState = {
+      const persistedState: PersistedState<TAccount> = {
         wallets,
         activeWallet,
         activeNetwork,
@@ -284,17 +320,21 @@ export class WalletManager {
 
   // ---------- Scoped Store Access ----------------------------------- //
 
-  private createStoreAccessor(walletKey: string): AdapterStoreAccessor {
+  private createStoreAccessor<T extends WalletAccount>(walletKey: string): AdapterStoreAccessor<T> {
+    // The adapter's account type `T` is independent of the manager's
+    // `TAccount`: the shared store holds all wallets, so mutations are
+    // funneled through a store view scoped to the adapter's own type.
+    const store = this.store as unknown as Store<State<T>>
     return {
-      getWalletState: () => this.store.state.wallets[walletKey],
+      getWalletState: () => store.state.wallets[walletKey],
       getActiveWallet: () => this.store.state.activeWallet,
       getActiveNetwork: () => this.store.state.activeNetwork,
       getState: () => this.store.state,
-      addWallet: (wallet) => addWallet(this.store, { walletId: walletKey, wallet }),
-      removeWallet: () => removeWallet(this.store, { walletId: walletKey }),
-      setAccounts: (accounts) => setAccounts(this.store, { walletId: walletKey, accounts }),
-      setActiveAccount: (address) => setActiveAccount(this.store, { walletId: walletKey, address }),
-      setActive: () => setActiveWallet(this.store, { walletId: walletKey })
+      addWallet: (wallet) => addWallet(store, { walletId: walletKey, wallet }),
+      removeWallet: () => removeWallet(store, { walletId: walletKey }),
+      setAccounts: (accounts) => setAccounts(store, { walletId: walletKey, accounts }),
+      setActiveAccount: (address) => setActiveAccount(store, { walletId: walletKey, address }),
+      setActive: () => setActiveWallet(store, { walletId: walletKey })
     }
   }
 
@@ -310,7 +350,10 @@ export class WalletManager {
 
   // ---------- Wallets ----------------------------------------------- //
 
-  private initializeWallets(walletConfigs: WalletAdapterConfig[]) {
+  private initializeWallets(
+    walletConfigs: readonly WalletAdapterConfig<any>[],
+    hydratedWalletKeys: WalletKey[]
+  ) {
     this.logger.info('Initializing wallets...')
 
     for (const config of walletConfigs) {
@@ -323,7 +366,7 @@ export class WalletManager {
 
       const storeAccessor = this.createStoreAccessor(walletKey)
 
-      const params: AdapterConstructorParams = {
+      const params: AdapterConstructorParams<any> = {
         id: config.id,
         metadata: config.metadata,
         store: storeAccessor,
@@ -346,25 +389,26 @@ export class WalletManager {
       this.logger.info(`Initialized ${walletKey}`)
     }
 
-    const state = this.store.state
-
-    // Check if connected wallets are still valid
-    const connectedWallets = Object.keys(state.wallets) as WalletKey[]
-    for (const walletKey of connectedWallets) {
-      if (!this._clients.has(walletKey)) {
+    // Check if connected wallets are still valid. Only wallet entries the
+    // manager hydrated itself are candidates for cleanup; entries under
+    // keys owned by external writers are honored.
+    for (const walletKey of hydratedWalletKeys) {
+      if (this.store.state.wallets[walletKey] && !this._clients.has(walletKey)) {
         this.logger.warn(`Connected wallet not found: ${walletKey}`)
         removeWallet(this.store, { walletId: walletKey })
       }
     }
 
-    // Check if active wallet is still valid
-    if (state.activeWallet && !this._clients.has(state.activeWallet)) {
-      this.logger.warn(`Active wallet not found: ${state.activeWallet}`)
+    // Check if active wallet is still valid. An active wallet backed by an
+    // externally owned entry (no adapter, but a live wallet entry) is kept.
+    const { activeWallet, wallets } = this.store.state
+    if (activeWallet && !this._clients.has(activeWallet) && !wallets[activeWallet]) {
+      this.logger.warn(`Active wallet not found: ${activeWallet}`)
       setActiveWallet(this.store, { walletId: null })
     }
   }
 
-  public get wallets(): BaseWallet[] {
+  public get wallets(): BaseWallet<any>[] {
     return [...this._clients.values()]
   }
 
@@ -416,12 +460,12 @@ export class WalletManager {
     }
   }
 
-  public get availableWallets(): BaseWallet[] {
+  public get availableWallets(): BaseWallet<any>[] {
     const activeNetwork = this.store.state.activeNetwork
     return this.wallets.filter((w) => this.isWalletAvailable(w.walletKey, activeNetwork))
   }
 
-  public getWallet(walletKey: WalletKey): BaseWallet | undefined {
+  public getWallet(walletKey: WalletKey): BaseWallet<any> | undefined {
     return this._clients.get(walletKey)
   }
 
@@ -602,7 +646,7 @@ export class WalletManager {
 
   // ---------- Active Wallet ----------------------------------------- //
 
-  public get activeWallet(): BaseWallet | null {
+  public get activeWallet(): BaseWallet<any> | null {
     const state = this.store.state
     const activeWallet = this.wallets.find((wallet) => wallet.walletKey === state.activeWallet)
     if (!activeWallet) {
@@ -642,7 +686,7 @@ export class WalletManager {
 
   // ---------- Sign Transactions ------------------------------------- //
 
-  public get signTransactions(): BaseWallet['signTransactions'] {
+  public get signTransactions(): BaseWallet<any>['signTransactions'] {
     if (!this.activeWallet) {
       this.logger.error('No active wallet found!')
       throw new Error('No active wallet found!')

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -6,12 +6,14 @@ import type { Store } from '@tanstack/store'
 
 export type { WalletState }
 
-export type WalletStateMap = Partial<Record<WalletKey, WalletState>>
+export type WalletStateMap<T extends WalletAccount = WalletAccount> = Partial<
+  Record<WalletKey, WalletState<T>>
+>
 
 export type ManagerStatus = 'initializing' | 'ready'
 
-export interface State {
-  wallets: WalletStateMap
+export interface State<T extends WalletAccount = WalletAccount> {
+  wallets: WalletStateMap<T>
   activeWallet: WalletKey | null
   activeNetwork: string
   algodClient: algosdk.Algodv2
@@ -20,7 +22,7 @@ export interface State {
   customNetworkConfigs: Record<string, Partial<NetworkConfig>>
 }
 
-export const DEFAULT_STATE: State = {
+export const DEFAULT_STATE = {
   wallets: {},
   activeWallet: null,
   activeNetwork: 'testnet',
@@ -28,17 +30,20 @@ export const DEFAULT_STATE: State = {
   managerStatus: 'initializing',
   networkConfig: DEFAULT_NETWORK_CONFIG,
   customNetworkConfigs: {}
-}
+} satisfies State
 
-export type PersistedState = Omit<State, 'algodClient' | 'managerStatus' | 'networkConfig'>
+export type PersistedState<T extends WalletAccount = WalletAccount> = Omit<
+  State<T>,
+  'algodClient' | 'managerStatus' | 'networkConfig'
+>
 
 export const LOCAL_STORAGE_KEY = '@txnlab/use-wallet:v5'
 
 // State mutations
 
-export function addWallet(
-  store: Store<State>,
-  { walletId, wallet }: { walletId: WalletKey; wallet: WalletState }
+export function addWallet<T extends WalletAccount>(
+  store: Store<State<T>>,
+  { walletId, wallet }: { walletId: WalletKey; wallet: WalletState<T> }
 ) {
   store.setState((state) => {
     const updatedWallets = {
@@ -57,7 +62,10 @@ export function addWallet(
   })
 }
 
-export function removeWallet(store: Store<State>, { walletId }: { walletId: WalletKey }) {
+export function removeWallet<T extends WalletAccount>(
+  store: Store<State<T>>,
+  { walletId }: { walletId: WalletKey }
+) {
   store.setState((state) => {
     const updatedWallets = { ...state.wallets }
     delete updatedWallets[walletId]
@@ -70,15 +78,18 @@ export function removeWallet(store: Store<State>, { walletId }: { walletId: Wall
   })
 }
 
-export function setActiveWallet(store: Store<State>, { walletId }: { walletId: WalletKey | null }) {
+export function setActiveWallet<T extends WalletAccount>(
+  store: Store<State<T>>,
+  { walletId }: { walletId: WalletKey | null }
+) {
   store.setState((state) => ({
     ...state,
     activeWallet: walletId
   }))
 }
 
-export function setActiveAccount(
-  store: Store<State>,
+export function setActiveAccount<T extends WalletAccount>(
+  store: Store<State<T>>,
   { walletId, address }: { walletId: WalletKey; address: string }
 ) {
   store.setState((state) => {
@@ -112,9 +123,9 @@ export function setActiveAccount(
   })
 }
 
-export function setAccounts(
-  store: Store<State>,
-  { walletId, accounts }: { walletId: WalletKey; accounts: WalletAccount[] }
+export function setAccounts<T extends WalletAccount>(
+  store: Store<State<T>>,
+  { walletId, accounts }: { walletId: WalletKey; accounts: T[] }
 ) {
   store.setState((state) => {
     const wallet = state.wallets[walletId]
@@ -151,8 +162,8 @@ export function setAccounts(
   })
 }
 
-export function setActiveNetwork(
-  store: Store<State>,
+export function setActiveNetwork<T extends WalletAccount>(
+  store: Store<State<T>>,
   { networkId, algodClient }: { networkId: NetworkId | string; algodClient: algosdk.Algodv2 }
 ) {
   store.setState((state) => ({
@@ -164,7 +175,9 @@ export function setActiveNetwork(
 
 // Type guards
 
-export function isValidWalletAccount(account: any): account is WalletAccount {
+export function isValidWalletAccount<T extends WalletAccount = WalletAccount>(
+  account: any
+): account is T {
   return (
     typeof account === 'object' &&
     account !== null &&
@@ -173,17 +186,21 @@ export function isValidWalletAccount(account: any): account is WalletAccount {
   )
 }
 
-export function isValidWalletState(wallet: any): wallet is WalletState {
+export function isValidWalletState<T extends WalletAccount = WalletAccount>(
+  wallet: any
+): wallet is WalletState<T> {
   return (
     typeof wallet === 'object' &&
     wallet !== null &&
     Array.isArray(wallet.accounts) &&
-    wallet.accounts.every(isValidWalletAccount) &&
+    wallet.accounts.every((account: any) => isValidWalletAccount(account)) &&
     (wallet.activeAccount === null || isValidWalletAccount(wallet.activeAccount))
   )
 }
 
-export function isValidPersistedState(state: unknown): state is PersistedState {
+export function isValidPersistedState<T extends WalletAccount = WalletAccount>(
+  state: unknown
+): state is PersistedState<T> {
   return (
     typeof state === 'object' &&
     state !== null &&

--- a/packages/core/src/wallets/base.ts
+++ b/packages/core/src/wallets/base.ts
@@ -13,13 +13,16 @@ import type {
   WalletMetadata
 } from 'src/wallets/types'
 
-export abstract class BaseWallet<TOptions = Record<string, unknown>> {
+export abstract class BaseWallet<
+  TOptions = Record<string, unknown>,
+  TType extends WalletAccount = WalletAccount
+> {
   public readonly id: string
   public readonly walletKey: string
   public metadata: WalletMetadata
 
   protected options: TOptions
-  protected store: AdapterStoreAccessor
+  protected store: AdapterStoreAccessor<TType>
   protected getAlgodClient: () => algosdk.Algodv2
 
   public subscribe: (callback: (state: State) => void) => () => void
@@ -33,7 +36,7 @@ export abstract class BaseWallet<TOptions = Record<string, unknown>> {
     subscribe,
     getAlgodClient,
     options
-  }: AdapterConstructorParams<TOptions>) {
+  }: AdapterConstructorParams<TOptions, TType>) {
     this.id = id
     this.walletKey = id
     this.metadata = { ...metadata }
@@ -50,7 +53,7 @@ export abstract class BaseWallet<TOptions = Record<string, unknown>> {
 
   // ---------- Public Methods ---------------------------------------- //
 
-  public abstract connect(args?: Record<string, any>): Promise<WalletAccount[]>
+  public abstract connect(args?: Record<string, any>): Promise<TType[]>
   public abstract disconnect(): Promise<void>
   public abstract resumeSession(): Promise<void>
 
@@ -110,7 +113,7 @@ export abstract class BaseWallet<TOptions = Record<string, unknown>> {
     return this.id.toUpperCase()
   }
 
-  public get accounts(): WalletAccount[] {
+  public get accounts(): TType[] {
     const walletState = this.store.getWalletState()
     return walletState ? walletState.accounts : []
   }
@@ -119,7 +122,7 @@ export abstract class BaseWallet<TOptions = Record<string, unknown>> {
     return this.accounts.map((account) => account.address)
   }
 
-  public get activeAccount(): WalletAccount | null {
+  public get activeAccount(): TType | null {
     const walletState = this.store.getWalletState()
     return walletState ? walletState.activeAccount : null
   }

--- a/packages/core/src/wallets/types.ts
+++ b/packages/core/src/wallets/types.ts
@@ -56,14 +56,14 @@ export interface WalletCapabilities {
  * All mutations are pre-bound to the adapter's wallet key —
  * adapters cannot accidentally modify another wallet's state.
  */
-export interface AdapterStoreAccessor {
-  getWalletState(): WalletState | undefined
+export interface AdapterStoreAccessor<TType extends WalletAccount = WalletAccount> {
+  getWalletState(): WalletState<TType> | undefined
   getActiveWallet(): WalletKey | null
   getActiveNetwork(): string
   getState(): State
-  addWallet(wallet: WalletState): void
+  addWallet(wallet: WalletState<TType>): void
   removeWallet(): void
-  setAccounts(accounts: WalletAccount[]): void
+  setAccounts(accounts: TType[]): void
   setActiveAccount(address: string): void
   setActive(): void
 }
@@ -73,10 +73,13 @@ export interface AdapterStoreAccessor {
  * Generic over the options type so adapters receive typed options
  * without unsafe casts.
  */
-export interface AdapterConstructorParams<TOptions = Record<string, unknown>> {
+export interface AdapterConstructorParams<
+  TOptions = Record<string, unknown>,
+  TType extends WalletAccount = WalletAccount
+> {
   id: string
   metadata: WalletMetadata
-  store: AdapterStoreAccessor
+  store: AdapterStoreAccessor<TType>
   subscribe: (callback: (state: State) => void) => () => void
   getAlgodClient: () => algosdk.Algodv2
   options?: TOptions
@@ -88,18 +91,43 @@ export interface AdapterConstructorParams<TOptions = Record<string, unknown>> {
  * the manager handles heterogeneous adapter configs in a single array.
  * Type safety lives in the factory function signature, not here.
  */
-export interface WalletAdapterConfig {
+export interface WalletAdapterConfig<TType extends WalletAccount = WalletAccount> {
   /** Unique identifier for this wallet adapter */
   id: string
   /** Display metadata (name, icon) */
   metadata: WalletMetadata
   /** The adapter class constructor */
-  Adapter: new (params: AdapterConstructorParams) => BaseWallet
+  Adapter: new (params: AdapterConstructorParams<Record<string, unknown>, TType>) => BaseWallet
   /** Wallet-specific options, passed through to the adapter constructor */
   options?: Record<string, unknown>
   /** Network capabilities — which networks this wallet supports */
   capabilities?: WalletCapabilities
 }
+
+/**
+ * Extracts the account type from a single adapter config.
+ * `WalletAdapterConfig<PQAccount>` resolves to `PQAccount`;
+ * anything else falls back to the base `WalletAccount`.
+ */
+export type WalletAccountOf<TConfig> =
+  TConfig extends WalletAdapterConfig<infer TType extends WalletAccount> ? TType : WalletAccount
+
+/**
+ * Infers the union of account types declared by an array of adapter
+ * configs. E.g. configs declaring `WalletAdapterConfig<PQAccount>` and
+ * `WalletAdapterConfig<ClassicAccount>` resolve to `PQAccount | ClassicAccount`.
+ * An empty array resolves to the base `WalletAccount`.
+ *
+ * Note: `WalletAccountOf` must be applied to the *naked* `TConfigs[number]`
+ * union so the conditional type distributes over each member; inferring
+ * directly from `TConfigs[number] extends WalletAdapterConfig<infer T>`
+ * would intersect the candidates instead of uniting them.
+ */
+export type InferWalletAccounts<TConfigs extends readonly WalletAdapterConfig<any>[]> = [
+  TConfigs[number]
+] extends [never]
+  ? WalletAccount
+  : WalletAccountOf<TConfigs[number]>
 
 /**
  * Common options accepted by all wallet adapter factory functions.
@@ -118,17 +146,17 @@ export interface WalletFactoryOptions {
  * (e.g. `useWallet()` in React). Defined in core so all framework
  * adapters share a single type.
  */
-export interface Wallet {
+export interface Wallet<TType extends WalletAccount = WalletAccount> {
   id: string
   walletKey: string
   metadata: WalletMetadata
-  accounts: WalletAccount[]
-  activeAccount: WalletAccount | null
+  accounts: TType[]
+  activeAccount: TType | null
   isConnected: boolean
   isActive: boolean
   canSignData: boolean
   canUsePrivateKey: boolean
-  connect: (args?: Record<string, any>) => Promise<WalletAccount[]>
+  connect: (args?: Record<string, any>) => Promise<TType[]>
   disconnect: () => Promise<void>
   setActive: () => void
   setActiveAccount: (address: string) => void
@@ -136,9 +164,9 @@ export interface Wallet {
 
 // ---------- Wallet State ------------------------------------------- //
 
-export type WalletState = {
-  accounts: WalletAccount[]
-  activeAccount: WalletAccount | null
+export type WalletState<T = WalletAccount> = {
+  accounts: T[]
+  activeAccount: T | null
 }
 
 // ---------- Transaction Types -------------------------------------- //

--- a/packages/frameworks/react/src/index.test.tsx
+++ b/packages/frameworks/react/src/index.test.tsx
@@ -10,6 +10,7 @@ import {
 import algosdk from 'algosdk'
 import * as React from 'react'
 import { WalletProvider, useWallet, useNetwork } from './index'
+import type { ResolvedWalletAccount, ResolvedWalletManager } from './index'
 
 const mocks = vi.hoisted(() => {
   return {
@@ -409,5 +410,70 @@ describe('useWallet - availableWallets', () => {
 
     expect(result.current.availableWallets).toHaveLength(2)
     expect(result.current.wallets).toHaveLength(2)
+  })
+})
+
+describe('Register - account type resolution', () => {
+  // Type-level equality assertion: `Eq<A, B>` resolves to the literal type
+  // `true` only when A and B are identical, so `const x: Eq<A, B> = true`
+  // fails to compile if the inference ever regresses.
+  type Eq<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false
+
+  interface QuantumAccount extends WalletAccount {
+    kind: 'quantum'
+    handleQuantumOperation: () => string
+  }
+
+  interface ClassicAccount extends WalletAccount {
+    kind: 'classic'
+    legacyId: number
+  }
+
+  it('defaults to the base WalletAccount without a Register declaration', () => {
+    const manager = new WalletManager({
+      wallets: [mockAdapterA()]
+    })
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WalletProvider manager={manager}>{children}</WalletProvider>
+    )
+
+    const { result } = renderHook(() => useWallet(), { wrapper })
+
+    const activeAccount: Eq<typeof result.current.activeAccount, WalletAccount | null> = true
+    const accounts: Eq<(typeof result.current.wallets)[number]['accounts'], WalletAccount[]> = true
+
+    expect(activeAccount && accounts).toBe(true)
+    expect(result.current.wallets).toHaveLength(1)
+  })
+
+  it('resolves the account union from a registered manager type', () => {
+    // Classic construction with an explicitly declared union;
+    // `WalletManager.create({ wallets: [...] })` infers the same shape
+    // from the adapter configs (covered by the core test suite)
+    const manager = new WalletManager<QuantumAccount | ClassicAccount>({
+      wallets: [mockAdapterA()]
+    })
+
+    // The resolution chain the public hook uses: a `Register` declaration
+    // carrying `typeof manager` resolves to the manager type and its
+    // account union (apps write `declare module '@txnlab/use-wallet-react'
+    // { interface Register { manager: typeof manager } }`)
+    const resolvedManager: Eq<
+      ResolvedWalletManager<{ manager: typeof manager }>,
+      WalletManager<QuantumAccount | ClassicAccount>
+    > = true
+    const resolvedAccount: Eq<
+      ResolvedWalletAccount<{ manager: typeof manager }>,
+      QuantumAccount | ClassicAccount
+    > = true
+
+    // Without a registration, resolution falls back to the base types
+    const unregisteredManager: Eq<ResolvedWalletManager, WalletManager> = true
+    const unregisteredAccount: Eq<ResolvedWalletAccount, WalletAccount> = true
+
+    expect(manager).toBeInstanceOf(WalletManager)
+    expect(resolvedManager && resolvedAccount).toBe(true)
+    expect(unregisteredManager && unregisteredAccount).toBe(true)
   })
 })

--- a/packages/frameworks/react/src/index.tsx
+++ b/packages/frameworks/react/src/index.tsx
@@ -6,6 +6,7 @@ import {
   StdSignDataResponse,
   StdSignMetadata,
   type Wallet,
+  type WalletAccount,
   WalletManager
 } from '@txnlab/use-wallet'
 import algosdk from 'algosdk'
@@ -13,20 +14,23 @@ import * as React from 'react'
 
 export * from '@txnlab/use-wallet'
 
-interface IWalletContext {
-  manager: WalletManager
+interface IWalletContext<TAccount extends WalletAccount = WalletAccount> {
+  manager: WalletManager<TAccount>
   algodClient: algosdk.Algodv2
   setAlgodClient: React.Dispatch<React.SetStateAction<algosdk.Algodv2>>
 }
 
-const WalletContext = React.createContext<IWalletContext | undefined>(undefined)
+const WalletContext = React.createContext<IWalletContext<any> | undefined>(undefined)
 
-interface WalletProviderProps {
-  manager: WalletManager
+interface WalletProviderProps<TAccount extends WalletAccount = WalletAccount> {
+  manager: WalletManager<TAccount>
   children: React.ReactNode
 }
 
-export const WalletProvider = ({ manager, children }: WalletProviderProps): React.JSX.Element => {
+export const WalletProvider = <TAccount extends WalletAccount = WalletAccount>({
+  manager,
+  children
+}: WalletProviderProps<TAccount>): React.JSX.Element => {
   const [algodClient, setAlgodClient] = React.useState(manager.algodClient)
 
   React.useEffect(() => {
@@ -120,8 +124,37 @@ export const useNetwork = () => {
   }
 }
 
-export const useWallet = () => {
-  const context = React.useContext(WalletContext)
+// Wagmi-style type registration: an app declares its manager type once,
+// next to where the manager is created:
+//
+//   const manager = WalletManager.create({ wallets: [pqWallet(), classicWallet()] })
+//   // or, with classic construction, declare the union explicitly:
+//   // const manager = new WalletManager<PQAccount | ClassicAccount>({ wallets: [...] })
+//
+//   declare module '@txnlab/use-wallet-react' {
+//     interface Register { manager: typeof manager }
+//   }
+//
+// Every bare `useWallet()` then infers the manager's account union; apps
+// that don't register keep the base `WalletAccount` default.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface Register {}
+
+export type ResolvedWalletManager<TRegister = Register> = TRegister extends {
+  manager: infer TManager extends WalletManager<any>
+}
+  ? TManager
+  : WalletManager
+
+export type ResolvedWalletAccount<TRegister = Register> =
+  ResolvedWalletManager<TRegister> extends WalletManager<infer TAccount> ? TAccount : WalletAccount
+
+// Internal implementation; the public hook binds `T` to the account type
+// resolved from the app's `Register` declaration
+const useWalletCore = <T extends WalletAccount = WalletAccount>() => {
+  // The module-level context erases the provider's generic; view it at the
+  // resolved account type `T` so the store-derived state flows as `T`
+  const context = React.useContext(WalletContext) as IWalletContext<T> | undefined
 
   if (!context) {
     throw new Error('useWallet must be used within the WalletProvider')
@@ -137,7 +170,7 @@ export const useWallet = () => {
   const activeNetwork = useStore(manager.store, (state) => state.activeNetwork)
 
   const transformToWallet = React.useCallback(
-    (wallet: BaseWallet): Wallet => {
+    (wallet: BaseWallet<any, any>): Wallet<T> => {
       const walletState = walletStateMap[wallet.walletKey]
       return {
         id: wallet.id,
@@ -227,3 +260,5 @@ export const useWallet = () => {
     transactionSigner
   }
 }
+
+export const useWallet = () => useWalletCore<ResolvedWalletAccount>()

--- a/packages/frameworks/solid/src/index.test.tsx
+++ b/packages/frameworks/solid/src/index.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@txnlab/use-wallet'
 import { For } from 'solid-js'
 import { WalletProvider, useWallet, useWalletManager, useNetwork } from './index'
+import type { ResolvedWalletAccount, ResolvedWalletManager } from './index'
 
 const mocks = vi.hoisted(() => {
   return {
@@ -715,5 +716,78 @@ describe('useWallet - availableWallets', () => {
     await waitFor(() => {
       expect(screen.getByTestId('available-count')).toHaveTextContent('2')
     })
+  })
+})
+
+describe('Register - account type resolution', () => {
+  // Type-level equality assertion: `Eq<A, B>` resolves to the literal type
+  // `true` only when A and B are identical, so `const x: Eq<A, B> = true`
+  // fails to compile if the inference ever regresses.
+  type Eq<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false
+
+  interface QuantumAccount extends WalletAccount {
+    kind: 'quantum'
+    handleQuantumOperation: () => string
+  }
+
+  interface ClassicAccount extends WalletAccount {
+    kind: 'classic'
+    legacyId: number
+  }
+
+  it('defaults to the base WalletAccount without a Register declaration', () => {
+    const manager = new WalletManager({
+      wallets: [mockAdapterA()]
+    })
+
+    let checks = false
+    const TestComponent = () => {
+      const { activeAccount, wallets } = useWallet()
+
+      const activeAccountType: Eq<ReturnType<typeof activeAccount>, WalletAccount | null> = true
+      const accountsType: Eq<ReturnType<typeof wallets>[number]['accounts'], WalletAccount[]> = true
+      checks = activeAccountType && accountsType && activeAccount() === null
+
+      return <div data-testid="wallet-count">{wallets().length}</div>
+    }
+
+    render(() => (
+      <WalletProvider manager={manager}>
+        <TestComponent />
+      </WalletProvider>
+    ))
+
+    expect(checks).toBe(true)
+    expect(screen.getByTestId('wallet-count')).toHaveTextContent('1')
+  })
+
+  it('resolves the account union from a registered manager type', () => {
+    // Classic construction with an explicitly declared union;
+    // `WalletManager.create({ wallets: [...] })` infers the same shape
+    // from the adapter configs (covered by the core test suite)
+    const manager = new WalletManager<QuantumAccount | ClassicAccount>({
+      wallets: [mockAdapterA()]
+    })
+
+    // The resolution chain the public hook uses: a `Register` declaration
+    // carrying `typeof manager` resolves to the manager type and its
+    // account union (apps write `declare module '@txnlab/use-wallet-solid'
+    // { interface Register { manager: typeof manager } }`)
+    const resolvedManager: Eq<
+      ResolvedWalletManager<{ manager: typeof manager }>,
+      WalletManager<QuantumAccount | ClassicAccount>
+    > = true
+    const resolvedAccount: Eq<
+      ResolvedWalletAccount<{ manager: typeof manager }>,
+      QuantumAccount | ClassicAccount
+    > = true
+
+    // Without a registration, resolution falls back to the base types
+    const unregisteredManager: Eq<ResolvedWalletManager, WalletManager> = true
+    const unregisteredAccount: Eq<ResolvedWalletAccount, WalletAccount> = true
+
+    expect(manager).toBeInstanceOf(WalletManager)
+    expect(resolvedManager && resolvedAccount).toBe(true)
+    expect(unregisteredManager && unregisteredAccount).toBe(true)
   })
 })

--- a/packages/frameworks/solid/src/index.tsx
+++ b/packages/frameworks/solid/src/index.tsx
@@ -15,28 +15,28 @@ import type {
 
 export * from '@txnlab/use-wallet'
 
-export interface Wallet {
+export interface Wallet<T extends WalletAccount = WalletAccount> {
   id: string
   walletKey: WalletKey
   metadata: WalletMetadata
-  readonly accounts: WalletAccount[]
-  readonly activeAccount: WalletAccount | null
+  readonly accounts: T[]
+  readonly activeAccount: T | null
   readonly isConnected: boolean
   readonly isActive: boolean
   canSignData: boolean
   canUsePrivateKey: boolean
-  connect: (args?: Record<string, any>) => Promise<WalletAccount[]>
+  connect: (args?: Record<string, any>) => Promise<T[]>
   disconnect: () => Promise<void>
   setActive: () => void
   setActiveAccount: (address: string) => void
 }
 
 interface WalletProviderProps {
-  manager: WalletManager
+  manager: WalletManager<any>
   children: JSX.Element
 }
 
-const WalletContext = createContext<() => WalletManager>()
+const WalletContext = createContext<() => WalletManager<any>>()
 
 export const WalletProvider = (props: WalletProviderProps): JSX.Element => {
   const store = () => props.manager
@@ -52,12 +52,37 @@ export const WalletProvider = (props: WalletProviderProps): JSX.Element => {
   return <WalletContext.Provider value={store}>{props.children}</WalletContext.Provider>
 }
 
-export const useWalletManager = (): WalletManager => {
+// Wagmi-style type registration: an app declares its manager type once,
+// next to where the manager is created:
+//
+//   const manager = WalletManager.create({ wallets: [pqWallet(), classicWallet()] })
+//   // or, with classic construction, declare the union explicitly:
+//   // const manager = new WalletManager<PQAccount | ClassicAccount>({ wallets: [...] })
+//
+//   declare module '@txnlab/use-wallet-solid' {
+//     interface Register { manager: typeof manager }
+//   }
+//
+// Every bare `useWallet()` then infers the manager's account union; apps
+// that don't register keep the base `WalletAccount` default.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface Register {}
+
+export type ResolvedWalletManager<TRegister = Register> = TRegister extends {
+  manager: infer TManager extends WalletManager<any>
+}
+  ? TManager
+  : WalletManager
+
+export type ResolvedWalletAccount<TRegister = Register> =
+  ResolvedWalletManager<TRegister> extends WalletManager<infer TAccount> ? TAccount : WalletAccount
+
+export const useWalletManager = (): ResolvedWalletManager => {
   const manager = useContext(WalletContext)
   if (!manager) {
     throw new Error('useWalletManager must be used within a WalletProvider')
   }
-  return manager()
+  return manager() as ResolvedWalletManager
 }
 
 export const useNetwork = () => {
@@ -138,8 +163,12 @@ export const useNetwork = () => {
   }
 }
 
-export const useWallet = () => {
-  const manager = createMemo(() => useWalletManager())
+// Internal implementation; the public hook binds `T` to the account type
+// resolved from the app's `Register` declaration
+const useWalletCore = <T extends WalletAccount = WalletAccount>() => {
+  // The context erases the manager's generic; view it at the resolved
+  // account type `T` so the store-derived state flows as `T`
+  const manager = createMemo(() => useWalletManager() as WalletManager<T>)
 
   const managerStatus = useStore(manager().store, (state) => state.managerStatus)
   const isReady = createMemo(() => managerStatus() === 'ready')
@@ -148,7 +177,7 @@ export const useWallet = () => {
   const walletStateMap = useStore(manager().store, (state) => state.wallets)
   const activeWalletId = useStore(manager().store, (state) => state.activeWallet)
 
-  const transformToWallet = (wallet: BaseWallet): Wallet => {
+  const transformToWallet = (wallet: BaseWallet<any, any>): Wallet<T> => {
     return {
       id: wallet.id,
       walletKey: wallet.walletKey,
@@ -263,3 +292,5 @@ export const useWallet = () => {
     transactionSigner
   }
 }
+
+export const useWallet = () => useWalletCore<ResolvedWalletAccount>()

--- a/packages/frameworks/svelte/src/index.test.ts
+++ b/packages/frameworks/svelte/src/index.test.ts
@@ -14,6 +14,7 @@ import algosdk from 'algosdk'
 import { getContext, setContext } from 'svelte'
 import type { Mock } from 'vitest'
 import { useWalletContext, useWalletManager, useNetwork, useWallet } from './index'
+import type { ResolvedWalletAccount, ResolvedWalletManager } from './index'
 
 // Mock Svelte's context functions
 vi.mock('svelte', async (importOriginal) => {
@@ -553,5 +554,69 @@ describe('useWallet - availableWallets', () => {
 
     expect(wallet.availableWallets.current).toHaveLength(2)
     expect(wallet.wallets).toHaveLength(2)
+  })
+})
+
+describe('Register - account type resolution', () => {
+  // Type-level equality assertion: `Eq<A, B>` resolves to the literal type
+  // `true` only when A and B are identical, so `const x: Eq<A, B> = true`
+  // fails to compile if the inference ever regresses.
+  type Eq<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false
+
+  interface QuantumAccount extends WalletAccount {
+    kind: 'quantum'
+    handleQuantumOperation: () => string
+  }
+
+  interface ClassicAccount extends WalletAccount {
+    kind: 'classic'
+    legacyId: number
+  }
+
+  it('defaults to the base WalletAccount without a Register declaration', () => {
+    ;(getContext as Mock).mockReturnValue(mockWalletManager)
+
+    const { activeAccount, wallets } = useWallet()
+
+    const activeAccountType: Eq<typeof activeAccount.current, WalletAccount | null | undefined> =
+      true
+    const accountsType: Eq<
+      (typeof wallets)[number]['accounts']['current'],
+      WalletAccount[] | undefined
+    > = true
+
+    expect(activeAccountType && accountsType).toBe(true)
+    expect(activeAccount.current).toBeUndefined()
+    expect(wallets).toHaveLength(2)
+  })
+
+  it('resolves the account union from a registered manager type', () => {
+    // Classic construction with an explicitly declared union;
+    // `WalletManager.create({ wallets: [...] })` infers the same shape
+    // from the adapter configs (covered by the core test suite)
+    const manager = new WalletManager<QuantumAccount | ClassicAccount>({
+      wallets: [mockAdapterA()]
+    })
+
+    // The resolution chain the public hook uses: a `Register` declaration
+    // carrying `typeof manager` resolves to the manager type and its
+    // account union (apps write `declare module '@txnlab/use-wallet-svelte'
+    // { interface Register { manager: typeof manager } }`)
+    const resolvedManager: Eq<
+      ResolvedWalletManager<{ manager: typeof manager }>,
+      WalletManager<QuantumAccount | ClassicAccount>
+    > = true
+    const resolvedAccount: Eq<
+      ResolvedWalletAccount<{ manager: typeof manager }>,
+      QuantumAccount | ClassicAccount
+    > = true
+
+    // Without a registration, resolution falls back to the base types
+    const unregisteredManager: Eq<ResolvedWalletManager, WalletManager> = true
+    const unregisteredAccount: Eq<ResolvedWalletAccount, WalletAccount> = true
+
+    expect(manager).toBeInstanceOf(WalletManager)
+    expect(resolvedManager && resolvedAccount).toBe(true)
+    expect(unregisteredManager && unregisteredAccount).toBe(true)
   })
 })

--- a/packages/frameworks/svelte/src/index.ts
+++ b/packages/frameworks/svelte/src/index.ts
@@ -15,7 +15,7 @@ import {
 
 export * from '@txnlab/use-wallet'
 
-export const useWalletContext = (manager: WalletManager) => {
+export const useWalletContext = (manager: WalletManager<any>) => {
   setContext('walletManager', manager)
 
   manager.resumeSessions().catch((error) => {
@@ -23,12 +23,37 @@ export const useWalletContext = (manager: WalletManager) => {
   })
 }
 
-export const useWalletManager = (): WalletManager => {
-  const manager: WalletManager = getContext('walletManager')
+// Wagmi-style type registration: an app declares its manager type once,
+// next to where the manager is created:
+//
+//   const manager = WalletManager.create({ wallets: [pqWallet(), classicWallet()] })
+//   // or, with classic construction, declare the union explicitly:
+//   // const manager = new WalletManager<PQAccount | ClassicAccount>({ wallets: [...] })
+//
+//   declare module '@txnlab/use-wallet-svelte' {
+//     interface Register { manager: typeof manager }
+//   }
+//
+// Every bare `useWallet()` then infers the manager's account union; apps
+// that don't register keep the base `WalletAccount` default.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface Register {}
+
+export type ResolvedWalletManager<TRegister = Register> = TRegister extends {
+  manager: infer TManager extends WalletManager<any>
+}
+  ? TManager
+  : WalletManager
+
+export type ResolvedWalletAccount<TRegister = Register> =
+  ResolvedWalletManager<TRegister> extends WalletManager<infer TAccount> ? TAccount : WalletAccount
+
+export const useWalletManager = (): ResolvedWalletManager => {
+  const manager: WalletManager<any> = getContext('walletManager')
   if (!manager) {
     throw new Error('useWalletManager must be used within a useWalletContext')
   }
-  return manager
+  return manager as ResolvedWalletManager
 }
 
 export const useNetwork = () => {
@@ -109,26 +134,30 @@ export const useNetwork = () => {
   }
 }
 
-export interface Wallet {
+export interface Wallet<T extends WalletAccount = WalletAccount> {
   id: string
   walletKey: WalletKey
   metadata: WalletMetadata
-  accounts: { current: WalletAccount[] | undefined }
+  accounts: { current: T[] | undefined }
   isConnected: () => boolean
   isActive: () => boolean
   canSignData: boolean
   canUsePrivateKey: boolean
-  connect: (args?: Record<string, any>) => Promise<WalletAccount[]>
+  connect: (args?: Record<string, any>) => Promise<T[]>
   disconnect: () => Promise<void>
   setActive: () => void
   setActiveAccount: (address: string) => void
 }
 
-export const useWallet = () => {
-  const manager = useWalletManager()
+// Internal implementation; the public hook binds `T` to the account type
+// resolved from the app's `Register` declaration
+const useWalletCore = <T extends WalletAccount = WalletAccount>() => {
+  // The context erases the manager's generic; view it at the resolved
+  // account type `T` so the store-derived state flows as `T`
+  const manager = useWalletManager() as WalletManager<T>
   const walletStore = useStore(manager.store, (state) => state.wallets)
 
-  const transformToWallet = (wallet: BaseWallet): Wallet => {
+  const transformToWallet = (wallet: BaseWallet<any, any>): Wallet<T> => {
     return {
       id: wallet.id,
       walletKey: wallet.walletKey,
@@ -231,3 +260,5 @@ export const useWallet = () => {
     transactionSigner
   }
 }
+
+export const useWallet = () => useWalletCore<ResolvedWalletAccount>()

--- a/packages/frameworks/vue/src/index.ts
+++ b/packages/frameworks/vue/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@txnlab/use-wallet'
 export { WalletManagerPlugin } from './walletManagerPlugin'
 export { useWallet } from './useWallet'
+export type { Register, ResolvedWalletManager, ResolvedWalletAccount } from './useWallet'
 export { useNetwork } from './useNetwork'

--- a/packages/frameworks/vue/src/useWallet.test.ts
+++ b/packages/frameworks/vue/src/useWallet.test.ts
@@ -9,6 +9,7 @@ import { mount } from '@vue/test-utils'
 import algosdk from 'algosdk'
 import { inject, nextTick, ref, type InjectionKey } from 'vue'
 import { useWallet } from './useWallet'
+import type { ResolvedWalletAccount, ResolvedWalletManager } from './useWallet'
 import type { Mock } from 'vitest'
 
 // Mock Vue's inject function
@@ -373,5 +374,63 @@ describe('useWallet - availableWallets', () => {
 
     expect(availableWallets.value).toHaveLength(2)
     expect(wallets.value).toHaveLength(2)
+  })
+})
+
+describe('Register - account type resolution', () => {
+  // Type-level equality assertion: `Eq<A, B>` resolves to the literal type
+  // `true` only when A and B are identical, so `const x: Eq<A, B> = true`
+  // fails to compile if the inference ever regresses.
+  type Eq<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false
+
+  interface QuantumAccount extends WalletAccount {
+    kind: 'quantum'
+    handleQuantumOperation: () => string
+  }
+
+  interface ClassicAccount extends WalletAccount {
+    kind: 'classic'
+    legacyId: number
+  }
+
+  it('defaults to the base WalletAccount without a Register declaration', () => {
+    const { activeAccount, wallets } = useWallet()
+
+    const activeAccountType: Eq<typeof activeAccount.value, WalletAccount | null> = true
+    const accountsType: Eq<(typeof wallets.value)[number]['accounts'], WalletAccount[]> = true
+
+    expect(activeAccountType && accountsType).toBe(true)
+    expect(activeAccount.value).toBeNull()
+    expect(wallets.value).toHaveLength(2)
+  })
+
+  it('resolves the account union from a registered manager type', () => {
+    // Classic construction with an explicitly declared union;
+    // `WalletManager.create({ wallets: [...] })` infers the same shape
+    // from the adapter configs (covered by the core test suite)
+    const manager = new WalletManager<QuantumAccount | ClassicAccount>({
+      wallets: [mockAdapterA()]
+    })
+
+    // The resolution chain the public composable uses: a `Register`
+    // declaration carrying `typeof manager` resolves to the manager type and
+    // its account union (apps write `declare module '@txnlab/use-wallet-vue'
+    // { interface Register { manager: typeof manager } }`)
+    const resolvedManager: Eq<
+      ResolvedWalletManager<{ manager: typeof manager }>,
+      WalletManager<QuantumAccount | ClassicAccount>
+    > = true
+    const resolvedAccount: Eq<
+      ResolvedWalletAccount<{ manager: typeof manager }>,
+      QuantumAccount | ClassicAccount
+    > = true
+
+    // Without a registration, resolution falls back to the base types
+    const unregisteredManager: Eq<ResolvedWalletManager, WalletManager> = true
+    const unregisteredAccount: Eq<ResolvedWalletAccount, WalletAccount> = true
+
+    expect(manager).toBeInstanceOf(WalletManager)
+    expect(resolvedManager && resolvedAccount).toBe(true)
+    expect(unregisteredManager && unregisteredAccount).toBe(true)
   })
 })

--- a/packages/frameworks/vue/src/useWallet.ts
+++ b/packages/frameworks/vue/src/useWallet.ts
@@ -3,6 +3,7 @@ import {
   BaseWallet,
   WalletManager,
   type Wallet,
+  type WalletAccount,
   type StdSignMetadata,
   type StdSignDataResponse
 } from '@txnlab/use-wallet'
@@ -11,8 +12,37 @@ import { computed, inject, ref } from 'vue'
 
 export type SetAlgodClient = (client: algosdk.Algodv2) => void
 
-export function useWallet() {
-  const manager = inject<WalletManager>('walletManager')
+// Wagmi-style type registration: an app declares its manager type once,
+// next to where the manager is created:
+//
+//   const manager = WalletManager.create({ wallets: [pqWallet(), classicWallet()] })
+//   // or, with classic construction, declare the union explicitly:
+//   // const manager = new WalletManager<PQAccount | ClassicAccount>({ wallets: [...] })
+//
+//   declare module '@txnlab/use-wallet-vue' {
+//     interface Register { manager: typeof manager }
+//   }
+//
+// Every bare `useWallet()` then infers the manager's account union; apps
+// that don't register keep the base `WalletAccount` default.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface Register {}
+
+export type ResolvedWalletManager<TRegister = Register> = TRegister extends {
+  manager: infer TManager extends WalletManager<any>
+}
+  ? TManager
+  : WalletManager
+
+export type ResolvedWalletAccount<TRegister = Register> =
+  ResolvedWalletManager<TRegister> extends WalletManager<infer TAccount> ? TAccount : WalletAccount
+
+// Internal implementation; the public composable binds `T` to the account
+// type resolved from the app's `Register` declaration
+function useWalletCore<T extends WalletAccount = WalletAccount>() {
+  // The injection erases the manager's generic; view it at the resolved
+  // account type `T` so the store-derived state flows as `T`
+  const manager = inject<WalletManager<T>>('walletManager')
   const algodClient = inject<ReturnType<typeof ref<algosdk.Algodv2>>>('algodClient')
 
   if (!manager) {
@@ -28,7 +58,7 @@ export function useWallet() {
   const walletStateMap = useStore(manager.store, (state) => state.wallets)
   const activeWalletId = useStore(manager.store, (state) => state.activeWallet)
 
-  const transformToWallet = (wallet: BaseWallet): Wallet => {
+  const transformToWallet = (wallet: BaseWallet<any, any>): Wallet<T> => {
     const walletState = walletStateMap.value[wallet.walletKey]
     return {
       id: wallet.id,
@@ -143,4 +173,8 @@ export function useWallet() {
     signTransactions,
     transactionSigner
   }
+}
+
+export function useWallet() {
+  return useWalletCore<ResolvedWalletAccount>()
 }

--- a/packages/frameworks/vue/src/walletManagerPlugin.ts
+++ b/packages/frameworks/vue/src/walletManagerPlugin.ts
@@ -3,8 +3,11 @@ import { ref } from 'vue'
 import type algosdk from 'algosdk'
 
 export const WalletManagerPlugin = {
-  install(app: any, options: WalletManagerConfig) {
-    const manager = new WalletManager(options)
+  // Accepts either a config (the manager is constructed internally) or an
+  // existing instance, e.g. one created with `WalletManager.create()` whose
+  // type can back the app's `Register` declaration
+  install(app: any, options: WalletManagerConfig | WalletManager<any>) {
+    const manager = options instanceof WalletManager ? options : new WalletManager(options)
     const algodClient = ref(manager.algodClient)
 
     const setAlgodClient = (client: algosdk.Algodv2) => {


### PR DESCRIPTION
# feat: generic account types

Makes the account type generic across the stack: wallet state, store, manager, and the framework
hooks. Wallet adapters are untouched; every generic defaults to `WalletAccount`, so existing apps
compile and behave exactly as before. New capabilities are opt-in.

## What

- **Generic wallet state** (`packages/core/src/wallets/base.ts`, `types.ts`): `WalletState<T>` and
  `BaseWallet<TOptions, TType>` carry the account type, with `WalletAccount` as the default.
  Adapters can adopt a custom account type later via the second type parameter.
- **Generic store** (`packages/core/src/store.ts`): `State<T>`, `PersistedState<T>`, and all
  mutations (`addWallet`, `setAccounts`, ...) are generic over the account type. Mutations and the
  `WalletStateMap`/`PersistedState` types are exported from the package root.
- **Injectable store** (`packages/core/src/manager.ts`): `new WalletManager({ options: { store } })`
  adopts an externally created TanStack `Store` instead of creating a private one. Each writer owns
  its wallet keys: external entries survive hydration and stale-wallet cleanup, live entries win
  over stale persisted ones, and construction order does not matter.
- **Typed manager**: `WalletManager<TAccount>` carries the union of its adapters' account types.
  `WalletManager.create({ wallets })` infers that union from the adapter configs (direct
  construction cannot; TypeScript fixes the class parameter on the first array element), and
  classic `new WalletManager<PQAccount | ClassicAccount>({ ... })` declares it explicitly.
- **`Register` (wagmi-style)**: each framework package (React, Vue, Solid, Svelte) exposes a
  `Register` interface, the same pattern wagmi uses to link its config type to its hooks. An app
  declares its manager type once, next to where the manager is created, and every bare
  `useWallet()` infers the account union with no generics or casts at the call site:

  ```ts
  const manager = WalletManager.create({ wallets: [pqWallet(), classicWallet()] })
  // or declare it when constructing:
  // const manager = new WalletManager<PQAccount | ClassicAccount>({ wallets: [...] })

  declare module '@txnlab/use-wallet-react' {
    interface Register {
      manager: typeof manager
    }
  }

  // in a component, imports unchanged:
  import { useWallet } from '@txnlab/use-wallet-react'
  const { activeAccount } = useWallet()
  // activeAccount: PQAccount | ClassicAccount | null
  ```

  Apps that don't register keep the base `WalletAccount` default. The hooks take no type
  parameter; the declaration is the single source of truth. The Vue plugin also accepts an
  existing manager instance (`app.use(WalletManagerPlugin, manager)`) so `typeof manager` works
  there too.

## Why

- Wallets can hold a heterogeneous mix of account types (e.g. post-quantum accounts alongside
  classic ones). Consumers need the full union statically visible so each account narrows through
  a type guard instead of a cast.
- External systems can share one store instance with the manager and contribute their own wallet
  entries without being overwritten.
