### PR TITLE
ci: drop v5 from release and CI branch config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
   "configMigration": true,
   "timezone": "America/New_York",
   "assignees": ["drichar"],
-  "baseBranchPatterns": ["main", "v5"],
+  "baseBranchPatterns": ["main"],
   "ignorePaths": ["**/node_modules/**"],
   "minimumReleaseAge": "3 days",
   "lockFileMaintenance": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, v5]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [main, v5]
+    branches: [main]
 
 permissions:
   contents: write

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,6 +1,6 @@
 export default {
   tagFormat: 'v${version}',
-  branches: ['main', { name: 'v5', prerelease: 'rc', channel: 'next' }],
+  branches: ['main'],
   plugins: [
     '@semantic-release/commit-analyzer',
     [


### PR DESCRIPTION
## Summary

5.0.0 stable shipped from `main` (promotion merge bbd80dbb), so the `v5` pre-release channel is retired. This removes the remaining `v5` references from the release and CI configuration, which is a prerequisite for deleting `origin/v5` — that branch is fully contained in `main`.

## Details

- Removed the `{ name: 'v5', prerelease: 'rc', channel: 'next' }` branch from `.releaserc.js`
- Dropped `v5` from the push trigger in `release.yml`
- Dropped `v5` from the `pull_request` trigger in `ci.yml`
- Dropped `v5` from `baseBranchPatterns` in `renovate.json`, so Renovate stops raising PRs against a branch that is about to be deleted (this is what produced #444)

## Follow-up

Once this merges, `origin/v5` can be deleted. #431 has already been retargeted to `main` so it won't be auto-closed by the deletion; #444 will auto-close with the branch, and Renovate will re-raise lock file maintenance against `main` on its next run.