### PR TITLE
docs: fix WalletKey type rendering in migration guide

### DIFF
--- a/docs/guides/migrating-from-v4.x.md
+++ b/docs/guides/migrating-from-v4.x.md
@@ -307,7 +307,13 @@ const id: string = 'pera' // valid
 
 #### `WalletKey`
 
-`WalletKey` was a union type of `WalletId | \`${WalletId.WALLETCONNECT}:${string}\``. In v5, it is simply `string`.
+In v4, `WalletKey` was a union type:
+
+```typescript
+type WalletKey = WalletId | `${WalletId.WALLETCONNECT}:${string}`
+```
+
+In v5, it is simply `string`.
 
 #### Data Signing Types
 


### PR DESCRIPTION
## Summary

The `WalletKey` entry in the v4 → v5 migration guide renders as broken text on the docs site. It nested backslash-escaped backticks inside an inline code span, and backslash escapes are literal inside code spans — so the span closed early and the template literal type spilled out as plain text.

Reported from the live page at https://txnlab.gitbook.io/use-wallet/guides/migrating-from-v4.x

## Details

Before:

```
`WalletKey` was a union type of `WalletId | \`${WalletId.WALLETCONNECT}:${string}\``. In v5, it is simply `string`.
```

After — a fenced `typescript` block, matching the `WalletId` section directly above it:

```
In v4, `WalletKey` was a union type:

    type WalletKey = WalletId | `${WalletId.WALLETCONNECT}:${string}`

In v5, it is simply `string`.
```

I also linted the rest of `docs/` for the same class of problem — unbalanced `{% tabs %}` / `{% tab %}` / `{% hint %}` / `{% code %}` directives, and odd backtick counts on lines outside fenced blocks. This was the only occurrence.

## Follow-up

`docs/` changes reach the site through `gitbook/v5`, so once this merges, `main` needs to be merged into `gitbook/v5` for the fix to appear (same pattern as `gitbook/v4`).